### PR TITLE
[EN] Enhanced get state sentences for `media_player`

### DIFF
--- a/responses/en/HassGetState.yaml
+++ b/responses/en/HassGetState.yaml
@@ -9,6 +9,14 @@ responses:
       one: |
         {{ slots.name | capitalize }} is {{ state.state_with_unit }}
 
+      alternate_state: |
+        {{ slots.name | capitalize }} is {{ slots.actual_state }}, but it is
+        {% if state.state in slots.alternate_state %}
+          {{ slots.alternate_state[state.state] }}
+        {% else %}
+          {{ state.state }}
+        {% endif %}
+
       one_yesno: |
         {% if query.matched %}
           Yes

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -128,6 +128,16 @@ lists:
         out: "locked"
       - in: "unlocked"
         out: "unlocked"
+  media_player_states:
+    values:
+      - in: "[turned ]off"
+        out: "off"
+      - in: "(idle|standing by)"
+        out: ["on", "idle", "standby", "buffering"]
+      - in: "(playing|[turned ]on)"
+        out: "playing"
+      - in: "paused"
+        out: "paused"
 
   # binary_sensor
   bs_battery_states:
@@ -372,6 +382,7 @@ expansion_rules:
   in: "(in|on|at|of)"
   position: "{position}[[ ]%| percent]"
   volume: "{volume:volume_level}[[ ]%| percent]"
+  media_players: "([media ]player[s]|speaker[s]stereo[s]|tv[s])"
 
   # Context awareness expansion rules
   all: "(all|all of|every|every single|each|each and every)"

--- a/sentences/en/homeassistant_HassGetState.yaml
+++ b/sentences/en/homeassistant_HassGetState.yaml
@@ -15,6 +15,7 @@ intents:
         excludes_context:
           domain:
             - cover
+            - media_player
 
       - sentences:
           - (is|are) [there] any {on_off_domains:domain} {on_off_states:state} [in <area>]

