### PR TITLE
[EN] HassGetState optimizations

### DIFF
--- a/sentences/en/homeassistant_HassGetState.yaml
+++ b/sentences/en/homeassistant_HassGetState.yaml
@@ -3,33 +3,47 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - (do you know|tell me|<what_is>) [the [current] (state|value) of] <name> [in <area>]
+          - (do you know|tell me|<what_is>) [the [current ](state|value) of ]<name>[ in <area>]
         response: one
         excludes_context:
           domain:
             - scene
             - script
       - sentences:
-          - is [the] [state of] <name> {on_off_states:state} [in <area>]
+          - is [the ][state of ]<name> {on_off_states:state}
+          - is [the ][state of ]<name> (({on_off_states:state};in <area>))
         response: one_yesno
         excludes_context:
           domain:
             - cover
 
       - sentences:
-          - (is|are) [there] any {on_off_domains:domain} {on_off_states:state} [in <area>]
+          - (is|are)[ there] any {on_off_domains:domain} {on_off_states:state} [in <area>]
           - (do you know|tell me) if there are any {on_off_domains:domain} {on_off_states:state} [in <area>]
         response: any
 
       - sentences:
-          - are all [the] {on_off_domains:domain} [(switched|turned|set[ to])] {on_off_states:state} [in <area>]
-          - are all [the] {on_off_domains:domain} in <area> [(switched|turned|set[ to])] {on_off_states:state}
+          - are [all ][[of ]the ]{on_off_domains:domain} [(switched|turned|set[ to]) ]{on_off_states:state}
+          - are [all ][of ]<area> {on_off_domains:domain} [(switched|turned|set[ to]) ]{on_off_states:state}
+          - are [all ][[of ]the ]{on_off_domains:domain} ([(switched|turned|set[ to]) ]{on_off_states:state};in <area>)
         response: all
 
       - sentences:
-          - "[do you know] (which|what) {on_off_domains:domain} (is|are) {on_off_states:state} [in <area>]"
+          - is the light [(switched|turned|set[ to]) ]{on_off_states:state}
+          - is the light ([(switched|turned|set[ to]) ]{on_off_states:state};in <area>)
+          - is <area> light [(switched|turned|set[ to]) ]{on_off_states:state}
+        slots:
+          domain: light
+        response: all
+
+      - sentences:
+          - "[do you know ](which|what) {on_off_domains:domain} (is|are) {on_off_states:state}"
+          - "[do you know ](which|what) {on_off_domains:domain} ((is|are) {on_off_states:state};in <area>)"
+          - "[do you know ](which|what) <area> {on_off_domains:domain} (is|are) {on_off_states:state}"
         response: which
 
       - sentences:
-          - "[tell me] how many {on_off_domains:domain} (is|are) {on_off_states:state} [in <area>]"
+          - "[tell me ]how many {on_off_domains:domain} (is|are) {on_off_states:state}"
+          - "[tell me ]how many {on_off_domains:domain} ((is|are) {on_off_states:state};in <area>)"
+          - "[tell me ]how many <area> {on_off_domains:domain} (is|are) {on_off_states:state}"
         response: how_many

--- a/sentences/en/homeassistant_HassGetState.yaml
+++ b/sentences/en/homeassistant_HassGetState.yaml
@@ -3,23 +3,12 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - (do you know|tell me|<what_is>) [the [current ](state|value) of ]<name>[ in <area>]
-        response: one
-        excludes_context:
-          domain:
-            - scene
-            - script
-      - sentences:
-          - is [the ][state of ]<name> {on_off_states:state}
-          - is [the ][state of ]<name> (({on_off_states:state};in <area>))
-        response: one_yesno
-        excludes_context:
-          domain:
-            - cover
-
-      - sentences:
-          - (is|are)[ there] any {on_off_domains:domain} {on_off_states:state} [in <area>]
-          - (do you know|tell me) if there are any {on_off_domains:domain} {on_off_states:state} [in <area>]
+          - (is|are)[ there] any {on_off_domains:domain} {on_off_states:state}
+          - (is|are)[ there] any {on_off_domains:domain} ({on_off_states:state};in <area>)
+          - (is|are)[ there] any <area> {on_off_domains:domain} {on_off_states:state}
+          - (do you know|tell me) if there are any {on_off_domains:domain} {on_off_states:state}
+          - (do you know|tell me) if there are any {on_off_domains:domain} ({on_off_states:state};in <area>)
+          - (do you know|tell me) if there are any <area> {on_off_domains:domain} {on_off_states:state}
         response: any
 
       - sentences:
