### PR TITLE
Add test-level context

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -221,6 +221,9 @@ TESTS_SCHEMA = vol.Schema(
         vol.Required("tests"): [
             {
                 vol.Required("sentences"): [str],
+                vol.Optional("context"): {
+                    str: match_anything_but_dict,
+                },
                 vol.Required("intent"): {
                     vol.Required("name"): str,
                     vol.Optional("slots"): {

--- a/sentences/en/binary_sensor_HassGetState.yaml
+++ b/sentences/en/binary_sensor_HassGetState.yaml
@@ -875,9 +875,6 @@ intents:
       - sentences:
           - "is anything vibrating [in <area>]"
         response: any
-        requires_context:
-          domain: binary_sensor
-          device_class: vibration
         slots:
           domain: binary_sensor
           device_class: vibration

--- a/tests/en/binary_sensor_HassGetState.yaml
+++ b/tests/en/binary_sensor_HassGetState.yaml
@@ -1158,9 +1158,6 @@ tests:
       - "is anything vibrating?"
     intent:
       name: HassGetState
-      context:
-        domain: binary_sensor
-        device_class: vibration
       slots:
         domain: "binary_sensor"
         device_class: "vibration"

--- a/tests/en/cover_HassTurnOff.yaml
+++ b/tests/en/cover_HassTurnOff.yaml
@@ -65,10 +65,10 @@ tests:
   - sentences:
       - "close the curtains"
       - "close the curtains in here"
+    context:
+      area: Living Room
     intent:
       name: HassTurnOff
-      context:
-        area: Living Room
       slots:
         domain: cover
         area: Living Room

--- a/tests/en/cover_HassTurnOn.yaml
+++ b/tests/en/cover_HassTurnOn.yaml
@@ -66,10 +66,10 @@ tests:
   - sentences:
       - "open the curtains"
       - "open the curtains in here"
+    context:
+      area: Living Room
     intent:
       name: HassTurnOn
-      context:
-        area: Living Room
       slots:
         domain: cover
         area: Living Room

--- a/tests/en/fan_HassTurnOff.yaml
+++ b/tests/en/fan_HassTurnOff.yaml
@@ -37,10 +37,10 @@ tests:
       - "turn all the fans off in here"
       - "turn the fans here off"
       - "turn the fans off"
+    context:
+      area: Living Room
     intent:
       name: HassTurnOff
-      context:
-        area: Living Room
       slots:
         domain: fan
         area: Living Room

--- a/tests/en/fan_HassTurnOn.yaml
+++ b/tests/en/fan_HassTurnOn.yaml
@@ -27,10 +27,10 @@ tests:
       - "turn all the fans on in here"
       - "turn the fans here on"
       - "turn the fans on"
+    context:
+      area: Living Room
     intent:
       name: HassTurnOn
-      context:
-        area: Living Room
       slots:
         domain: fan
         area: Living Room

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -15,20 +15,20 @@ tests:
       - "create 1 hour timer"
       - "1 hour timer"
       - "timer for 1 hour"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         hours: 1
     response: Timer set for 1 hour
 
   - sentences:
       - "set a timer for 5 and a half minutes"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         minutes: 5
         seconds: 30
@@ -37,10 +37,10 @@ tests:
   - sentences:
       - "set a timer for half a minute"
       - "set a timer for 1/2 a minute"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         seconds: 30
     response: Timer set for 30 seconds
@@ -48,10 +48,10 @@ tests:
   - sentences:
       - "set a timer for 1 and a half hours"
       - "set a timer for 1 and a 1/2 hours"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         hours: 1
         minutes: 30
@@ -60,10 +60,10 @@ tests:
   - sentences:
       - "set a timer for half an hour"
       - "set a timer for 1/2 an hour"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         minutes: 30
     response: Timer set for 30 minutes
@@ -72,10 +72,10 @@ tests:
       - "start a 1 hour and 15 minute timer"
       - "timer for 1 hour and 15 minutes"
       - "set timer for 1 hour and 15 minutes"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         hours: 1
         minutes: 15
@@ -85,10 +85,10 @@ tests:
       - "start a 1 hour and 30 second timer"
       - "timer for 1 hour and 30 seconds"
       - "set timer for 1 hour and 30 seconds"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         hours: 1
         seconds: 30
@@ -98,10 +98,10 @@ tests:
       - "start a 1 hour 15 minute and 30 second timer"
       - "1 hour 15 minute 30 second timer"
       - "set timer for 1 hour, 15 minutes, and 30 seconds"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         hours: 1
         minutes: 15
@@ -112,10 +112,10 @@ tests:
       - "start a 5 minute timer"
       - "5 minute timer"
       - "timer for 5 minutes"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         minutes: 5
     response: Timer set for 5 minutes
@@ -125,10 +125,10 @@ tests:
       - "5 minute timer for pizza"
       - "set timer called pizza for 5 minutes"
       - "timer for 5 minutes called pizza"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         minutes: 5
         name:
@@ -140,10 +140,10 @@ tests:
       - "start a 5 minute and 10 second timer"
       - "timer for 5 minutes and 10 seconds"
       - "5 minute 10 second timer"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         minutes: 5
         seconds: 10
@@ -153,10 +153,10 @@ tests:
       - "start a 45 second timer"
       - "timer for 45 seconds"
       - "45 second timer"
+    context:
+      area: Living Room
     intent:
       name: HassStartTimer
-      context:
-        area: Living Room
       slots:
         seconds: 45
     response: Timer set for 45 seconds

--- a/tests/en/light_HassLightSet.yaml
+++ b/tests/en/light_HassLightSet.yaml
@@ -39,10 +39,10 @@ tests:
       - "set the brightness to 50%"
       - "change the brightness in here to 50 percent"
       - "turn brightness to 50% in here"
+    context:
+      area: Bedroom
     intent:
       name: HassLightSet
-      context:
-        area: Bedroom
       slots:
         brightness: 50
         area: Bedroom
@@ -104,10 +104,10 @@ tests:
       - "set the brightness to the max"
       - "change the brightness in here to highest"
       - "turn brightness to maximum in here"
+    context:
+      area: Bedroom
     intent:
       name: HassLightSet
-      context:
-        area: Bedroom
       slots:
         brightness: 100
         area: Bedroom
@@ -155,10 +155,10 @@ tests:
       - "make the lights red"
       - "set the color of all lights in here to red"
       - "make all the lights red in here"
+    context:
+      area: Bedroom
     intent:
       name: HassLightSet
-      context:
-        area: Bedroom
       slots:
         color: red
         area: Bedroom

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -104,10 +104,10 @@ tests:
       - turn the lights in here off
       - turn the lights off
       - turn the lights off here
+    context:
+      area: Living Room
     intent:
       name: HassTurnOff
-      context:
-        area: Living Room
       slots:
         domain: light
         area: Living Room

--- a/tests/en/light_HassTurnOn.yaml
+++ b/tests/en/light_HassTurnOn.yaml
@@ -108,11 +108,10 @@ tests:
       - turn the lights in here on
       - turn the lights on
       - turn the lights on here
-
+    context:
+      area: Living Room
     intent:
       name: HassTurnOn
-      context:
-        area: Living Room
       slots:
         domain: light
         area: Living Room

--- a/tests/en/media_player_HassMediaNext.yaml
+++ b/tests/en/media_player_HassMediaNext.yaml
@@ -26,20 +26,20 @@ tests:
       - "skip the track"
       - "skip"
       - "skip this"
+    context:
+      area: Living Room
     intent:
       name: HassMediaNext
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Playing next"
   - sentences:
       - "next item in living room"
       - "skip song in living room"
+    context:
+      area: Living Room
     intent:
       name: HassMediaNext
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Playing next"

--- a/tests/en/media_player_HassMediaPause.yaml
+++ b/tests/en/media_player_HassMediaPause.yaml
@@ -10,21 +10,21 @@ tests:
     response: "Paused"
   - sentences:
       - "pause"
+    context:
+      area: Living Room
     intent:
       name: HassMediaPause
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Paused"
   - sentences:
       - "pause music in the living room"
       - "pause my show in the living room"
       - "pause living room media player"
+    context:
+      area: Living Room
     intent:
       name: HassMediaPause
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Paused"

--- a/tests/en/media_player_HassMediaPrevious.yaml
+++ b/tests/en/media_player_HassMediaPrevious.yaml
@@ -23,12 +23,12 @@ tests:
       - "replay the last track"
       - "play the last song again"
       - "replay"
+    context:
+      area: Living Room
     intent:
       name: HassMediaPrevious
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Playing previous"
   - sentences:
       - "go back in the living room"
@@ -36,10 +36,10 @@ tests:
       - "go back to the last track in the living room"
       - "replay the last track in the living room"
       - "in the living room play the last song again"
+    context:
+      area: Living Room
     intent:
       name: HassMediaPrevious
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Playing previous"

--- a/tests/en/media_player_HassMediaUnpause.yaml
+++ b/tests/en/media_player_HassMediaUnpause.yaml
@@ -13,21 +13,21 @@ tests:
   - sentences:
       - "unpause"
       - "resume"
+    context:
+      area: Living Room
     intent:
       name: HassMediaUnpause
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Resumed"
   - sentences:
       - "resume music in the living room"
       - "unpause my show in the living room"
       - "resume living room media player"
+    context:
+      area: Living Room
     intent:
       name: HassMediaUnpause
       slots:
         area: "Living Room"
-      context:
-        area: Living Room
     response: "Resumed"

--- a/tests/en/media_player_HassSetVolume.yaml
+++ b/tests/en/media_player_HassSetVolume.yaml
@@ -20,10 +20,10 @@ tests:
       - "increase the volume to 90 percent"
       - "turn the volume down to 90 percent"
       - "turn up the volume to 90"
+    context:
+      area: Living Room
     intent:
       name: HassSetVolume
-      context:
-        area: Living Room
       slots:
         area: "Living Room"
         volume_level: 90
@@ -35,10 +35,10 @@ tests:
       - "increase the volume in living room to 90 percent"
       - "in the living room turn the volume down to 90 percent"
       - "turn up the volume to 90 in the living room"
+    context:
+      area: Living Room
     intent:
       name: HassSetVolume
-      context:
-        area: Living Room
       slots:
         area: "Living Room"
         volume_level: 90

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -138,7 +138,7 @@ def do_test_language_sentences_file(
                     intent.get("context", {}).get("domain") == testing_domain
                 ), f"File {test_file}: tests should have domain slot set to {testing_domain}"
 
-        intent_context = test.get("context", {})
+        test_context = test.get("context", {})
         expected_response_texts = test.get("response")
         if expected_response_texts:
             if isinstance(expected_response_texts, str):
@@ -176,7 +176,7 @@ def do_test_language_sentences_file(
                     sentence,
                     language_sentences,
                     slot_lists=slot_lists,
-                    intent_context=intent_context,
+                    intent_context=test_context,
                     best_slot_name="name",
                 )
                 assert result is not None, f"Recognition failed for '{sentence}'"

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -149,10 +149,12 @@ def do_test_language_sentences_file(
                 )
 
         for sentence in test["sentences"]:
+            sentence_unique_id = sentence + str(intent.get("context", ""))
+
             assert (
-                sentence not in seen_sentences
+                sentence_unique_id not in seen_sentences
             ), f"Duplicate sentence found: {sentence}"
-            seen_sentences.add(sentence)
+            seen_sentences.add(sentence_unique_id)
 
             # Filter {name} list using input text
             slot_lists["name"] = TextSlotList(

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -138,7 +138,7 @@ def do_test_language_sentences_file(
                     intent.get("context", {}).get("domain") == testing_domain
                 ), f"File {test_file}: tests should have domain slot set to {testing_domain}"
 
-        intent_context = intent.get("context", {})
+        intent_context = test.get("context", {})
         expected_response_texts = test.get("response")
         if expected_response_texts:
             if isinstance(expected_response_texts, str):
@@ -149,7 +149,7 @@ def do_test_language_sentences_file(
                 )
 
         for sentence in test["sentences"]:
-            sentence_unique_id = sentence + str(intent.get("context", ""))
+            sentence_unique_id = sentence + str(test.get("context", ""))
 
             assert (
                 sentence_unique_id not in seen_sentences


### PR DESCRIPTION
It should be fine to have 2 identical test sentences if their context is different (e.g. "turn off the lights" should mean "turn off all lights" without context and "turn off the lights in this area" when the satellite's area is provided as context).

Although technically you could have passed such a set of sentences to HA, it was impossible to add them to the intents repo until now due to tests not passing.

Part of the cause was the double use of `intent.context`, both as input context to the test and as expected outcome after the recognition. This PR splits the 2 concerns (input context and expected output context) and allows several identical sentences to be tested, as long as their input contexts differ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional "context" key within test dictionaries to enhance test specificity without allowing nested dictionaries.
  
- **Bug Fixes**
  - Removed incorrect `requires_context` fields in intent definitions related to binary sensors, improving accuracy.

- **Refactor**
  - Restructured `context` field placement in YAML test files for better organization and clarity, moving it from intent to test case or scenario levels.

- **Tests**
  - Enhanced contextual information for various intents by adding or restructuring `context` fields to specify areas such as Living Room and Bedroom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->