--- a/sentences/en/media_player_HassGetState.yaml
+++ b/sentences/en/media_player_HassGetState.yaml
@@ -1,0 +1,75 @@
+language: en
+intents:
+  HassGetState:
+    data:
+      - sentences:
+          - is [the ][state of ]<name> [turned ]on[ in <area>]
+        slots:
+          actual_state: "on"
+          alternate_state:
+            "on": "in an unknown state"
+            idle: "not playing"
+            standby: "in standby"
+        response: alternate_state
+        requires_context:
+          domain: media_player
+        excludes_context:
+          state:
+            - "playing"
+            - "off"
+
+      - sentences:
+          - is [the ][state of ]<name> [turned ]off[ in <area>]
+        slots:
+          state:
+            - "on"
+            - "idle"
+            - "paused"
+            - "standby"
+            - "buffering"
+          actual_state: "not off"
+          alternate_state:
+            "on": "in an unknown state"
+            idle: "not playing anything"
+            standby: "in standby"
+        response: alternate_state
+        requires_context:
+          domain: media_player
+
+      - sentences:
+          - is [the] [state of] <name> {media_player_states:state} [in <area>]
+        response: one_yesno
+        requires_context:
+          domain: media_player
+
+      - sentences:
+          - (is|are) [there] any <media_players> {media_player_states:state} [in <area>]
+          - (do you know|tell me) if there are any <media_players> {media_player_states:state} [in <area>]
+        slots:
+          domain: media_player
+        response: any
+      - sentences:
+          - (is|are) [there] any <media_players> {media_player_states:state} [in <area>]
+          - (do you know|tell me) if there are any <media_players> {media_player_states:state} [in <area>]
+        slots:
+          domain: media_player
+        response: any
+
+      - sentences:
+          - are all [the] <media_players> {media_player_states:state} [in <area>]
+          - are all [the] <media_players> in <area> {media_player_states:state}
+        slots:
+          domain: media_player
+        response: all
+
+      - sentences:
+          - "[do you know] (which|what) <media_players> (is|are) {media_player_states:state} [in <area>]"
+        slots:
+          domain: media_player
+        response: which
+
+      - sentences:
+          - "[tell me] how many <media_players> (is|are) {media_player_states:state} [in <area>]"
+        slots:
+          domain: media_player
+        response: how_many

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -117,7 +117,7 @@ def get_matched_states(
     if device_class_entity is not None:
         device_class = device_class_entity.value
 
-    state_name: Optional[str] = None
+    state_name: Optional[str | List[str]] = None
     state_entity = result.entities.get("state")
     if state_entity is not None:
         state_name = state_entity.value
@@ -163,7 +163,9 @@ def get_matched_states(
 
         if state_name is not None:
             # Match state
-            if state.hass_state == state_name:
+            if isinstance(state_name, str) and state.hass_state == state_name:
+                matched.append(state)
+            elif isinstance(state_name, list) and state.hass_state in state_name:
                 matched.append(state)
             else:
                 unmatched.append(state)

--- a/tests/en/media_player_HassGetState.yaml
+++ b/tests/en/media_player_HassGetState.yaml
@@ -1,0 +1,125 @@
+language: en
+tests:
+  - sentences:
+      - "is the TV on?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "TV"
+        actual_state: "on"
+        alternate_state:
+          "on": "in an unknown state"
+          idle: "not playing"
+          standby: "in standby"
+      context:
+        domain: media_player
+        volume_level: "50"
+    response: "Tv is on, but it is not playing"
+
+  - sentences:
+      - "is the TV off?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "TV"
+        state:
+          - "on"
+          - "idle"
+          - "paused"
+          - "standby"
+          - "buffering"
+        actual_state: "not off"
+        alternate_state:
+          "on": "in an unknown state"
+          idle: "not playing anything"
+          standby: "in standby"
+      context:
+        domain: media_player
+        volume_level: "50"
+    response: "Tv is not off, but it is not playing anything"
+
+  - sentences:
+      - "is the TV playing?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "TV"
+        state: "playing"
+      context:
+        domain: media_player
+        volume_level: "50"
+    response: "No, idle"
+
+  - sentences:
+      - "is the TV standing by?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "TV"
+        state:
+          - "on"
+          - "idle"
+          - "standby"
+          - "buffering"
+      context:
+        domain: media_player
+        volume_level: "50"
+    response: "Yes"
+
+  - sentences:
+      - "are any media players on in the kitchen?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Kitchen"
+        domain: "media_player"
+        state: "playing"
+    response: "No"
+
+  - sentences:
+      - "are all media players on?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "media_player"
+        state: "playing"
+    response: "No, TV is not on"
+
+  - sentences:
+      - "are all media players off?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "media_player"
+        state: "off"
+    response: "No, TV is not off"
+
+  - sentences:
+      - "which media players are on?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "media_player"
+        state: "playing"
+    response: "Not any"
+
+  - sentences:
+      - "how many media players are on?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "media_player"
+        state: "playing"
+    response: "0"
+
+  - sentences:
+      - "are all the media players on in the living room"
+      - "are all media players on in the living room?"
+      - "are all media players in the living room on?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "media_player"
+        state: "playing"
+        area: "Living Room"
+    response: "No, TV is not on"


### PR DESCRIPTION
An attempt to fix #2229 (at least in English)

These sentences "rephrase" some states that you ask about regarding media players.

Also, when the state is ambiguous (e.g. `is the TV on?`), the response clarifies the state, e.g. `the TV is on, but it is not playing`.

As a dependency in this PR, there is a [small fix](https://github.com/home-assistant/intents/pull/2230/commits/ce9ab25caa6d87ad2ca5240eaafe3e5a35d28a25) regarding passing a list for the `state` slot, which, although supported in hassil, would have appeared as no matches were found until now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an `alternate_state` response template for more nuanced state representation.
  - Added detailed state management and querying for media players.

- **Enhancements**
  - Refined state definitions for media players, including states like "off", "on", "idle", "standby", "buffering", "playing", and "paused".
  - Updated Home Assistant intents to exclude `media_player` from specific state checks.

- **Tests**
  - Added tests for querying and managing media player states to ensure accurate and reliable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->