@@ -47,3 +36,18 @@ intents:
           - "[tell me ]how many {on_off_domains:domain} ((is|are) {on_off_states:state};in <area>)"
           - "[tell me ]how many <area> {on_off_domains:domain} (is|are) {on_off_states:state}"
         response: how_many
+
+      - sentences:
+          - (do you know|tell me|<what_is>) [the [current ](state|value) of ]<name>[ in <area>]
+        response: one
+        excludes_context:
+          domain:
+            - scene
+            - script
+      - sentences:
+          - is [the ][state of ]<name> {on_off_states:state}
+          - is [the ][state of ]<name> (({on_off_states:state};in <area>))
+        response: one_yesno
+        excludes_context:
+          domain:
+            - cover

--- a/tests/en/homeassistant_HassGetState.yaml
+++ b/tests/en/homeassistant_HassGetState.yaml
@@ -68,6 +68,7 @@ tests:
       - "are all the lights on in the kitchen"
       - "are all lights turned on in the kitchen?"
       - "are all lights in the kitchen on?"
+      - "is the kitchen light on?"
     intent:
       name: HassGetState
       slots:

--- a/tests/en/homeassistant_HassGetState.yaml
+++ b/tests/en/homeassistant_HassGetState.yaml
@@ -19,7 +19,31 @@ tests:
     response: "No, off"
 
   - sentences:
+      - "is the bedroom lamp on in the bedroom?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "Bedroom Lamp"
+        area: "Bedroom"
+        state: "on"
+    response: "No, off"
+
+  - sentences:
+      - "are any switches on?"
+      - "tell me if there are any switches on"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "switch"
+        state: "on"
+    response: "Yes, Kitchen Switch"
+
+  - sentences:
       - "are any switches on in the kitchen?"
+      - "are any kitchen switches on?"
+      - "are any switches in the kitchen on?"
+      - "tell me if there are any switches on in the kitchen"
+      - "tell me if there are any kitchen switches on"
     intent:
       name: HassGetState
       slots:
@@ -38,13 +62,38 @@ tests:
     response: "No, Bedroom Switch is not on"
 
   - sentences:
+      - "are all the bedroom switches on?"
+      - "are all the switches on in the bedroom?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Bedroom"
+        domain: "switch"
+        state: "on"
+    response: "No, Bedroom Switch is not on"
+
+  - sentences:
       - "are all lights off?"
+      - "is the light off?"
     intent:
       name: HassGetState
       slots:
         domain: "light"
         state: "off"
     response: "No, Garage Light, Kitchen cabinets, Kitchen ceiling and 3 more are not off"
+
+  - sentences:
+      - "are all lights off in the kitchen?"
+      - "are all the kitchen lights off?"
+      - "is the light off in the kitchen?"
+      - "is the kitchen light off?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Kitchen"
+        domain: "light"
+        state: "off"
+    response: "No, Kitchen cabinets, Kitchen ceiling and Kitchen countertop are not off"
 
   - sentences:
       - "which lights are on?"
@@ -56,6 +105,17 @@ tests:
     response: "Garage Light, Kitchen cabinets, Kitchen ceiling and 3 more"
 
   - sentences:
+      - "which lights are on in the kitchen?"
+      - "which kitchen lights are on?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Kitchen"
+        domain: "light"
+        state: "on"
+    response: "Kitchen cabinets, Kitchen ceiling and Kitchen countertop"
+
+  - sentences:
       - "how many lights are on?"
     intent:
       name: HassGetState
@@ -63,6 +123,17 @@ tests:
         domain: "light"
         state: "on"
     response: "6"
+
+  - sentences:
+      - "how many lights are on in the kitchen?"
+      - "how many kitchen lights are on?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Kitchen"
+        domain: "light"
+        state: "on"
+    response: "3"
 
   - sentences:
       - "are all the lights on in the kitchen"


### PR DESCRIPTION
Apart from optimizing the sentences for `HassGetState` a bit, I've also introduced a new set of sentences specifically for querying lights.

`Is the light off in the kitchen` usually means asking if *all* of the lights are off.

Inspired by #2218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced querying capabilities for Home Assistant entity states, including specific areas like the bedroom and kitchen.
  - Added new sentence structures for more detailed and varied queries.

- **Refactor**
  - Improved clarity and coverage of existing sentence structures for querying entity states.

- **Tests**
  - Added and refined test queries for specific devices and areas to ensure accurate responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->