### PR TITLE
[NL] Experiment: add `de` and `het` to `skip_list`

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -315,9 +315,9 @@ lists:
       to: 100
   brightness_level:
     values:
-      - in: ([het|de] max|[het] maximum|maximaal|[het] maximale|[z'n|zijn|het] hoogst[e])
+      - in: (max|maximum|maximaal|maximale|[z'n|zijn] hoogst[e])
         out: 100
-      - in: ([het|de] min|[het] minimum|minimaal|[het] minimale|[z'n|zijn|het] laagst[e])
+      - in: (min|minimum|minimaal|minimale|[z'n|zijn] laagst[e])
         out: 1
 
   color:
@@ -378,9 +378,9 @@ lists:
         out: "open"
       - in: "(dicht|gesloten)"
         out: "closed"
-      - in: "(open aan het gaan|aan het (openen|open gaan))"
+      - in: "(open aan gaan|aan (openen|open gaan))"
         out: "opening"
-      - in: "(dicht aan het gaan|aan het (dicht gaan|sluiten))"
+      - in: "(dicht aan gaan|aan (dicht gaan|sluiten))"
         out: "closing"
   cover_classes:
     values:
@@ -426,9 +426,9 @@ lists:
 
   bs_battery_charging_states:
     values:
-      - in: "(aan (het laden|de lader)|opgeladen)"
+      - in: "(aan (laden|lader)|opgeladen)"
         out: "on"
-      - in: "niet aan (het laden|de lader)"
+      - in: "niet aan (laden|lader)"
         out: "off"
 
   bs_carbon_monoxide_states:
@@ -552,9 +552,9 @@ lists:
 
   bs_running_states:
     values:
-      - in: "[op] (actief|bezig|draait|werkt|[aan [he|']t|te] (draaien|werk[en])|activiteit)"
+      - in: "[op] (actief|bezig|draait|werkt|[aan|te] (draaien|werk[en])|activiteit)"
         out: "on"
-      - in: "(niet [op] (actief|bezig|(aan [he|']t|te) (draaien|werk[en]))|(draaien|werk[en]) niet|[op] inactief|[geen |in]activiteit)"
+      - in: "(niet [op] (actief|bezig|(aan|te) (draaien|werk[en]))|(draaien|werk[en]) niet|[op] inactief|[geen |in]activiteit)"
         out: "off"
 
   bs_safety_states:
@@ -594,9 +594,9 @@ lists:
 
   bs_vibration_states:
     values:
-      - in: "(trilt|vibreert|[aan het|te] (trillen|vibreren)|trilling[en]|vibratie[s])"
+      - in: "(trilt|vibreert|[aan|te] (trillen|vibreren)|trilling[en]|vibratie[s])"
         out: "on"
-      - in: "(niet aan het (trillen|vibreren)|(trilt|vibreert|trillen|vibreren) niet|geen (trilling[en]|vibratie[s]))"
+      - in: "(niet aan (trillen|vibreren)|(trilt|vibreert|trillen|vibreren) niet|geen (trilling[en]|vibratie[s]))"
         out: "off"
 
   bs_window_states:
@@ -659,23 +659,24 @@ lists:
 
 expansion_rules:
   # generic expansion rules for sentences
-  name: "[de|het] {name}"
-  area: "[de|het] {area}"
-  floor: "[de|het] {floor}"
+  name: "{name}"
+  area: "{area}"
+  floor: "{floor}"
   in: "[in|op|van|bij]"
   by: "(door|met|bij)"
   here: "(hier|in deze (kamer|ruimte))"
+  my: (mijn|m'n)
   name_area: >
     (
-      <name> [<in> <area>]
-      |<in> <area> <name>
-      |<area>[ ]<name>
+      {name} [<in> {area}]
+      |<in> {area} {name}
+      |{area}[ ]{name}
     )
   sensor_name_area: >
     (
-      [<in>] [<area>][ ]{name}
-      |[<in> [<area>]] [<by>] <name>
-      |[<by>] <name> [<in>] <area>
+      [<in>] [{area}][ ]{name}
+      |[<in> [{area}]] [<by>] {name}
+      |[<by>] {name} [<in>] {area}
     )
   change: "(zet|mag|mogen|doe|verander|maak|schakel)"
   would: "(kan|kun|wil) (je|jij)"
@@ -694,28 +695,28 @@ expansion_rules:
   shutter: "(rolluik[en]|shutter[s])"
   window: "(raam|ramen)"
   # device/entity types
-  light: "[de|het|een] (lamp[en]|licht[en]|verlichting)"
-  fan: "[de|een] (ventilator[s|en]|fan[s])"
-  switch: "[de|een] (schakelaar[s]|switch[es]|plug[gen])"
-  cover: "[de|het] (<awning>|<blind>|<curtain>|<door>|<garage>|<gate>|<shade>|<shutter>|<window>)"
+  light: "[een] (lamp[en]|licht[en]|verlichting)"
+  fan: "[een] (ventilator[s|en]|fan[s])"
+  switch: "[een] (schakelaar[s]|switch[es]|plug[gen])"
+  cover: "(<awning>|<blind>|<curtain>|<door>|<garage>|<gate>|<shade>|<shutter>|<window>)"
   # lock specific
-  lock: "[de|het|een] ([deur]slot[en]|vergrendeling[en])"
+  lock: "[een] ([deur]slot[en]|vergrendeling[en])"
   locked: "(<to> slot|[<to>] vergrendeld)"
-  unlocked: "[<to>] (van [het] slot|ontgrendeld)"
+  unlocked: "[<to>] (van slot|ontgrendeld)"
   lock_name: >
     (
-      <lock> [van] <name>
-     |<name>[ ]([deur]slot[en]|vergrendeling[en])
+      <lock> [van] {name}
+     |{name}[ ]([deur]slot[en]|vergrendeling[en])
     )
   lock_name_area: >
     (
-      <lock> [van] [{area}[ ]]<name>
-      |<lock_name> [<in> <area>]
-      |[<in> <area>] <lock_name>)
-      |<area>[ ]<name>[ ]([deur]slot[en]|vergrendeling[en]
+      <lock> [van] [{area}[ ]]{name}
+      |<lock_name> [<in> {area}]
+      |[<in> {area}] <lock_name>)
+      |{area}[ ]{name}[ ]([deur]slot[en]|vergrendeling[en]
     )
   # light brightness
-  brightness: "[de] (helderheid|felheid|intensiteit|lichtsterkte)"
+  brightness: "(helderheid|felheid|intensiteit|lichtsterkte)"
   brightness_value: "{brightness}[ ][%|procent]"
   # temperature/climate states
   temperature: "{temperature}[ ][°|graden] [{temperature_unit}]"
@@ -725,12 +726,12 @@ expansion_rules:
   closed: "(dicht|omlaag|naar beneden|neerwaarts)"
   # binary_sensor specific
   detect: "(detecteert|registreert|detecteren|registreren|gedetecteerd|geregistreerd|waar[ ]genomen)"
-  sensor: "[een|de] (apparaat|apparaten|sensor[s|en]|iets)"
+  sensor: "[een] (apparaat|apparaten|sensor[s|en]|iets)"
   sensor_area: >
     (
-      [[de|een] {area}][ ](apparaat|apparaten|sensor[s|en])
-     |[<in> [de|het] {area}] <sensor>
-     |[een|de] (apparaat|apparaten|sensor[s|en]|iets) [[in|op|van|bij] <area>]
+      [[een] {area}][ ](apparaat|apparaten|sensor[s|en])
+     |[<in> {area}] <sensor>
+     |[een] (apparaat|apparaten|sensor[s|en]|iets) [[in|op|van|bij] {area}]
     )
   numeric_value_set: "(zet|doe|mag|verander|maak|draai|verhoog|verlaag)"
   media_item: "(lied[je[s]]|nummer[s]|track[s]|item[s]|aflevering[en]|video[s]|film[pje][s]|muziek[je[s]]|playlist[s]|afspeellijst[en])"
@@ -741,9 +742,9 @@ expansion_rules:
   what_is: (wat (is|zijn)|hoeveel (is|zijn)|hoe (hoog|laag) (is|zijn))
   what_is_the_class_of_name: >
     (
-      <what_is> (het|de) <class> (van|in|(aangegeven|gemeten) door) <name> [in <area>]
-     |<what_is> <name>[[']s] [gemeten] <class> [in <area>]
-     |<what_is> <area>[ ]<name>[s] [gemeten] <class>
+      <what_is> <class> (van|in|(aangegeven|gemeten) door) {name} [in {area}]
+     |<what_is> {name}[[']s] [gemeten] <class> [in {area}]
+     |<what_is> {area}[ ]{name}[s] [gemeten] <class>
     )
 
   # Timers
@@ -768,16 +769,16 @@ expansion_rules:
   timer_start_minutes: "{timer_minutes:start_minutes} (minuut|minuten) [[en] {timer_seconds:start_seconds} seconde[n|s]]"
   timer_start_hours: "{timer_hours:start_hours} (uur|uren) [[en] {timer_minutes:start_minutes} (minuut|minuten)] [[en] {timer_seconds:start_seconds} seconde[s|n]]"
   timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
-  timer_named: (genaamd|met [de] naam|voor [de|het|een])
+  timer_named: (genaamd|met naam|voor [een])
   timer_prefix: (<timer_start> |{area}[ ]|{timer_name:name}[ ]|)
   timer_suffix: >
     (
       (van|voor) <timer_start>
-      |[<in>] <area>
+      |[<in>] {area}
       |<timer_named> {timer_name:name}
     )
-  my_timer: "[de|mijn|m'n] ([<timer_prefix>](timer|kookwekker)|(timer|kookwekker) <timer_suffix>)"
-  area_timer: "<in> <area> [de|mijn|m'n] (timer|kookwekker)"
+  my_timer: "[<my>] ([<timer_prefix>](timer|kookwekker)|(timer|kookwekker) <timer_suffix>)"
+  area_timer: "<in> {area} [<my>] (timer|kookwekker)"
 
 skip_words:
   - "alstublieft"
@@ -788,3 +789,6 @@ skip_words:
   - "ik wil"
   - "voor mij"
   - "voor me"
+  - "de"
+  - "het"
+  - "'t"

--- a/sentences/nl/binary_sensor_HassGetState.yaml
+++ b/sentences/nl/binary_sensor_HassGetState.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       # https://www.home-assistant.io/integrations/binary_sensor/
       - sentences:
-          - "<is> [de] [batterij[status]] [van] [[<in>] <area>][ ]<name>[ ][batterij] [[<in>] <area>] {bs_battery_states:state} [[<in>] <area>]"
+          - "<is> [batterij[status]] [van] [[<in>] {area}][ ]{name}[ ][batterij] [[<in>] {area}] {bs_battery_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -14,7 +14,7 @@ intents:
           device_class: battery
 
       - sentences:
-          - "<is> [[de] batterij [van]] [[<in>] <area>][ ]<name>[ ][batterij] [[<in>] <area>] {bs_battery_charging_states:state} [[<in>] <area>]"
+          - "<is> [batterij [van]] [[<in>] {area}][ ]{name}[ ][batterij] [[<in>] {area}] {bs_battery_charging_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -24,11 +24,11 @@ intents:
           device_class: battery_charging
 
       - sentences:
-          - "<detect> [<by>] <sensor_name_area> {bs_carbon_monoxide_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_carbon_monoxide_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_carbon_monoxide_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_carbon_monoxide_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_carbon_monoxide_states:state} <detect> [[<in>] <area>]"
+          - "<detect> [<by>] <sensor_name_area> {bs_carbon_monoxide_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_carbon_monoxide_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_carbon_monoxide_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_carbon_monoxide_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_carbon_monoxide_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -38,11 +38,11 @@ intents:
           device_class: carbon_monoxide
 
       - sentences:
-          - "(is|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_cold_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_cold_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_cold_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_cold_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area>  {bs_cold_states:state} <detect> [[<in>] <area>]"
+          - "(is|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_cold_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_cold_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_cold_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_cold_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area>  {bs_cold_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -52,7 +52,7 @@ intents:
           device_class: cold
 
       - sentences:
-          - "<is> <sensor_name_area> {bs_connectivity_states:state} [[<in>] <area>]"
+          - "<is> <sensor_name_area> {bs_connectivity_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -62,7 +62,7 @@ intents:
           device_class: connectivity
 
       - sentences:
-          - "<is> <sensor_name_area> {bs_door_states:state} [[<in>] <area>]"
+          - "<is> <sensor_name_area> {bs_door_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -72,7 +72,7 @@ intents:
           device_class: door
 
       - sentences:
-          - "<is> <sensor_name_area> {bs_garage_door_states:state} [[<in>] <area>]"
+          - "<is> <sensor_name_area> {bs_garage_door_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -82,11 +82,11 @@ intents:
           device_class: garage_door
 
       - sentences:
-          - "<detect> [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_gas_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_gas_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_gas_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_gas_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_gas_states:state} <detect> [[<in>] <area>]"
+          - "<detect> [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_gas_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_gas_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_gas_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_gas_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_gas_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -96,11 +96,11 @@ intents:
           device_class: gas
 
       - sentences:
-          - "(<is>|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_heat_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_heat_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_heat_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_heat_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_heat_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_heat_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_heat_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_heat_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_heat_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_heat_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -110,11 +110,11 @@ intents:
           device_class: heat
 
       - sentences:
-          - "(<is>|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_light_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_light_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_light_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_light_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_light_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_light_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_light_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_light_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_light_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_light_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -124,7 +124,7 @@ intents:
           device_class: light
 
       - sentences:
-          - "<is> <sensor_name_area> {bs_lock_states:state} [[<in>] <area>]"
+          - "<is> <sensor_name_area> {bs_lock_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -134,11 +134,11 @@ intents:
           device_class: lock
 
       - sentences:
-          - "(<is>|<detect>) [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_moisture_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_moisture_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_moisture_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_moisture_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_moisture_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_moisture_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_moisture_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_moisture_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_moisture_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_moisture_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -148,11 +148,11 @@ intents:
           device_class: moisture
 
       - sentences:
-          - "<detect> [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_motion_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_motion_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_motion_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_motion_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_motion_states:state} <detect> [[<in>] <area>]"
+          - "<detect> [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_motion_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_motion_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_motion_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_motion_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_motion_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -162,11 +162,11 @@ intents:
           device_class: motion
 
       - sentences:
-          - "<detect> [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_occupancy_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_occupancy_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "(is|zijn|word[t|en]) [er] [[<in>] <area>] {bs_occupancy_states:state} <detect> <sensor_name_area>"
-          - "(is|zijn|wordt[t|en]) [er] [[<in>] <area>] {bs_occupancy_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_occupancy_states:state} <detect> [[<in>] <area>]"
+          - "<detect> [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_occupancy_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_occupancy_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "(is|zijn|word[t|en]) [er] [[<in>] {area}] {bs_occupancy_states:state} <detect> <sensor_name_area>"
+          - "(is|zijn|wordt[t|en]) [er] [[<in>] {area}] {bs_occupancy_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_occupancy_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -176,7 +176,7 @@ intents:
           device_class: occupancy
 
       - sentences:
-          - "<is> <sensor_name_area> {bs_opening_states:state} [[<in>] <area>]"
+          - "<is> <sensor_name_area> {bs_opening_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -186,8 +186,8 @@ intents:
           device_class: opening
 
       - sentences:
-          - "<is> [[de] (kabel[s]|lader[s]) van] [<area>][ ]<name> [[<in>] <area>] {bs_plug_states:state} [[<in>] <area>]"
-          - "<is> [[<in>] <area>] [[de] (kabel[s]|lader[s]) van] <name>[[ ](lader[s]|kabel[s])]  [[<in>] <area>] {bs_plug_states:state} [[<in>] <area>]"
+          - "<is> [(kabel[s]|lader[s]) van] [{area}][ ]{name} [[<in>] {area}] {bs_plug_states:state} [[<in>] {area}]"
+          - "<is> [[<in>] {area}] [(kabel[s]|lader[s]) van] {name}[[ ](lader[s]|kabel[s])]  [[<in>] {area}] {bs_plug_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -198,11 +198,11 @@ intents:
 
       # power
       - sentences:
-          - "(<is>|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_power_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_power_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_power_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_power_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_power_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_power_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_power_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_power_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_power_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_power_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -213,7 +213,7 @@ intents:
 
       # presense
       - sentences:
-          - "<is> <sensor_name_area> {bs_presence_states:state} [[<in>] <area>]"
+          - "<is> <sensor_name_area> {bs_presence_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -224,12 +224,12 @@ intents:
 
       # problem
       - sentences:
-          - "<is> er [[<in>] <area>] {bs_problem_states:state} <sensor_name_area>"
-          - "(heeft|<detect>) <sensor_name_area> {bs_problem_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_problem_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_problem_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_problem_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_problem_states:state} <detect> [[<in>] <area>]"
+          - "<is> er [[<in>] {area}] {bs_problem_states:state} <sensor_name_area>"
+          - "(heeft|<detect>) <sensor_name_area> {bs_problem_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_problem_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_problem_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_problem_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_problem_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -239,34 +239,34 @@ intents:
           device_class: problem
 
       - sentences:
-          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_problem_states:state} [[<in>] <area>]
-          - "<is> [er] [[<in>] <area>] [ergens] [[<in>] <area>] {bs_problem_states:state} [[<in>] <area>] <detect> [[<in>] <area>]"
+          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_problem_states:state} [[<in>] {area}]
+          - "<is> [er] [[<in>] {area}] [ergens] [[<in>] {area}] {bs_problem_states:state} [[<in>] {area}] <detect> [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: problem
 
       - sentences:
-          - "(is|zijn) er [[<in>] <area>] <all> [[<in>] <area>] {bs_problem_states:state} [[<in>] <area>]"
-          - <detect> <all> <sensor_area> {bs_problem_states:state} [[<in>] <area>]
-          - <is> [<by>] <all> [[<in>] <area>][ ]<sensor> {bs_problem_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - "(is|zijn) er [[<in>] {area}] <all> [[<in>] {area}] {bs_problem_states:state} [[<in>] {area}]"
+          - <detect> <all> <sensor_area> {bs_problem_states:state} [[<in>] {area}]
+          - <is> [<by>] <all> [[<in>] {area}][ ]<sensor> {bs_problem_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
           device_class: problem
 
       - sentences:
-          - Welk[e] <sensor_area> (nemen|neemt) {bs_problem_states:state} waar [[<in>] <area>]
-          - Welk[e] <sensor_area> <detect> {bs_problem_states:state} [[<in>] <area>]
+          - Welk[e] <sensor_area> (nemen|neemt) {bs_problem_states:state} waar [[<in>] {area}]
+          - Welk[e] <sensor_area> <detect> {bs_problem_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: problem
 
       - sentences:
-          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] <area>] {bs_problem_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] <area>] {bs_problem_states:state} [[<in>] <area>] waar [[<in>] <area>]
-          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] <area>] {bs_problem_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] {area}] {bs_problem_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] {area}] {bs_problem_states:state} [[<in>] {area}] waar [[<in>] {area}]
+          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] {area}] {bs_problem_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -275,11 +275,11 @@ intents:
       # running
       - sentences:
           - "{bs_running_states:state} <sensor_name_area>"
-          - "(<is>|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_running_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_running_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_running_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_running_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_running_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_running_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_running_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_running_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_running_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_running_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -290,8 +290,8 @@ intents:
 
       - sentences:
           - "{bs_running_states:state} [er] [ergens] <sensor_area>"
-          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_running_states:state} [[<in>] <area>]
-          - "<is> [er] [[<in>] <area>] [ergens] [[<in>] <area>] {bs_running_states:state} [[<in>] <area>] <detect> [[<in>] <area>]"
+          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_running_states:state} [[<in>] {area}]
+          - "<is> [er] [[<in>] {area}] [ergens] [[<in>] {area}] {bs_running_states:state} [[<in>] {area}] <detect> [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -299,26 +299,26 @@ intents:
 
       - sentences:
           - "{bs_running_states:state} <all> <sensor_area>"
-          - "is er [[<in>] <area>] <all> [[<in>] <area>] {bs_running_states:state} [[<in>] <area>]"
-          - (<detect>|<is>) <all> <sensor_area> {bs_running_states:state} [[<in>] <area>]
-          - <is> [<by>] <all> [[<in>] <area>][ ]<sensor> {bs_running_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - "is er [[<in>] {area}] <all> [[<in>] {area}] {bs_running_states:state} [[<in>] {area}]"
+          - (<detect>|<is>) <all> <sensor_area> {bs_running_states:state} [[<in>] {area}]
+          - <is> [<by>] <all> [[<in>] {area}][ ]<sensor> {bs_running_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
           device_class: running
 
       - sentences:
-          - Welk[e] <sensor_area> (nemen|neemt) {bs_running_states:state} waar [[<in>] <area>]
-          - Welk[e] <sensor_area> [<detect>|<is>] {bs_running_states:state} [[<in>] <area>]
+          - Welk[e] <sensor_area> (nemen|neemt) {bs_running_states:state} waar [[<in>] {area}]
+          - Welk[e] <sensor_area> [<detect>|<is>] {bs_running_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: running
 
       - sentences:
-          - hoe[ ]veel <sensor_area> [<detect>|<is>] [er] [[<in>] <area>] {bs_running_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] <area>] {bs_running_states:state} [[<in>] <area>] waar [[<in>] <area>]
-          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] <area>] {bs_running_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - hoe[ ]veel <sensor_area> [<detect>|<is>] [er] [[<in>] {area}] {bs_running_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] {area}] {bs_running_states:state} [[<in>] {area}] waar [[<in>] {area}]
+          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] {area}] {bs_running_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -326,11 +326,11 @@ intents:
 
       # safety
       - sentences:
-          - "(<is>|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_safety_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_safety_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_safety_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_safety_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_safety_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_safety_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_safety_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_safety_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_safety_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_safety_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -340,34 +340,34 @@ intents:
           device_class: safety
 
       - sentences:
-          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_safety_states:state} [[<in>] <area>]
-          - "<is> [er] [[<in>] <area>] [ergens] [[<in>] <area>] {bs_safety_states:state} [[<in>] <area>] <detect> [[<in>] <area>]"
+          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_safety_states:state} [[<in>] {area}]
+          - "<is> [er] [[<in>] {area}] [ergens] [[<in>] {area}] {bs_safety_states:state} [[<in>] {area}] <detect> [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: safety
 
       - sentences:
-          - "is het [[<in>] <area>] <all> [[<in>] <area>] {bs_safety_states:state} [[<in>] <area>]"
-          - (<detect>|<is>) <all> <sensor_area> {bs_safety_states:state} [[<in>] <area>]
-          - <is> [<by>] <all> [[<in>] <area>][ ]<sensor> {bs_safety_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - "is [[<in>] {area}] <all> [[<in>] {area}] {bs_safety_states:state} [[<in>] {area}]"
+          - (<detect>|<is>) <all> <sensor_area> {bs_safety_states:state} [[<in>] {area}]
+          - <is> [<by>] <all> [[<in>] {area}][ ]<sensor> {bs_safety_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
           device_class: safety
 
       - sentences:
-          - Welk[e] <sensor_area> (nemen|neemt) {bs_safety_states:state} waar [[<in>] <area>]
-          - Welk[e] <sensor_area> <detect> {bs_safety_states:state} [[<in>] <area>]
+          - Welk[e] <sensor_area> (nemen|neemt) {bs_safety_states:state} waar [[<in>] {area}]
+          - Welk[e] <sensor_area> <detect> {bs_safety_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: safety
 
       - sentences:
-          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] <area>] {bs_safety_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] <area>] {bs_safety_states:state} [[<in>] <area>] waar [[<in>] <area>]
-          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] <area>] {bs_safety_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] {area}] {bs_safety_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] {area}] {bs_safety_states:state} [[<in>] {area}] waar [[<in>] {area}]
+          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] {area}] {bs_safety_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -375,11 +375,11 @@ intents:
 
       # smoke
       - sentences:
-          - "(<is>|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_smoke_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_smoke_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_smoke_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_smoke_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_smoke_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_smoke_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_smoke_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_smoke_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_smoke_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_smoke_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -389,33 +389,33 @@ intents:
           device_class: smoke
 
       - sentences:
-          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_smoke_states:state} [[<in>] <area>]
-          - "<is> [er] [[<in>] <area>] [ergens] [[<in>] <area>] {bs_smoke_states:state} [[<in>] <area>] <detect> [[<in>] <area>]"
+          - (<detect>|<is>) [er] [ergens] [[<by>] <sensor_area>] {bs_smoke_states:state} [[<in>] {area}]
+          - "<is> [er] [[<in>] {area}] [ergens] [[<in>] {area}] {bs_smoke_states:state} [[<in>] {area}] <detect> [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: smoke
 
       - sentences:
-          - <detect> <all> <sensor_area> {bs_smoke_states:state} [[<in>] <area>]
-          - <is> [<by>] <all> [[<in>] <area>][ ]<sensor> {bs_smoke_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - <detect> <all> <sensor_area> {bs_smoke_states:state} [[<in>] {area}]
+          - <is> [<by>] <all> [[<in>] {area}][ ]<sensor> {bs_smoke_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
           device_class: smoke
 
       - sentences:
-          - Welk[e] <sensor_area> (nemen|neemt) {bs_smoke_states:state} waar [[<in>] <area>]
-          - Welk[e] <sensor_area> <detect> {bs_smoke_states:state} [[<in>] <area>]
+          - Welk[e] <sensor_area> (nemen|neemt) {bs_smoke_states:state} waar [[<in>] {area}]
+          - Welk[e] <sensor_area> <detect> {bs_smoke_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: smoke
 
       - sentences:
-          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] <area>] {bs_smoke_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] <area>] {bs_smoke_states:state} [[<in>] <area>] waar [[<in>] <area>]
-          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] <area>] {bs_smoke_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] {area}] {bs_smoke_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] {area}] {bs_smoke_states:state} [[<in>] {area}] waar [[<in>] {area}]
+          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] {area}] {bs_smoke_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -424,11 +424,11 @@ intents:
       # sound
       - sentences:
           - "maakt <sensor_name_area> {bs_sound_states:state}"
-          - "(<is>|<detect>) [er] [[<in>]|<by>] [<area>][ ]<name> [[<in>] <area>] {bs_sound_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_sound_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_sound_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_sound_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_sound_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [[<in>]|<by>] [{area}][ ]{name} [[<in>] {area}] {bs_sound_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_sound_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_sound_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_sound_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_sound_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -439,9 +439,9 @@ intents:
 
       - sentences:
           - "maakt [er] [ergens] <sensor_area> {bs_sound_states:state}"
-          - "<is> [er] [ergens] [[<by>] <sensor_area>] {bs_sound_states:state} [[aan het maken] [[<in>] <area>]|[[<in>] <area>] [aan het maken]]"
-          - <detect> [er] [ergens]  <sensor_area> {bs_sound_states:state} [[<in>] <area>]
-          - "<is> [er] [[<in>] <area>] [ergens] [[<in>] <area>] {bs_sound_states:state} [[<in>] <area>] <detect> [[<in>] <area>]"
+          - "<is> [er] [ergens] [[<by>] <sensor_area>] {bs_sound_states:state} [[aan maken] [[<in>] {area}]|[[<in>] {area}] [aan maken]]"
+          - <detect> [er] [ergens]  <sensor_area> {bs_sound_states:state} [[<in>] {area}]
+          - "<is> [er] [[<in>] {area}] [ergens] [[<in>] {area}] {bs_sound_states:state} [[<in>] {area}] <detect> [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -449,28 +449,28 @@ intents:
 
       - sentences:
           - "(maakt|maken) <all> <sensor_area> {bs_sound_states:state}"
-          - <is> <all> <sensor_area> {bs_sound_states:state} [[aan het maken] [[<in>] <area>]|[[<in>] <area>] [aan het maken]]
-          - <detect> <all>  <sensor_area> {bs_sound_states:state} [[<in>] <area>]
-          - <is> [<by>] <all> [[<in>] <area>][ ]<sensor> {bs_sound_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - <is> <all> <sensor_area> {bs_sound_states:state} [[aan maken] [[<in>] {area}]|[[<in>] {area}] [aan maken]]
+          - <detect> <all>  <sensor_area> {bs_sound_states:state} [[<in>] {area}]
+          - <is> [<by>] <all> [[<in>] {area}][ ]<sensor> {bs_sound_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
           device_class: sound
 
       - sentences:
-          - Welk[e] <sensor_area> [is|zijn] {bs_sound_states:state} [[aan het maken] [[<in>] <area>]|[[<in>] <area>] [aan het maken]]
-          - Welk[e] <sensor_area> (nemen|neemt) {bs_sound_states:state} waar [[<in>] <area>]
-          - Welk[e] <sensor_area> <detect> {bs_sound_states:state} [[<in>] <area>]
+          - Welk[e] <sensor_area> [is|zijn] {bs_sound_states:state} [[aan maken] [[<in>] {area}]|[[<in>] {area}] [aan maken]]
+          - Welk[e] <sensor_area> (nemen|neemt) {bs_sound_states:state} waar [[<in>] {area}]
+          - Welk[e] <sensor_area> <detect> {bs_sound_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: sound
 
       - sentences:
-          - hoe[ ]veel <sensor_area> [is|zijn] [er] [[<in>] <area>] {bs_sound_states:state} [[aan het maken] [[<in>] <area>]|[[<in>] <area>] [aan het maken]]
-          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] <area>] {bs_sound_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] <area>] {bs_sound_states:state} [[<in>] <area>] waar [[<in>] <area>]
-          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] <area>] {bs_sound_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - hoe[ ]veel <sensor_area> [is|zijn] [er] [[<in>] {area}] {bs_sound_states:state} [[aan maken] [[<in>] {area}]|[[<in>] {area}] [aan maken]]
+          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] {area}] {bs_sound_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] {area}] {bs_sound_states:state} [[<in>] {area}] waar [[<in>] {area}]
+          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] {area}] {bs_sound_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -478,11 +478,11 @@ intents:
 
       # tamper
       - sentences:
-          - "(<is>|<detect>) [er] [in|op|van|bij] [<area>] [door|met|bij] <name> [[<in>] <area>] {bs_tamper_states:state} [[<in>] <area>]"
-          - "neemt <sensor_name_area> {bs_tamper_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_tamper_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_tamper_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_tamper_states:state} <detect> [[<in>] <area>]"
+          - "(<is>|<detect>) [er] [in|op|van|bij] [{area}] [door|met|bij] {name} [[<in>] {area}] {bs_tamper_states:state} [[<in>] {area}]"
+          - "neemt <sensor_name_area> {bs_tamper_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_tamper_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_tamper_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_tamper_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -492,18 +492,18 @@ intents:
           device_class: tamper
 
       - sentences:
-          - "<is> [er] [ergens] [[<by>] <sensor_area>] {bs_tamper_states:state} [[<in>] <area>]"
-          - <detect> [er] [ergens] [<by>] <sensor_area> {bs_tamper_states:state} [[<in>] <area>]
-          - "<is> [er] [[<in>] <area>] [ergens] [[<by>] <sensor_area>]  {bs_tamper_states:state} [[<in>] <area>] <detect> [[<in>] <area>]"
+          - "<is> [er] [ergens] [[<by>] <sensor_area>] {bs_tamper_states:state} [[<in>] {area}]"
+          - <detect> [er] [ergens] [<by>] <sensor_area> {bs_tamper_states:state} [[<in>] {area}]
+          - "<is> [er] [[<in>] {area}] [ergens] [[<by>] <sensor_area>]  {bs_tamper_states:state} [[<in>] {area}] <detect> [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: tamper
 
       - sentences:
-          - <is> ([<by>] <all>|<all> [<by>]) <sensor_area> {bs_tamper_states:state} [[<in>] <area>]
-          - <detect> <all>  <sensor_area> {bs_tamper_states:state} [[<in>] <area>]
-          - <is> [<by>] <all> [[<in>] <area>][ ]<sensor> {bs_tamper_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - <is> ([<by>] <all>|<all> [<by>]) <sensor_area> {bs_tamper_states:state} [[<in>] {area}]
+          - <detect> <all>  <sensor_area> {bs_tamper_states:state} [[<in>] {area}]
+          - <is> [<by>] <all> [[<in>] {area}][ ]<sensor> {bs_tamper_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
@@ -511,18 +511,18 @@ intents:
 
       - sentences:
           - Welk[e] <sensor_area> [is|zijn|wordt|worden] {bs_tamper_states:state}
-          - Welk[e] <sensor_area> (nemen|neemt) {bs_tamper_states:state} waar [[<in>] <area>]
-          - Welk[e] <sensor_area> <detect> {bs_tamper_states:state} [[<in>] <area>]
+          - Welk[e] <sensor_area> (nemen|neemt) {bs_tamper_states:state} waar [[<in>] {area}]
+          - Welk[e] <sensor_area> <detect> {bs_tamper_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: tamper
 
       - sentences:
-          - "[<by>] hoe[ ]veel <sensor_area> [is|zijn|word(t|en)] [er] [[<in>] <area>] {bs_tamper_states:state} [[<in>] <area>]"
-          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] <area>] {bs_tamper_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] <area>] {bs_tamper_states:state} [[<in>] <area>] waar [[<in>] <area>]
-          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] <area>] {bs_tamper_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - "[<by>] hoe[ ]veel <sensor_area> [is|zijn|word(t|en)] [er] [[<in>] {area}] {bs_tamper_states:state} [[<in>] {area}]"
+          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] {area}] {bs_tamper_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] {area}] {bs_tamper_states:state} [[<in>] {area}] waar [[<in>] {area}]
+          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] {area}] {bs_tamper_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -530,9 +530,9 @@ intents:
 
       # update
       - sentences:
-          - "<is> [[<in>] <area>][ ]<name> [[in|op|van] [<area>]] {bs_update_states:state} [[<in>] <area>]"
-          - "<is> [er] [[<in>] <area>] [een] {bs_update_states:state} [klaar|beschikbaar] voor <sensor_name_area>"
-          - "<is> [er] voor <sensor_name_area> [een] {bs_update_states:state} [klaar|beschikbaar] [[<in>] <area>]"
+          - "<is> [[<in>] {area}][ ]{name} [[in|op|van] [{area}]] {bs_update_states:state} [[<in>] {area}]"
+          - "<is> [er] [[<in>] {area}] [een] {bs_update_states:state} [klaar|beschikbaar] voor <sensor_name_area>"
+          - "<is> [er] voor <sensor_name_area> [een] {bs_update_states:state} [klaar|beschikbaar] [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -542,17 +542,17 @@ intents:
           device_class: update
 
       - sentences:
-          - "<is> [er] [ergens] <sensor_area> {bs_update_states:state} [[<in>] <area>]"
-          - "<is> [er] [ergens]  {bs_update_states:state} [[<in>] <area>]"
-          - "<is> [er] [[<in>] <area>] [ergens] [[<in>] <area>] {bs_update_states:state} [voor] (klaar|beschikbaar) [[<in>] <area>]"
+          - "<is> [er] [ergens] <sensor_area> {bs_update_states:state} [[<in>] {area}]"
+          - "<is> [er] [ergens]  {bs_update_states:state} [[<in>] {area}]"
+          - "<is> [er] [[<in>] {area}] [ergens] [[<in>] {area}] {bs_update_states:state} [voor] (klaar|beschikbaar) [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: update
 
       - sentences:
-          - <is> <all> <sensor_area> {bs_update_states:state} [[<in>] <area>]
-          - <is> [er] voor <all> <sensor_area> {bs_update_states:state} (klaar|beschikbaar) [[<in>] <area>]
+          - <is> <all> <sensor_area> {bs_update_states:state} [[<in>] {area}]
+          - <is> [er] voor <all> <sensor_area> {bs_update_states:state} (klaar|beschikbaar) [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
@@ -560,15 +560,15 @@ intents:
 
       - sentences:
           - Welk[e] <sensor_area> [is|zijn] {bs_update_states:state}
-          - Voor welk[e] <sensor_area> <is> {bs_update_states:state} (klaar|beschikbaar) [[<in>] <area>]
+          - Voor welk[e] <sensor_area> <is> {bs_update_states:state} (klaar|beschikbaar) [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: update
 
       - sentences:
-          - hoe[ ]veel <sensor_area> [is|zijn] [er] [[<in>] <area>] {bs_update_states:state} [[<in>] <area>]
-          - voor hoe[ ]veel <sensor_area> (staat|staan) [er] [[<in>] <area>] {bs_update_states:state} [[<in>] <area>] (klaar|beschikbaar) [[<in>] <area>]
+          - hoe[ ]veel <sensor_area> [is|zijn] [er] [[<in>] {area}] {bs_update_states:state} [[<in>] {area}]
+          - voor hoe[ ]veel <sensor_area> (staat|staan) [er] [[<in>] {area}] {bs_update_states:state} [[<in>] {area}] (klaar|beschikbaar) [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -577,11 +577,11 @@ intents:
       # vibration
       - sentences:
           - "{bs_vibration_states:state} <sensor_name_area>"
-          - "(is|<detect>) [er] <sensor_name_area> {bs_vibration_states:state} [[<in>] <area>]"
-          - "neemt [<area>][ ]<name> [[<in>] <area>] {bs_vibration_states:state} (waar [[<in>] <area>]|[[<in>] <area>] waar)"
-          - "<is> [er] [[<in>] <area>] {bs_vibration_states:state} <detect> <sensor_name_area>"
-          - "<is> [er] [[<in>] <area>] {bs_vibration_states:state} <by> [<area>][ ]<name> <detect> [[<in>] <area>]"
-          - "<is> [er] <sensor_name_area> {bs_vibration_states:state} <detect> [[<in>] <area>]"
+          - "(is|<detect>) [er] <sensor_name_area> {bs_vibration_states:state} [[<in>] {area}]"
+          - "neemt [{area}][ ]{name} [[<in>] {area}] {bs_vibration_states:state} (waar [[<in>] {area}]|[[<in>] {area}] waar)"
+          - "<is> [er] [[<in>] {area}] {bs_vibration_states:state} <detect> <sensor_name_area>"
+          - "<is> [er] [[<in>] {area}] {bs_vibration_states:state} <by> [{area}][ ]{name} <detect> [[<in>] {area}]"
+          - "<is> [er] <sensor_name_area> {bs_vibration_states:state} <detect> [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -592,9 +592,9 @@ intents:
 
       - sentences:
           - "{bs_vibration_states:state} [er] [ergens] <sensor_area>"
-          - "<is> [er] [ergens] <sensor_area> {bs_vibration_states:state} [[<in>] <area>]"
-          - <detect> [er] [ergens]  <sensor_area> {bs_vibration_states:state} [[<in>] <area>]
-          - "<is> [er] [[<in>] <area>] [ergens] [[<in>] <area>] {bs_vibration_states:state} [[<in>] <area>] <detect> [[<in>] <area>]"
+          - "<is> [er] [ergens] <sensor_area> {bs_vibration_states:state} [[<in>] {area}]"
+          - <detect> [er] [ergens]  <sensor_area> {bs_vibration_states:state} [[<in>] {area}]
+          - "<is> [er] [[<in>] {area}] [ergens] [[<in>] {area}] {bs_vibration_states:state} [[<in>] {area}] <detect> [[<in>] {area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -602,9 +602,9 @@ intents:
 
       - sentences:
           - "{bs_vibration_states:state} <all> <sensor_area>"
-          - <is> <all> <sensor_area> {bs_vibration_states:state} [[<in>] <area>]
-          - <detect> <all>  <sensor_area> {bs_vibration_states:state} [[<in>] <area>]
-          - <is> [<by>] <all> [[<in>] <area>][ ]<sensor> {bs_vibration_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - <is> <all> <sensor_area> {bs_vibration_states:state} [[<in>] {area}]
+          - <detect> <all>  <sensor_area> {bs_vibration_states:state} [[<in>] {area}]
+          - <is> [<by>] <all> [[<in>] {area}][ ]<sensor> {bs_vibration_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: all
         slots:
           domain: binary_sensor
@@ -612,18 +612,18 @@ intents:
 
       - sentences:
           - Welk[e] <sensor_area> [is|zijn] {bs_vibration_states:state}
-          - Welk[e] <sensor_area> (nemen|neemt) {bs_vibration_states:state} waar [[<in>] <area>]
-          - Welk[e] <sensor_area> <detect> {bs_vibration_states:state} [[<in>] <area>]
+          - Welk[e] <sensor_area> (nemen|neemt) {bs_vibration_states:state} waar [[<in>] {area}]
+          - Welk[e] <sensor_area> <detect> {bs_vibration_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: binary_sensor
           device_class: vibration
 
       - sentences:
-          - hoe[ ]veel <sensor_area> [is|zijn] [er] [[<in>] <area>] {bs_vibration_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] <area>] {bs_vibration_states:state} [[<in>] <area>]
-          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] <area>] {bs_vibration_states:state} [[<in>] <area>] waar [[<in>] <area>]
-          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] <area>] {bs_vibration_states:state} [[<in>] <area>] <detect> [[<in>] <area>]
+          - hoe[ ]veel <sensor_area> [is|zijn] [er] [[<in>] {area}] {bs_vibration_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> <detect> [er] [[<in>] {area}] {bs_vibration_states:state} [[<in>] {area}]
+          - hoe[ ]veel <sensor_area> nemen [er] [[<in>] {area}] {bs_vibration_states:state} [[<in>] {area}] waar [[<in>] {area}]
+          - <by> hoe[ ]veel <sensor_area> word(t|en) [er] [[<in>] {area}] {bs_vibration_states:state} [[<in>] {area}] <detect> [[<in>] {area}]
         response: how_many
         slots:
           domain: binary_sensor
@@ -631,7 +631,7 @@ intents:
 
       # window|no any/all/which/how_many sentences because of conflicts with domain: cover / device_class: window
       - sentences:
-          - "<is> <sensor_name_area> {bs_window_states:state} [[<in>] <area>]"
+          - "<is> <sensor_name_area> {bs_window_states:state} [[<in>] {area}]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor

--- a/sentences/nl/climate_HassClimateGetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateGetTemperature.yaml
@@ -3,12 +3,12 @@ intents:
   HassClimateGetTemperature:
     data:
       - sentences:
-          - "Wat is [de] [huidige] temperatuur [<in>] <area>"
-          - "Hoe <warm> is het [<in>] <area>"
-          - "Wat is de <area>[ ]temperatuur"
+          - "Wat is [huidige] temperatuur [<in>] {area}"
+          - "Hoe <warm> is [<in>] {area}"
+          - "Wat is {area}[ ]temperatuur"
       - sentences:
-          - "Wat is [de] [huidige] <name>[ ]temperatuur"
-          - "Wat is [de] [huidige] temperatuur [van|in] [de] <name>"
-          - "(hoe [hoog|laag|<warm>]|op hoeveel graden) (is|staat)  [de] <name> [ingesteld]"
+          - "Wat is [huidige] {name}[ ]temperatuur"
+          - "Wat is [huidige] temperatuur [van|in] {name}"
+          - "(hoe [hoog|laag|<warm>]|op hoeveel graden) (is|staat) {name} [ingesteld]"
         requires_context:
           domain: "climate"

--- a/sentences/nl/climate_HassClimateSetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateSetTemperature.yaml
@@ -3,8 +3,8 @@ intents:
   HassClimateSetTemperature:
     data:
       - sentences:
-          - "<numeric_value_set> [de] temperatuur [[<in>] <area>] <to> <temperature> [graden]"
-          - "<numeric_value_set> [de] temperatuur <to> <temperature> [graden] [[<in>] <area>]"
-          - "<numeric_value_set> [de] <area>[ ]temperatuur <to> <temperature> [graden]"
-          - "(<area>|temperatuur [<to>]) <temperature> graden [(zetten|draaien|doen)]"
-          - "[<would>] (<area>|[<area>[ ]|de ]temperatuur|temperatuur <in> <area>) [<to>] <temperature> graden (zetten|draaien|doen)"
+          - "<numeric_value_set> temperatuur [[<in>] {area}] <to> <temperature> [graden]"
+          - "<numeric_value_set> temperatuur <to> <temperature> [graden] [[<in>] {area}]"
+          - "<numeric_value_set> {area}[ ]temperatuur <to> <temperature> [graden]"
+          - "({area}|temperatuur [<to>]) <temperature> graden [(zetten|draaien|doen)]"
+          - "[<would>] ({area}|[{area}[ ]|de ]temperatuur|temperatuur <in> {area}) [<to>] <temperature> graden (zetten|draaien|doen)"

--- a/sentences/nl/cover_HassGetState.yaml
+++ b/sentences/nl/cover_HassGetState.yaml
@@ -3,9 +3,9 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<is> [er] <name>[[ ]<cover>] {cover_states:state} [[<in>] (<area>|<floor>)]"
-          - "<is> [er] ([<in>] (<area>|<floor>)[ ];<name>[[ ]<cover>]) {cover_states:state}"
-          - "<is> <name>[[ ]<cover>] {cover_states:state} [[<in>] (<area>|<floor>)] "
+          - "<is> [er] {name}[[ ]<cover>] {cover_states:state} [[<in>] ({area}|{floor})]"
+          - "<is> [er] ([<in>] ({area}|{floor})[ ];{name}[[ ]<cover>]) {cover_states:state}"
+          - "<is> {name}[[ ]<cover>] {cover_states:state} [[<in>] ({area}|{floor})] "
         response: one_yesno
         requires_context:
           domain: cover
@@ -13,30 +13,30 @@ intents:
           domain: cover
 
       - sentences:
-          - "<is> [er] [[<in>] <area>|<floor>|ergens|nog] [een] {cover_classes:device_class} {cover_states:state}"
-          - "<is> [er] [ergens|nog] [een] {cover_classes:device_class} ([<in>] <area>;{cover_states:state})"
-          - "<is> [er] {cover_classes:device_class} ({cover_states:state};[<in>] (<area>|<floor>))"
+          - "<is> [er] [[<in>] {area}|{floor}|ergens|nog] [een] {cover_classes:device_class} {cover_states:state}"
+          - "<is> [er] [ergens|nog] [een] {cover_classes:device_class} ([<in>] {area};{cover_states:state})"
+          - "<is> [er] {cover_classes:device_class} ({cover_states:state};[<in>] ({area}|{floor}))"
         response: any
         slots:
           domain: cover
 
       - sentences:
-          - "<is> [[<in>] (<area>|<floor>)] [<all>|de] {cover_classes:device_class} {cover_states:state}"
-          - "<is> [<all>|de] {cover_classes:device_class} ([<in>] (<area>|<floor>);{cover_states:state})"
+          - "<is> [[<in>] ({area}|{floor})] [<all>|de] {cover_classes:device_class} {cover_states:state}"
+          - "<is> [<all>|de] {cover_classes:device_class} ([<in>] ({area}|{floor});{cover_states:state})"
         response: all
         slots:
           domain: cover
 
       - sentences:
           - "Welk[e] {cover_classes:device_class} <is> {cover_states:state}"
-          - "Welk[e] {cover_classes:device_class} ([[<in>] (<area>|<floor>)];<is> {cover_states:state})"
+          - "Welk[e] {cover_classes:device_class} ([[<in>] ({area}|{floor})];<is> {cover_states:state})"
         response: which
         slots:
           domain: cover
 
       - sentences:
-          - "Hoe[ ]veel {cover_classes:device_class} [[<in>] (<area>|<floor>)] <is> [er]  {cover_states:state}"
-          - "Hoe[ ]veel {cover_classes:device_class} <is> [er] ([<in>] (<area>|<floor>);{cover_states:state})"
+          - "Hoe[ ]veel {cover_classes:device_class} [[<in>] ({area}|{floor})] <is> [er]  {cover_states:state}"
+          - "Hoe[ ]veel {cover_classes:device_class} <is> [er] ([<in>] ({area}|{floor});{cover_states:state})"
         response: how_many
         slots:
           domain: cover

--- a/sentences/nl/cover_HassSetPosition.yaml
+++ b/sentences/nl/cover_HassSetPosition.yaml
@@ -3,29 +3,29 @@ intents:
   HassSetPosition:
     data:
       - sentences:
-          - "[<numeric_value_set>|open|sluit] <name>[[ ]<cover>][[ ](positie|stand)] [<to>] <position>"
-          - "[<numeric_value_set>|open|sluit] [de] (positie|stand) [van] <name>[[ ]<cover>] [<to>] <position>"
-          - "[<change>] <name>[[ ]<cover>][[ ](positie|stand)] ([<to>] <position>;(omhoog|omlaag))"
-          - "[<change>] [de] (positie|stand) [van] <name>[[ ]<cover>] ([<to>] <position>;(omhoog|omlaag))"
-          - "[<would> <name>][[ ](positie|stand)] [<to>] <position> (zetten|doen|verhogen|verlagen)"
-          - "[<would>] [de] (positie|stand) [van] <name> [<to>] <position> (zetten|doen|verhogen|verlagen)"
+          - "[<numeric_value_set>|open|sluit] {name}[[ ]<cover>][[ ](positie|stand)] [<to>] <position>"
+          - "[<numeric_value_set>|open|sluit] (positie|stand) [van] {name}[[ ]<cover>] [<to>] <position>"
+          - "[<change>] {name}[[ ]<cover>][[ ](positie|stand)] ([<to>] <position>;(omhoog|omlaag))"
+          - "[<change>] (positie|stand) [van] {name}[[ ]<cover>] ([<to>] <position>;(omhoog|omlaag))"
+          - "[<would> {name}][[ ](positie|stand)] [<to>] <position> (zetten|doen|verhogen|verlagen)"
+          - "[<would>] (positie|stand) [van] {name} [<to>] <position> (zetten|doen|verhogen|verlagen)"
         requires_context:
           domain: cover
         slots:
           domain: cover
 
       - sentences:
-          - "(<numeric_value_set>|open|sluit) [de|het] {cover_classes:device_class}[[ ](positie|stand)] (<to> <position>;[<in>] <area>)"
-          - "(<numeric_value_set>|open|sluit) [de] (positie|stand) [van] [de|het] {cover_classes:device_class} (<to> <position>;[<in>] <area>)"
-          - "(<numeric_value_set>|open|sluit) <area>[ ]{cover_classes:device_class}[[ ](positie|stand)] <to> <position>"
-          - "(<numeric_value_set>|open|sluit) [de] (positie|stand) [van] <area>[ ]{cover_classes:device_class} <to> <position>"
-          - "[<change>] <area>[ ]{cover_classes:device_class}[[ ](positie|stand)] ([<to>] <position>;(omhoog|omlaag))"
-          - "[<change>] [de] (positie|stand) [van] [de|het] <area>[ ]{cover_classes:device_class} ([<to>] <position>;(omhoog|omlaag))"
-          - "[<change>] ([<in>] <area>;[de|het] {cover_classes:device_class}[[ ](positie|stand)]) ([<to>] <position>;(omhoog|omlaag))"
-          - "[<change>] ([<in>] <area>;[de] (positie|stand) [van] [de|het] {cover_classes:device_class}) ([<to>] <position>;(omhoog|omlaag))"
-          - "[<would>] <area>[ ]{cover_classes:device_class}[[ ](positie|stand)] [<to>] <position> (zetten|doen|verhogen|verlagen)"
-          - "[<would>] [de] (positie|stand) [van] [de|het] <area>[ ]{cover_classes:device_class} [<to>] <position> (zetten|doen|verhogen|verlagen)"
-          - "[<would>] ([<in>] <area>;[de|het] {cover_classes:device_class}[[ ](positie|stand)]) [<to>] <position> (zetten|doen|verhogen|verlagen)"
-          - "[<would>] ([<in>] <area>;[de] (positie|stand) [van] [de|het] {cover_classes:device_class}) [<to>] <position> (zetten|doen|verhogen|verlagen)"
+          - "(<numeric_value_set>|open|sluit) [de|het] {cover_classes:device_class}[[ ](positie|stand)] (<to> <position>;[<in>] {area})"
+          - "(<numeric_value_set>|open|sluit) (positie|stand) [van] [de|het] {cover_classes:device_class} (<to> <position>;[<in>] {area})"
+          - "(<numeric_value_set>|open|sluit) {area}[ ]{cover_classes:device_class}[[ ](positie|stand)] <to> <position>"
+          - "(<numeric_value_set>|open|sluit) (positie|stand) [van] {area}[ ]{cover_classes:device_class} <to> <position>"
+          - "[<change>] {area}[ ]{cover_classes:device_class}[[ ](positie|stand)] ([<to>] <position>;(omhoog|omlaag))"
+          - "[<change>] (positie|stand) [van] [de|het] {area}[ ]{cover_classes:device_class} ([<to>] <position>;(omhoog|omlaag))"
+          - "[<change>] ([<in>] {area};[de|het] {cover_classes:device_class}[[ ](positie|stand)]) ([<to>] <position>;(omhoog|omlaag))"
+          - "[<change>] ([<in>] {area};(positie|stand) [van] [de|het] {cover_classes:device_class}) ([<to>] <position>;(omhoog|omlaag))"
+          - "[<would>] {area}[ ]{cover_classes:device_class}[[ ](positie|stand)] [<to>] <position> (zetten|doen|verhogen|verlagen)"
+          - "[<would>] (positie|stand) [van] [de|het] {area}[ ]{cover_classes:device_class} [<to>] <position> (zetten|doen|verhogen|verlagen)"
+          - "[<would>] ([<in>] {area};[de|het] {cover_classes:device_class}[[ ](positie|stand)]) [<to>] <position> (zetten|doen|verhogen|verlagen)"
+          - "[<would>] ([<in>] {area};(positie|stand) [van] [de|het] {cover_classes:device_class}) [<to>] <position> (zetten|doen|verhogen|verlagen)"
         slots:
           domain: cover

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -3,27 +3,27 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "sluit <name>[[ ]<cover>]"
-          - "[<would>] <name>[[ ]<cover>] (sluiten|dicht doen)"
-          - "[<change>] <name>[[ ]<cover>] <closed>"
+          - "sluit {name}[[ ]<cover>]"
+          - "[<would>] {name}[[ ]<cover>] (sluiten|dicht doen)"
+          - "[<change>] {name}[[ ]<cover>] <closed>"
         response: "cover"
         requires_context:
           domain: cover
 
       - sentences:
-          - "sluit [de] garage[ ][deur]"
-          - "[<would>] [de] garage[ ][deur] (sluiten|dicht doen)"
-          - "[<change>] [de] garage[ ][deur] <closed>"
+          - "sluit garage[ ][deur]"
+          - "[<would>] garage[ ][deur] (sluiten|dicht doen)"
+          - "[<change>] garage[ ][deur] <closed>"
         response: "cover"
         slots:
           device_class: "garage"
           domain: "cover"
 
       - sentences:
-          - "sluit (<name>[[ ]<cover>];[<in>] (<area>|<floor>))"
-          - "[<would>] (<name>[[ ]<cover>];[<in>] (<area>|<floor>)) (sluiten|dicht doen)"
-          - "[<change>] [<in>] (<area>|<floor>) <name>[[ ]<cover>] <closed>"
-          - "[<change>] <name>[[ ]<cover>] (<closed>;[<in>] (<area>|<floor>))"
+          - "sluit ({name}[[ ]<cover>];[<in>] ({area}|{floor}))"
+          - "[<would>] ({name}[[ ]<cover>];[<in>] ({area}|{floor})) (sluiten|dicht doen)"
+          - "[<change>] [<in>] ({area}|{floor}) {name}[[ ]<cover>] <closed>"
+          - "[<change>] {name}[[ ]<cover>] (<closed>;[<in>] ({area}|{floor}))"
         response: "cover"
         requires_context:
           device_class:
@@ -34,22 +34,22 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "sluit ([de|het] <curtain>;[<in>] (<area>|<floor>))"
-          - "[<would>] ([de|het] <curtain>;[<in>] (<area>|<floor>)) (sluiten|dicht doen)"
-          - "[<would>] (<area>|<floor>)[ ]<curtain> (sluiten|dicht doen)"
-          - "[<change>] [<in>] (<area>|<floor>) [de|het] <curtain> <closed>"
-          - "[<change>] [de|het] <curtain> (<closed>;[<in>] (<area>|<floor>))"
+          - "sluit ([de|het] <curtain>;[<in>] ({area}|{floor}))"
+          - "[<would>] ([de|het] <curtain>;[<in>] ({area}|{floor})) (sluiten|dicht doen)"
+          - "[<would>] ({area}|{floor})[ ]<curtain> (sluiten|dicht doen)"
+          - "[<change>] [<in>] ({area}|{floor}) [de|het] <curtain> <closed>"
+          - "[<change>] [de|het] <curtain> (<closed>;[<in>] ({area}|{floor}))"
         response: "cover"
         slots:
           device_class: "curtain"
           domain: "cover"
 
       - sentences:
-          - "sluit [de|het] (<blind>|<shutter>|<shade>) [<in>] (<area>|<floor>)"
-          - "[<would>] ([de|het] (<blind>|<shutter>|<shade>);[<in>] (<area>|<floor>)) (sluiten|dicht doen)"
-          - "[<would>] (<area>|<floor>)[ ](<blind>|<shutter>|<shade>) (sluiten|dicht doen)"
-          - "[<change>] [<in>] (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <closed>"
-          - "[<change>] [de|het] (<blind>|<shutter>|<shade>) (<closed>;[<in>] (<area>|<floor>))"
+          - "sluit [de|het] (<blind>|<shutter>|<shade>) [<in>] ({area}|{floor})"
+          - "[<would>] ([de|het] (<blind>|<shutter>|<shade>);[<in>] ({area}|{floor})) (sluiten|dicht doen)"
+          - "[<would>] ({area}|{floor})[ ](<blind>|<shutter>|<shade>) (sluiten|dicht doen)"
+          - "[<change>] [<in>] ({area}|{floor}) [de|het] (<blind>|<shutter>|<shade>) <closed>"
+          - "[<change>] [de|het] (<blind>|<shutter>|<shade>) (<closed>;[<in>] ({area}|{floor}))"
         response: "cover"
         slots:
           device_class:

--- a/sentences/nl/cover_HassTurnOn.yaml
+++ b/sentences/nl/cover_HassTurnOn.yaml
@@ -3,27 +3,27 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "open <name>[[ ]<cover>]"
-          - "[<would>] <name>[[ ]<cover>] (openen|open doen)"
-          - "[<change>] <name>[[ ]<cover>] <open>"
+          - "open {name}[[ ]<cover>]"
+          - "[<would>] {name}[[ ]<cover>] (openen|open doen)"
+          - "[<change>] {name}[[ ]<cover>] <open>"
         response: "cover"
         requires_context:
           domain: cover
 
       - sentences:
-          - "open [de] garage[ ][deur]"
-          - "[<would>] [de] garage[ ][deur] (openen|open doen)"
-          - "[<change>] [de] garage[ ][deur] <open>"
+          - "open garage[ ][deur]"
+          - "[<would>] garage[ ][deur] (openen|open doen)"
+          - "[<change>] garage[ ][deur] <open>"
         response: "cover"
         slots:
           device_class: "garage"
           domain: "cover"
 
       - sentences:
-          - "open (<name>[[ ]<cover>];[<in>] (<area>|<floor>))"
-          - "[<would>] (<name>[[ ]<cover>];[<in>] (<area>|<floor>)) (openen|open doen)"
-          - "[<change>] [<in>] (<area>|<floor>) <name>[[ ]<cover>] <open>"
-          - "[<change>] <name>[[ ]<cover>] (<open>;[<in>] (<area>|<floor>))"
+          - "open ({name}[[ ]<cover>];[<in>] ({area}|{floor}))"
+          - "[<would>] ({name}[[ ]<cover>];[<in>] ({area}|{floor})) (openen|open doen)"
+          - "[<change>] [<in>] ({area}|{floor}) {name}[[ ]<cover>] <open>"
+          - "[<change>] {name}[[ ]<cover>] (<open>;[<in>] ({area}|{floor}))"
         response: "cover"
         requires_context:
           device_class:
@@ -34,20 +34,20 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "open ([de|het] <curtain>;[<in>] (<area>|<floor>))"
-          - "[<would>] ([de|het] <curtain>;[<in>] (<area>|<floor>)) (openen|open doen)"
-          - "[<change>] [<in>] (<area>|<floor>) [de|het] <curtain> <open>"
-          - "[<change>] [de|het] <curtain> (<open>;[<in>] (<area>|<floor>))"
+          - "open ([de|het] <curtain>;[<in>] ({area}|{floor}))"
+          - "[<would>] ([de|het] <curtain>;[<in>] ({area}|{floor})) (openen|open doen)"
+          - "[<change>] [<in>] ({area}|{floor}) [de|het] <curtain> <open>"
+          - "[<change>] [de|het] <curtain> (<open>;[<in>] ({area}|{floor}))"
         response: "cover"
         slots:
           device_class: "curtain"
           domain: "cover"
 
       - sentences:
-          - "open [de|het] (<blind>|<shutter>|<shade>) [<in>] (<area>|<floor>)"
-          - "[<would>] ([de|het] (<blind>|<shutter>|<shade>);[<in>] (<area>|<floor>)) (openen|open doen)"
-          - "[<change>] [<in>] (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <open>"
-          - "[<change>] [de|het] (<blind>|<shutter>|<shade>) (<open>;[<in>] (<area>|<floor>))"
+          - "open [de|het] (<blind>|<shutter>|<shade>) [<in>] ({area}|{floor})"
+          - "[<would>] ([de|het] (<blind>|<shutter>|<shade>);[<in>] ({area}|{floor})) (openen|open doen)"
+          - "[<change>] [<in>] ({area}|{floor}) [de|het] (<blind>|<shutter>|<shade>) <open>"
+          - "[<change>] [de|het] (<blind>|<shutter>|<shade>) (<open>;[<in>] ({area}|{floor}))"
         response: "cover"
         slots:
           device_class:

--- a/sentences/nl/fan_HassTurnOff.yaml
+++ b/sentences/nl/fan_HassTurnOff.yaml
@@ -3,12 +3,12 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<change>] [<all>] <fan> ([<to>] uit;[<in>] (<area>|<floor>))"
-          - "[<change>] [<all>] <fan> ([<in>] (<area>|<floor>);[<to>] uit)"
-          - "[<change>] [(<all>|<in>)] (<area>|<floor>)[ ]<fan> [<to>] uit"
-          - "[<would>] [<all>] (<area>|<floor>)[ ]<fan> (uit[ ](zetten|doen)|uitschakelen)"
-          - "[<would>] ([<in>] (<area>|<floor>);[<all>] <fan>) (uit[ ](zetten|doen)|uitschakelen)"
-          - "[<would>] [<all>] <fan> [<in>] (<area>|<floor>) (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<change>] [<all>] <fan> ([<to>] uit;[<in>] ({area}|{floor}))"
+          - "[<change>] [<all>] <fan> ([<in>] ({area}|{floor});[<to>] uit)"
+          - "[<change>] [(<all>|<in>)] ({area}|{floor})[ ]<fan> [<to>] uit"
+          - "[<would>] [<all>] ({area}|{floor})[ ]<fan> (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<would>] ([<in>] ({area}|{floor});[<all>] <fan>) (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<would>] [<all>] <fan> [<in>] ({area}|{floor}) (uit[ ](zetten|doen)|uitschakelen)"
         response: fans_area
         slots:
           domain: "fan"

--- a/sentences/nl/fan_HassTurnOn.yaml
+++ b/sentences/nl/fan_HassTurnOn.yaml
@@ -3,15 +3,15 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<change>] [<all>] <fan> ([<to>] aan;[<in>] (<area>|<floor>))"
-          - "Schakel [<all>] <fan> ([<to>] in;[<in>] (<area>|<floor>))"
-          - "[<change>] [<all>] <fan> ([<in>] (<area>|<floor>);[<to>] aan)"
-          - "Schakel [<all>] <fan> ([<in>] (<area>|<floor>);[<to>] in)"
-          - "[<change>] [(<all>|[<in>])] (<area>|<floor>)[ ]<fan> [<to>] aan"
-          - "Schakel [(<all>|[<in>])] (<area>|<floor>)[ ]<fan> [<to>] in"
-          - "[<would>] [<all>] (<area>|<floor>)[ ]<fan> (aan[ ](zetten|doen)|inschakelen)"
-          - "[<would>] ([<in>] (<area>|<floor>);[<all>] <fan>) (aan[ ](zetten|doen)|inschakelen)"
-          - "[<would>] [<all>] <fan> [<in>] (<area>|<floor>) (aan[ ](zetten|doen)|inschakelen)"
+          - "[<change>] [<all>] <fan> ([<to>] aan;[<in>] ({area}|{floor}))"
+          - "Schakel [<all>] <fan> ([<to>] in;[<in>] ({area}|{floor}))"
+          - "[<change>] [<all>] <fan> ([<in>] ({area}|{floor});[<to>] aan)"
+          - "Schakel [<all>] <fan> ([<in>] ({area}|{floor});[<to>] in)"
+          - "[<change>] [(<all>|[<in>])] ({area}|{floor})[ ]<fan> [<to>] aan"
+          - "Schakel [(<all>|[<in>])] ({area}|{floor})[ ]<fan> [<to>] in"
+          - "[<would>] [<all>] ({area}|{floor})[ ]<fan> (aan[ ](zetten|doen)|inschakelen)"
+          - "[<would>] ([<in>] ({area}|{floor});[<all>] <fan>) (aan[ ](zetten|doen)|inschakelen)"
+          - "[<would>] [<all>] <fan> [<in>] ({area}|{floor}) (aan[ ](zetten|doen)|inschakelen)"
         response: fans_area
         slots:
           domain: "fan"

--- a/sentences/nl/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/nl/homeassistant_HassDecreaseTimer.yaml
@@ -5,11 +5,9 @@ intents:
     data:
       - sentences:
           - "haal <timer_duration> (af;van <my_timer>)"
-          - "haal [<in>] <area> <timer_duration> (af;van <my_timer>)"
+          - "haal [<in>] {area} <timer_duration> (af;van <my_timer>)"
           - "[<would>] <timer_duration> (afhalen;van <my_timer>)"
-          - "[<would>] [<in>] <area> <timer_duration> (afhalen;van [<my>] timer)"
+          - "[<would>] [<in>] {area} <timer_duration> (afhalen;van [<my>] timer)"
           - "verkort (<my_timer>|<area_timer>) met <timer_duration>"
           - "kort (<my_timer>|<area_timer>) in met <timer_duration>"
           - "[<would>] (<my_timer>|<area_timer>) met <timer_duration> (verkorten|inkorten)"
-        expansion_rules:
-          my: (de|mijn|m'n)

--- a/sentences/nl/homeassistant_HassGetCurrentDate.yaml
+++ b/sentences/nl/homeassistant_HassGetCurrentDate.yaml
@@ -3,6 +3,6 @@ intents:
   HassGetCurrentDate:
     data:
       - sentences:
-          - "welke (dag|datum) is het [vandaag|nu]"
-          - "wat is de [huidige] (dag|datum)"
-          - "(vertel me|geef me) de [huidige] (datum|dag)"
+          - "welke (dag|datum) is [vandaag|nu]"
+          - "wat is [huidige] (dag|datum)"
+          - "(vertel me|geef me) [huidige] (datum|dag)"

--- a/sentences/nl/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/nl/homeassistant_HassGetCurrentTime.yaml
@@ -3,8 +3,8 @@ intents:
   HassGetCurrentTime:
     data:
       - sentences:
-          - "hoe laat is het [nu]"
+          - "hoe laat is [nu]"
           - "hoe laat leven we [nu]"
-          - "wat is de [huidige] tijd"
-          - "wat is (de tijd;nu)"
-          - "(vertel me|geef me) de [huidige] tijd"
+          - "wat is [huidige] tijd"
+          - "wat is (tijd;nu)"
+          - "(vertel me|geef me) [huidige] tijd"

--- a/sentences/nl/homeassistant_HassGetState.yaml
+++ b/sentences/nl/homeassistant_HassGetState.yaml
@@ -3,23 +3,23 @@ intents:
   HassGetState:
     data:
       - sentences: &one_sentences
-          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name_type>[ ][<state>]
-          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name_type>[ ][<state>])
-          - "[de] [huidige] <state> [van] [<area>][ ]<name_type>"
-          - "([<in>] <area>;[de] [huidige] <state> [van] <name_type>)"
-          - "[<area>[ ]]<name_type>[ ]<state>"
-          - "([<in>] <area>;<name_type>[ ]<state>)"
+          - Wat is [[huidige] <state> [van]] [{area}[ ]]<name_type>[ ][<state>]
+          - Wat is ([<in>] {area};[[huidige] <state> [van]] <name_type>[ ][<state>])
+          - "[huidige] <state> [van] [{area}][ ]<name_type>"
+          - "([<in>] {area};[huidige] <state> [van] <name_type>)"
+          - "[{area}[ ]]<name_type>[ ]<state>"
+          - "([<in>] {area};<name_type>[ ]<state>)"
         expansion_rules:
-          name_type: <name>
+          name_type: "{name}"
         response: one
 
       - sentences: &one_yesno_sentences
-          - <is> [[de] huidige] <name_type>[[ ]<state>] [op] {on_off_states:state} [[<in>] <area>]
-          - <is> [[de] huidige] <state> [van] <name_type> [op] {on_off_states:state} [[<in>] <area>]
-          - <is> ([<in>] <area>;[[de] huidige] <name_type>[[ ]<state>]) [op] {on_off_states:state}
-          - <is> ([<in>] <area>;[[de] huidige] <state> [van] <name_type>) [op] {on_off_states:state}
+          - <is> [huidige] <name_type>[[ ]<state>] [op] {on_off_states:state} [[<in>] {area}]
+          - <is> [huidige] <state> [van] <name_type> [op] {on_off_states:state} [[<in>] {area}]
+          - <is> ([<in>] {area};[huidige] <name_type>[[ ]<state>]) [op] {on_off_states:state}
+          - <is> ([<in>] {area};[huidige] <state> [van] <name_type>) [op] {on_off_states:state}
         expansion_rules:
-          name_type: <name>
+          name_type: "{name}"
         response: one_yesno
         excludes_context:
           domain:
@@ -27,7 +27,7 @@ intents:
 
       - sentences: *one_sentences
         expansion_rules:
-          name_type: <name>[ ]<light>
+          name_type: "{name}[ ]<light>"
         response: one
         requires_context:
           domain:
@@ -35,7 +35,7 @@ intents:
 
       - sentences: *one_yesno_sentences
         expansion_rules:
-          name_type: <name>[ ]<light>
+          name_type: "{name}[ ]<light>"
         response: one_yesno
         requires_context:
           domain:
@@ -43,7 +43,7 @@ intents:
 
       - sentences: *one_sentences
         expansion_rules:
-          name_type: <name>[ ]<switch>
+          name_type: "{name}[ ]<switch>"
         response: one
         requires_context:
           domain:
@@ -51,7 +51,7 @@ intents:
 
       - sentences: *one_yesno_sentences
         expansion_rules:
-          name_type: <name>[ ]<switch>
+          name_type: "{name}[ ]<switch>"
         response: one_yesno
         requires_context:
           domain:
@@ -59,7 +59,7 @@ intents:
 
       - sentences: *one_sentences
         expansion_rules:
-          name_type: <name>[ ]<fan>
+          name_type: "{name}[ ]<fan>"
         response: one
         requires_context:
           domain:
@@ -67,29 +67,29 @@ intents:
 
       - sentences: *one_yesno_sentences
         expansion_rules:
-          name_type: <name>[ ]<fan>
+          name_type: "{name}[ ]<fan>"
         response: one_yesno
         requires_context:
           domain:
             - fan
 
       - sentences:
-          - <is> er {on_off_domains:domain} {on_off_states:state} [[<in>] <area>]
-          - <is> er ({on_off_domains:domain};[<in>] <area>) {on_off_states:state}
+          - <is> er {on_off_domains:domain} {on_off_states:state} [[<in>] {area}]
+          - <is> er ({on_off_domains:domain};[<in>] {area}) {on_off_states:state}
         response: any
 
       - sentences:
-          - <is> [<all>] [de] {on_off_domains:domain} {on_off_states:state}
-          - <is> [<all>] [de] {on_off_domains:domain} ([<in>] <area>;{on_off_states:state})
-          - <is> ([<in>] <area>;[<all>] [de] {on_off_domains:domain}) {on_off_states:state}
+          - <is> [<all>] {on_off_domains:domain} {on_off_states:state}
+          - <is> [<all>] {on_off_domains:domain} ([<in>] {area};{on_off_states:state})
+          - <is> ([<in>] {area};[<all>] {on_off_domains:domain}) {on_off_states:state}
         response: all
 
       - sentences:
-          - Welk[e] {on_off_domains:domain} <is> [[<in>] <area>] {on_off_states:state}
-          - Welk[e] {on_off_domains:domain} ([<in>] <area>;<is> {on_off_states:state})
+          - Welk[e] {on_off_domains:domain} <is> [[<in>] {area}] {on_off_states:state}
+          - Welk[e] {on_off_domains:domain} ([<in>] {area};<is> {on_off_states:state})
         response: which
 
       - sentences:
           - Hoe[ ]veel {on_off_domains:domain} <is> [er] {on_off_states:state}
-          - Hoe[ ]veel {on_off_domains:domain} <is> [er] ([<in>] <area>;{on_off_states:state})
+          - Hoe[ ]veel {on_off_domains:domain} <is> [er] ([<in>] {area};{on_off_states:state})
         response: how_many

--- a/sentences/nl/homeassistant_HassIncreaseTimer.yaml
+++ b/sentences/nl/homeassistant_HassIncreaseTimer.yaml
@@ -5,11 +5,9 @@ intents:
     data:
       - sentences:
           - "voeg <timer_duration> (toe;aan <my_timer>)"
-          - "voeg [<in>] <area> <timer_duration> (toe;aan [<my>] timer)"
+          - "voeg [<in>] {area} <timer_duration> (toe;aan [<my>] timer)"
           - "[<would>] <timer_duration> (toevoegen;aan <my_timer>)"
-          - "[<would>] [<in>] <area> <timer_duration> (toevoegen;aan [<my>] timer)"
+          - "[<would>] [<in>] {area} <timer_duration> (toevoegen;aan [<my>] timer)"
           - "verleng (<my_timer>|<area_timer>) met <timer_duration>"
           - "[<would>] aan (<my_timer>|<area_timer>) <timer_duration> toevoegen"
           - "[<would>] (<my_timer>|<area_timer>) met <timer_duration> verlengen"
-        expansion_rules:
-          my: (de|mijn|m'n)

--- a/sentences/nl/homeassistant_HassRespond.yaml
+++ b/sentences/nl/homeassistant_HassRespond.yaml
@@ -7,14 +7,14 @@ intents:
         response: hello
 
       - sentences:
-          - "ben je altijd aan het (luisteren|opnemen)"
+          - "ben je altijd aan (luisteren|opnemen)"
           - "luister je altijd"
           - "neem je altijd op"
         response: listening
 
       - sentences:
-          - "wat gebeurt er met (mijn|de) data"
-          - "waar gaat (mijn|de) data heen"
+          - "wat gebeurt er met [<my>] data"
+          - "waar gaat [<my>] data heen"
         response: data
 
       - sentences:

--- a/sentences/nl/homeassistant_HassTimerStatus.yaml
+++ b/sentences/nl/homeassistant_HassTimerStatus.yaml
@@ -4,12 +4,11 @@ intents:
   HassTimerStatus:
     data:
       - sentences:
-          - "[wat is de] (<my_status_timer>|<my_status_timers>)  status"
-          - "[wat is de] status van (<my_status_timer>|<my_status_timers>) "
+          - "[wat is] (<my_status_timer>|<my_status_timers>)  status"
+          - "[wat is] status van (<my_status_timer>|<my_status_timers>) "
           - "[hoe veel] tijd [is] [er] [nog] over (op|van|voor) (<my_status_timer>|<my_status_timers>) "
           - "hoe lang (is|moet) (<my_status_timer>|<my_status_timers>) nog"
           - "hoe lang (zijn|moeten) <my_status_timers> nog"
         expansion_rules:
-          my: (de|mijn|m'n)
           my_status_timer: "[<my>] ([<timer_prefix>](timer|kookwekker)|(timer|kookwekker) <timer_suffix>)"
           my_status_timers: "[<my>] ([<timer_prefix>](timers|kookwekkers)|(timers|kookwekkers) <timer_suffix>)"

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -3,12 +3,12 @@ intents:
   HassTurnOff:
     data:
       - sentences: &sentences
-          - "[<change>] <name_type> [<to>] uit [<in> <area>]"
+          - "[<change>] <name_type> [<to>] uit [<in> {area}]"
           - "[<change>] <name_area> [<to>] uit"
-          - "[<would>] <name_type> (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
+          - "[<would>] <name_type> (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> {area}]"
           - "[<would>] <name_area> (uit[ ](zetten|doen)|uit[ ]schakelen|doen)"
         expansion_rules:
-          name_type: <name>
+          name_type: "{name}"
         excludes_context:
           domain:
             - binary_sensor
@@ -23,12 +23,12 @@ intents:
       # light
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<light>
+          name_type: "{name}[ ]<light>"
           name_area: &name_area >
             (
-              <name_type> <in> <area>
-              |<in> <area> <name_type>
-              |<area>[ ]<name_type>
+              <name_type> <in> {area}
+              |<in> {area} <name_type>
+              |{area}[ ]<name_type>
             )
         requires_context:
           domain:
@@ -37,7 +37,7 @@ intents:
       # switch
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<switch>
+          name_type: "{name}[ ]<switch>"
           name_area: *name_area
         requires_context:
           domain:
@@ -46,7 +46,7 @@ intents:
       # fan
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<fan>
+          name_type: "{name}[ ]<fan>"
           name_area: *name_area
         requires_context:
           domain:

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -3,14 +3,14 @@ intents:
   HassTurnOn:
     data:
       - sentences: &sentences
-          - "[<change>] <name_type> [<to>] aan [<in> <area>]"
+          - "[<change>] <name_type> [<to>] aan [<in> {area}]"
           - "[<change>] <name_area> [<to>] aan"
-          - "schakel <name_type> [<to>] in [<in> <area>]"
+          - "schakel <name_type> [<to>] in [<in> {area}]"
           - "schakel <name_area> [<to>] in"
-          - "[<would>] <name_type> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
+          - "[<would>] <name_type> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> {area}]"
           - "[<would>] <name_area> (aan[ ](zetten|doen)|inschakelen)"
         expansion_rules:
-          name_type: <name>
+          name_type: "{name}"
         excludes_context:
           domain:
             - binary_sensor
@@ -25,12 +25,12 @@ intents:
       # light
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<light>
+          name_type: "{name}[ ]<light>"
           name_area: &name_area >
             (
-              <name_type> <in> <area>
-              |<in> <area> <name_type>
-              |<area>[ ]<name_type>
+              <name_type> <in> {area}
+              |<in> {area} <name_type>
+              |{area}[ ]<name_type>
             )
         requires_context:
           domain:
@@ -39,7 +39,7 @@ intents:
       # switch
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<switch>
+          name_type: "{name}[ ]<switch>"
           name_area: *name_area
         requires_context:
           domain:
@@ -48,7 +48,7 @@ intents:
       # fan
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<fan>
+          name_type: "{name}[ ]<fan>"
           name_area: *name_area
         requires_context:
           domain:

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -4,57 +4,57 @@ intents:
     data:
       # Brightness value
       - sentences:
-          - "[<numeric_value_set>|dim] [<brightness>] [van] <name>[[ ]<light>] [<to>] <brightness_value>"
-          - "[<numeric_value_set>|dim] [van] <name>[[ ]<light>][[ ]<brightness>] [<to>] <brightness_value>"
-          - "[<would>] [<brightness>] [van] <name>[[ ]<light>] [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
-          - "[<would>] <name>[[ ]<light>][[ ]<brightness>] [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
+          - "[<numeric_value_set>|dim] [<brightness>] [van] {name}[[ ]<light>] [<to>] <brightness_value>"
+          - "[<numeric_value_set>|dim] [van] {name}[[ ]<light>][[ ]<brightness>] [<to>] <brightness_value>"
+          - "[<would>] [<brightness>] [van] {name}[[ ]<light>] [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
+          - "[<would>] {name}[[ ]<light>][[ ]<brightness>] [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
         response: "brightness"
         requires_context:
           domain: light
 
       - sentences:
-          - "[<numeric_value_set>|dim] (<brightness>|<light>) <in> (<area>|<floor>) [<to>] <brightness_value>"
-          - "[<numeric_value_set>|dim] [<brightness>] <in> (<area>|<floor>)[ ]<light> [<to>] <brightness_value>"
-          - "[<numeric_value_set>|dim] (<area>|<floor>)[ ](<brightness>|<light>) [<to>] <brightness_value>"
-          - "[<would>] (<brightness>|<light>) <in> (<area>|<floor>) [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
-          - "[<would>] [<brightness>] <in> (<area>|<floor>)[ ]<light> [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
-          - "[<would>] (<area>|<floor>)[ ](<brightness>|<light>) [<to>] <brightness_value> (zetten|doen|veranderen)"
-          - "[<would>] (<area>|<floor>)[[ ](<brightness>|<light>)] [<to>] <brightness_value> dimmen"
+          - "[<numeric_value_set>|dim] (<brightness>|<light>) <in> ({area}|{floor}) [<to>] <brightness_value>"
+          - "[<numeric_value_set>|dim] [<brightness>] <in> ({area}|{floor})[ ]<light> [<to>] <brightness_value>"
+          - "[<numeric_value_set>|dim] ({area}|{floor})[ ](<brightness>|<light>) [<to>] <brightness_value>"
+          - "[<would>] (<brightness>|<light>) <in> ({area}|{floor}) [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
+          - "[<would>] [<brightness>] <in> ({area}|{floor})[ ]<light> [<to>] <brightness_value> (zetten|doen|veranderen|dimmen)"
+          - "[<would>] ({area}|{floor})[ ](<brightness>|<light>) [<to>] <brightness_value> (zetten|doen|veranderen)"
+          - "[<would>] ({area}|{floor})[[ ](<brightness>|<light>)] [<to>] <brightness_value> dimmen"
         response: "brightness"
 
       # Max/Min brightness
       - sentences:
-          - "[<numeric_value_set>|dim] <name>[[ ]<light>][[ ]<brightness>] [<to>] [het] {brightness_level:brightness}"
-          - "[<numeric_value_set>|dim] <brightness> [van] <name>[ ][<light>] [<to>] [het] {brightness_level:brightness}"
-          - "[<numeric_value_set>|dim] <name>[ ][lamp] [<to>] [de|het] {brightness_level:brightness} <brightness>"
-          - "[<would>] <name>[[ ]<light>][[ ]<brightness>] [<to>] [het] {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
-          - "[<would>] <brightness> [van] <name>[ ][<light>] [<to>] [het] {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
-          - "[<would>] <name>[ ][lamp] [<to>] [de|het] {brightness_level:brightness} <brightness> (zetten|doen|veranderen|dimmen)"
+          - "[<numeric_value_set>|dim] {name}[[ ]<light>][[ ]<brightness>] [<to>] [het] {brightness_level:brightness}"
+          - "[<numeric_value_set>|dim] <brightness> [van] {name}[ ][<light>] [<to>] [het] {brightness_level:brightness}"
+          - "[<numeric_value_set>|dim] {name}[ ][lamp] [<to>] [de|het] {brightness_level:brightness} <brightness>"
+          - "[<would>] {name}[[ ]<light>][[ ]<brightness>] [<to>] [het] {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
+          - "[<would>] <brightness> [van] {name}[ ][<light>] [<to>] [het] {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
+          - "[<would>] {name}[ ][lamp] [<to>] [de|het] {brightness_level:brightness} <brightness> (zetten|doen|veranderen|dimmen)"
         requires_context:
           domain: light
         response: "brightness"
 
       - sentences:
-          - "[<numeric_value_set>|dim] (<brightness>|<light>) <in> (<area>|<floor>) [<to>] {brightness_level:brightness}"
-          - "[<numeric_value_set>|dim] [<brightness>] <in> (<area>|<floor>)[ ]<light> [<to>] {brightness_level:brightness}"
-          - "[<numeric_value_set>|dim] (<area>|<floor>)[[ ]<light>][ ]<brightness> [<to>] {brightness_level:brightness}"
-          - "[<numeric_value_set>|dim] <in> (<area>|<floor>)[[ ]<light>][ ]<brightness> [<to>] {brightness_level:brightness}"
-          - "[<numeric_value_set>|dim] (<area>|<floor>) [<to>] [de|het] {brightness_level:brightness} [<brightness>]"
-          - "[<would>] (<brightness>|<light>) <in> (<area>|<floor>) {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
-          - "[<would>] [<brightness>] <in> (<area>|<floor>)[ ]<light> [het] {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
-          - "[<would>] <in> (<area>|<floor>)[[ ]<light>][ ]<brightness> {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
-          - "[<would>] (<area>|<floor>) [<to>] [de|het] {brightness_level:brightness} <brightness> (zetten|doen|veranderen|dimmen)"
+          - "[<numeric_value_set>|dim] (<brightness>|<light>) <in> ({area}|{floor}) [<to>] {brightness_level:brightness}"
+          - "[<numeric_value_set>|dim] [<brightness>] <in> ({area}|{floor})[ ]<light> [<to>] {brightness_level:brightness}"
+          - "[<numeric_value_set>|dim] ({area}|{floor})[[ ]<light>][ ]<brightness> [<to>] {brightness_level:brightness}"
+          - "[<numeric_value_set>|dim] <in> ({area}|{floor})[[ ]<light>][ ]<brightness> [<to>] {brightness_level:brightness}"
+          - "[<numeric_value_set>|dim] ({area}|{floor}) [<to>] [de|het] {brightness_level:brightness} [<brightness>]"
+          - "[<would>] (<brightness>|<light>) <in> ({area}|{floor}) {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
+          - "[<would>] [<brightness>] <in> ({area}|{floor})[ ]<light> [het] {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
+          - "[<would>] <in> ({area}|{floor})[[ ]<light>][ ]<brightness> {brightness_level:brightness} (zetten|doen|veranderen|dimmen)"
+          - "[<would>] ({area}|{floor}) [<to>] [de|het] {brightness_level:brightness} <brightness> (zetten|doen|veranderen|dimmen)"
         response: "brightness"
 
       # Color
       - sentences:
-          - "[<change>] <name>[ ][<light>][ ][kleur] [<to>] {color}"
-          - "[<change>] [[de] kleur van] <name>[ ][<light>] [<to>] {color}"
-          - "[<would>] <name>[ ][<light>][ ][kleur] [<to>] {color} (zetten|doen|veranderen|maken)"
-          - "[<would>] [[de] kleur van] <name>[ ][<light>] [<to>] {color} (zetten|doen|veranderen|maken)"
+          - "[<change>] {name}[ ][<light>][ ][kleur] [<to>] {color}"
+          - "[<change>] [kleur van] {name}[ ][<light>] [<to>] {color}"
+          - "[<would>] {name}[ ][<light>][ ][kleur] [<to>] {color} (zetten|doen|veranderen|maken)"
+          - "[<would>] [kleur van] {name}[ ][<light>] [<to>] {color} (zetten|doen|veranderen|maken)"
         response: "color"
 
       - sentences:
-          - "[<change>] [[de] kleur van] ([[<all>] <light>] [<in>] (<area>|<floor>)|(<area>|<floor>)[[ ]<light>]) [<to>] {color}"
-          - "[<would>] [[de] kleur van] ([[<all>] <light>] [<in>] (<area>|<floor>)|(<area>|<floor>)[[ ]<light>]) [<to>] {color} (zetten|doen|veranderen|maken)"
+          - "[<change>] [kleur van] ([[<all>] <light>] [<in>] ({area}|{floor})|({area}|{floor})[[ ]<light>]) [<to>] {color}"
+          - "[<would>] [kleur van] ([[<all>] <light>] [<in>] ({area}|{floor})|({area}|{floor})[[ ]<light>]) [<to>] {color} (zetten|doen|veranderen|maken)"
         response: "color"

--- a/sentences/nl/light_HassTurnOff.yaml
+++ b/sentences/nl/light_HassTurnOff.yaml
@@ -3,15 +3,15 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<change>] [<all>] <light> ([<to>] uit;<in> (<area>|<floor>))"
-          - "[<change>] [<all>] (<area>|<floor>)[ ]<light> [<to>] uit"
-          - "[<change>] <in> (<area>|<floor>) [<all>] <light> [<to>] uit"
-          - "Schakel [<all>] <light> ([<to>] uit;<in> (<area>|<floor>))"
-          - "Schakel [<all>] (<area>|<floor>)[ ]<light> [<to>] uit"
-          - "Schakel <in> (<area>|<floor>) [<all>] <light> [<to>] uit"
-          - "[<would>] [<all>] <light> (<in> (<area>|<floor>);uit[ ](zetten|doen|schakelen))"
-          - "[<would>] [<all>] (<area>|<floor>)[ ]<light> [<to>] uit[ ](zetten|doen|schakelen)"
-          - "[<would>] [<all>] <light> [<to>] [<to>] uit[ ](zetten|doen|schakelen) <in> (<area>|<floor>)"
+          - "[<change>] [<all>] <light> ([<to>] uit;<in> ({area}|{floor}))"
+          - "[<change>] [<all>] ({area}|{floor})[ ]<light> [<to>] uit"
+          - "[<change>] <in> ({area}|{floor}) [<all>] <light> [<to>] uit"
+          - "Schakel [<all>] <light> ([<to>] uit;<in> ({area}|{floor}))"
+          - "Schakel [<all>] ({area}|{floor})[ ]<light> [<to>] uit"
+          - "Schakel <in> ({area}|{floor}) [<all>] <light> [<to>] uit"
+          - "[<would>] [<all>] <light> (<in> ({area}|{floor});uit[ ](zetten|doen|schakelen))"
+          - "[<would>] [<all>] ({area}|{floor})[ ]<light> [<to>] uit[ ](zetten|doen|schakelen)"
+          - "[<would>] [<all>] <light> [<to>] [<to>] uit[ ](zetten|doen|schakelen) <in> ({area}|{floor})"
         response: "lights_area"
         slots:
           domain: "light"

--- a/sentences/nl/light_HassTurnOn.yaml
+++ b/sentences/nl/light_HassTurnOn.yaml
@@ -3,15 +3,15 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<change>] [<all>] <light> ([<to>] aan;<in> (<area>|<floor>))"
-          - "[<change>] [<all>] (<area>|<floor>)[ ]<light> [<to>] aan"
-          - "[<change>] <in> (<area>|<floor>) [<all>] <light> [<to>] aan"
-          - "Schakel [<all>] <light> ([<to>] in;<in> (<area>|<floor>))"
-          - "Schakel [<all>] (<area>|<floor>)[ ]<light> [<to>] in"
-          - "Schakel <in> (<area>|<floor>) [<all>] <light> [<to>] in"
-          - "[<would>] [<all>] <light> (<in> (<area>|<floor>);(aan[ ](zetten|doen)|in[ ]schakelen))"
-          - "[<would>] [<all>] (<area>|<floor>)[ ]<light> [<to>] (aan[ ](zetten|doen)|in[ ]schakelen)"
-          - "[<would>] [<all>] <light> [<to>] [<to>] (aan[ ](zetten|doen)|in[ ]schakelen) <in> (<area>|<floor>)"
+          - "[<change>] [<all>] <light> ([<to>] aan;<in> ({area}|{floor}))"
+          - "[<change>] [<all>] ({area}|{floor})[ ]<light> [<to>] aan"
+          - "[<change>] <in> ({area}|{floor}) [<all>] <light> [<to>] aan"
+          - "Schakel [<all>] <light> ([<to>] in;<in> ({area}|{floor}))"
+          - "Schakel [<all>] ({area}|{floor})[ ]<light> [<to>] in"
+          - "Schakel <in> ({area}|{floor}) [<all>] <light> [<to>] in"
+          - "[<would>] [<all>] <light> (<in> ({area}|{floor});(aan[ ](zetten|doen)|in[ ]schakelen))"
+          - "[<would>] [<all>] ({area}|{floor})[ ]<light> [<to>] (aan[ ](zetten|doen)|in[ ]schakelen)"
+          - "[<would>] [<all>] <light> [<to>] [<to>] (aan[ ](zetten|doen)|in[ ]schakelen) <in> ({area}|{floor})"
         response: "lights_area"
         slots:
           domain: "light"

--- a/sentences/nl/lock_HassGetState.yaml
+++ b/sentences/nl/lock_HassGetState.yaml
@@ -3,7 +3,7 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<is> [[<in>] <area>] [de [huidige] [(status|staat|stand) van]] <name> [[<in>] <area>] {lock_states:state} [[<in>] <area>]"
+          - "<is> [[<in>] {area}] [[huidige] [(status|staat|stand) van]] {name} [[<in>] {area}] {lock_states:state} [[<in>] {area}]"
         response: one_yesno
         requires_context:
           domain: lock
@@ -11,28 +11,28 @@ intents:
           domain: lock
 
       - sentences:
-          - <is> er [[<in>] <area>] <lock> [[<in>] <area>] {lock_states:state} [[<in>] <area>]
+          - <is> er [[<in>] {area}] <lock> [[<in>] {area}] {lock_states:state} [[<in>] {area}]
         response: any
         slots:
           domain: lock
 
       - sentences:
-          - <is> [[<in>] <area>] [<all>] <lock> [[<in>] <area>] {lock_states:state} [[<in>] <area>]
-          - <is> [[<in>] <area>] [<all>] [de] deur[en] [[<in>] <area>] {door_lock_states:state} [[<in>] <area>]
+          - <is> [[<in>] {area}] [<all>] <lock> [[<in>] {area}] {lock_states:state} [[<in>] {area}]
+          - <is> [[<in>] {area}] [<all>] deur[en] [[<in>] {area}] {door_lock_states:state} [[<in>] {area}]
         response: all
         slots:
           domain: lock
 
       - sentences:
-          - Welk[e] <lock> [[<in>] <area>] <is> [[<in>] <area>] {lock_states:state} [[<in>] <area>]
-          - Welk[e] deur[en] [[<in>] <area>] <is> [[<in>] <area>] {door_lock_states:state} [[<in>] <area>]
+          - Welk[e] <lock> [[<in>] {area}] <is> [[<in>] {area}] {lock_states:state} [[<in>] {area}]
+          - Welk[e] deur[en] [[<in>] {area}] <is> [[<in>] {area}] {door_lock_states:state} [[<in>] {area}]
         response: which
         slots:
           domain: lock
 
       - sentences:
-          - Hoe[ ]veel <lock> <is> [er] [[<in>] <area>] {lock_states:state} [[<in>] <area>]
-          - Hoe[ ]veel deur[en] <is> [er] [[<in>] <area>] {door_lock_states:state} [[<in>] <area>]
+          - Hoe[ ]veel <lock> <is> [er] [[<in>] {area}] {lock_states:state} [[<in>] {area}]
+          - Hoe[ ]veel deur[en] <is> [er] [[<in>] {area}] {door_lock_states:state} [[<in>] {area}]
         response: how_many
         slots:
           domain: lock

--- a/sentences/nl/lock_HassTurnOff.yaml
+++ b/sentences/nl/lock_HassTurnOff.yaml
@@ -5,15 +5,15 @@ intents:
       - sentences:
           - "ontgrendel (<name_area>|<lock_name_area>)"
           - "open <lock_name_area>"
-          - "[<change>] <lock_name> open <in> <area>"
+          - "[<change>] <lock_name> open <in> {area}"
           - "[<change>] <lock_name_area> open"
-          - "[<change>] (<name>|<lock_name>) <unlocked> <in> <area>"
+          - "[<change>] ({name}|<lock_name>) <unlocked> <in> {area}"
           - "[<change>] (<name_area>|<lock_name_area>) <unlocked>"
           - "[<would>] (<name_area>|<lock_name_area>) <unlocked> (doen|zetten|draaien)"
-          - "[<would>] (<name>|<lock_name>) <unlocked> (doen|zetten|draaien) <in> <area>"
-          - "[<would>] (<name>|<lock_name>) ontgrendelen <in> <area>"
+          - "[<would>] ({name}|<lock_name>) <unlocked> (doen|zetten|draaien) <in> {area}"
+          - "[<would>] ({name}|<lock_name>) ontgrendelen <in> {area}"
           - "[<would>] (<name_area>|<lock_name_area>) ontgrendelen"
-          - "[<would>] <lock_name> (open[ ](doen|zetten|draaien)|openen) <in> <area>"
+          - "[<would>] <lock_name> (open[ ](doen|zetten|draaien)|openen) <in> {area}"
           - "[<would>] <lock_name_area> (open[ ](doen|zetten|draaien)|openen)"
         requires_context:
           domain: lock
@@ -21,33 +21,33 @@ intents:
 
       - sentences:
           - "[<change>] <all_area_door_lock> <unlocked>"
-          - "[<change>] [<all>] (<lock>|deur[en]) <unlocked> <in> <area>"
+          - "[<change>] [<all>] (<lock>|deur[en]) <unlocked> <in> {area}"
           - "[<change>] <all_area_lock> open"
-          - "[<change>] [<all>] <lock> open <in> <area>"
+          - "[<change>] [<all>] <lock> open <in> {area}"
           - "open <all_area_lock>"
-          - "open [<all>] <lock> <in> <area>"
+          - "open [<all>] <lock> <in> {area}"
           - "ontgrendel <all_area_door_lock>"
-          - "ontgrendel [<all>] (<lock>|deur[en]) <in> <area>"
+          - "ontgrendel [<all>] (<lock>|deur[en]) <in> {area}"
           - "[<would>] <all_area_door_lock> ontgrendelen"
-          - "[<would>] [<all>] (<lock>|deur[en]) ontgrendelen <in> <area>"
+          - "[<would>] [<all>] (<lock>|deur[en]) ontgrendelen <in> {area}"
           - "[<would>] <all_area_lock> (open[ ](doen|zetten|draaien)|openen)"
-          - "[<would>] [<all>] <lock> (open[ ](doen|zetten|draaien)|openen) <in> <area>"
+          - "[<would>] [<all>] <lock> (open[ ](doen|zetten|draaien)|openen) <in> {area}"
           - "[<would>] <all_area_door_lock> <unlocked> (doen|zetten|draaien)"
-          - "[<would>] [<all>] (<lock>|deur[en]) <unlocked> (doen|zetten|draaien) <in> <area>"
+          - "[<would>] [<all>] (<lock>|deur[en]) <unlocked> (doen|zetten|draaien) <in> {area}"
         expansion_rules:
           all_area_lock: >
             (
-              <in> <area> <lock>
-             |(<all>;<in> <area>) <lock>
-             |[<all>] <lock> <in> <area>
-             |[<all>] <area>[ ]<lock>
+              <in> {area} <lock>
+             |(<all>;<in> {area}) <lock>
+             |[<all>] <lock> <in> {area}
+             |[<all>] {area}[ ]<lock>
             )
           all_area_door_lock: >
             (
-              <in> <area> (<lock>|deur[en])
-             |(<all>;<in> <area>) (<lock>|deur[en])
-             |[<all>] (<lock>|deur[en]) <in> <area>
-             |[<all>] <area>[ ](<lock>|deur[en])
+              <in> {area} (<lock>|deur[en])
+             |(<all>;<in> {area}) (<lock>|deur[en])
+             |[<all>] (<lock>|deur[en]) <in> {area}
+             |[<all>] {area}[ ](<lock>|deur[en])
             )
         response: lock_area
         slots:

--- a/sentences/nl/lock_HassTurnOn.yaml
+++ b/sentences/nl/lock_HassTurnOn.yaml
@@ -5,15 +5,15 @@ intents:
       - sentences:
           - "vergrendel (<name_area>|<lock_name_area>)"
           - "sluit <lock_name_area>"
-          - "[<change>] <lock_name> dicht <in> <area>"
+          - "[<change>] <lock_name> dicht <in> {area}"
           - "[<change>] <lock_name_area> dicht"
-          - "[<change>] (<name>|<lock_name>) <locked> <in> <area>"
+          - "[<change>] ({name}|<lock_name>) <locked> <in> {area}"
           - "[<change>] (<name_area>|<lock_name_area>) <locked>"
           - "[<would>] (<name_area>|<lock_name_area>) <locked> (doen|zetten|draaien)"
-          - "[<would>] (<name>|<lock_name>) <locked> (doen|zetten|draaien) <in> <area>"
-          - "[<would>] (<name>|<lock_name>) vergrendelen <in> <area>"
+          - "[<would>] ({name}|<lock_name>) <locked> (doen|zetten|draaien) <in> {area}"
+          - "[<would>] ({name}|<lock_name>) vergrendelen <in> {area}"
           - "[<would>] (<name_area>|<lock_name_area>) vergrendelen"
-          - "[<would>] <lock_name> (dicht[ ](doen|zetten|draaien)|sluiten) <in> <area>"
+          - "[<would>] <lock_name> (dicht[ ](doen|zetten|draaien)|sluiten) <in> {area}"
           - "[<would>] <lock_name_area> (dicht[ ](doen|zetten|draaien)|sluiten)"
         requires_context:
           domain: lock
@@ -21,33 +21,33 @@ intents:
 
       - sentences:
           - "[<change>] <all_area_door_lock> <locked>"
-          - "[<change>] [<all>] (<lock>|deur[en]) <locked> <in> <area>"
+          - "[<change>] [<all>] (<lock>|deur[en]) <locked> <in> {area}"
           - "[<change>] <all_area_lock> dicht"
-          - "[<change>] [<all>] <lock> dicht <in> <area>"
+          - "[<change>] [<all>] <lock> dicht <in> {area}"
           - "sluit <all_area_lock>"
-          - "sluit [<all>] <lock> <in> <area>"
+          - "sluit [<all>] <lock> <in> {area}"
           - "vergrendel <all_area_door_lock>"
-          - "vergrendel [<all>] (<lock>|deur[en]) <in> <area>"
+          - "vergrendel [<all>] (<lock>|deur[en]) <in> {area}"
           - "[<would>] <all_area_door_lock> vergrendelen"
-          - "[<would>] [<all>] (<lock>|deur[en]) vergrendelen <in> <area>"
+          - "[<would>] [<all>] (<lock>|deur[en]) vergrendelen <in> {area}"
           - "[<would>] <all_area_lock> (dicht[ ](doen|zetten|draaien)|sluiten)"
-          - "[<would>] [<all>] <lock> (dicht[ ](doen|zetten|draaien)|sluiten) <in> <area>"
+          - "[<would>] [<all>] <lock> (dicht[ ](doen|zetten|draaien)|sluiten) <in> {area}"
           - "[<would>] <all_area_door_lock> <locked> (doen|zetten|draaien)"
-          - "[<would>] [<all>] (<lock>|deur[en]) <locked> (doen|zetten|draaien) <in> <area>"
+          - "[<would>] [<all>] (<lock>|deur[en]) <locked> (doen|zetten|draaien) <in> {area}"
         expansion_rules:
           all_area_lock: >
             (
-              <in> <area> <lock>
-             |(<all>;<in> <area>) <lock>
-             |[<all>] <lock> <in> <area>
-             |[<all>] <area>[ ]<lock>
+              <in> {area} <lock>
+             |(<all>;<in> {area}) <lock>
+             |[<all>] <lock> <in> {area}
+             |[<all>] {area}[ ]<lock>
             )
           all_area_door_lock: >
             (
-              <in> <area> (<lock>|deur[en])
-             |(<all>;<in> <area>) (<lock>|deur[en])
-             |[<all>] (<lock>|deur[en]) <in> <area>
-             |[<all>] <area>[ ](<lock>|deur[en])
+              <in> {area} (<lock>|deur[en])
+             |(<all>;<in> {area}) (<lock>|deur[en])
+             |[<all>] (<lock>|deur[en]) <in> {area}
+             |[<all>] {area}[ ](<lock>|deur[en])
             )
         response: lock_area
         slots:

--- a/sentences/nl/media_player_HassMediaNext.yaml
+++ b/sentences/nl/media_player_HassMediaNext.yaml
@@ -3,12 +3,12 @@ intents:
   HassMediaNext:
     data:
       - sentences:
-          - "volgende <media_item> [op|voor] <name>"
-          - "[ga|zet] [op] <name> [op|naar] [het|de] volgende <media_item>"
-          - "(ga naar|zet) [het|de] volgende <media_item> op <name> [op]"
-          - "sla [[het|de] huidige|dit] <media_item> op <name> over"
-          - "sla dit op <name> over"
-          - "([op|voor] <name>;[de|het] volgende <media_item>) (opzetten|afspelen)"
+          - "volgende <media_item> [op|voor] {name}"
+          - "[ga|zet] [op] {name} [op|naar] [het|de] volgende <media_item>"
+          - "(ga naar|zet) [het|de] volgende <media_item> op {name} [op]"
+          - "sla [[het|de] huidige|dit] <media_item> op {name} over"
+          - "sla dit op {name} over"
+          - "([op|voor] {name};[de|het] volgende <media_item>) (opzetten|afspelen)"
         requires_context:
           domain: media_player
       - sentences:
@@ -21,9 +21,9 @@ intents:
           area:
             slot: true
       - sentences:
-          - "volgende <media_item> [<in>] <area>"
-          - "[ga|zet] [<in>] <area> [op|naar] [het|de] volgende <media_item>"
-          - "(ga naar|zet) [het|de] volgende <media_item> [<in>] <area> [op]"
-          - "sla [[het|de] huidige|dit] <media_item> [<in>] <area> over"
-          - "sla dit [<in>] <area> over"
-          - "([<in>] <area>;[de|het] volgende <media_item>) (opzetten|afspelen)"
+          - "volgende <media_item> [<in>] {area}"
+          - "[ga|zet] [<in>] {area} [op|naar] [het|de] volgende <media_item>"
+          - "(ga naar|zet) [het|de] volgende <media_item> [<in>] {area} [op]"
+          - "sla [[het|de] huidige|dit] <media_item> [<in>] {area} over"
+          - "sla dit [<in>] {area} over"
+          - "([<in>] {area};[de|het] volgende <media_item>) (opzetten|afspelen)"

--- a/sentences/nl/media_player_HassMediaPause.yaml
+++ b/sentences/nl/media_player_HassMediaPause.yaml
@@ -3,9 +3,9 @@ intents:
   HassMediaPause:
     data:
       - sentences:
-          - "(pauzeer|stop) [[de|het] <media_item> [op]] <name>"
-          - "[zet] <name> [op] (pauze|stop)"
-          - "[[de|het] <media_item> [op]] <name> (op (pauze|stop) zetten|pauzeren|stoppen)"
+          - "(pauzeer|stop) [[de|het] <media_item> [op]] {name}"
+          - "[zet] {name} [op] (pauze|stop)"
+          - "[[de|het] <media_item> [op]] {name} (op (pauze|stop) zetten|pauzeren|stoppen)"
         requires_context:
           domain: media_player
       - sentences:
@@ -15,7 +15,7 @@ intents:
           area:
             slot: true
       - sentences:
-          - "(pauzeer|stop) [[de|het] <media_item> [<in>]] <area>"
-          - "<area> pauze"
-          - "[zet] <area> [op] (pauze|stop)"
-          - "<area> (op (pauze|stop) zetten|pauzeren|stoppen)"
+          - "(pauzeer|stop) [[de|het] <media_item> [<in>]] {area}"
+          - "{area} pauze"
+          - "[zet] {area} [op] (pauze|stop)"
+          - "{area} (op (pauze|stop) zetten|pauzeren|stoppen)"

--- a/sentences/nl/media_player_HassMediaPrevious.yaml
+++ b/sentences/nl/media_player_HassMediaPrevious.yaml
@@ -3,11 +3,11 @@ intents:
   HassMediaPrevious:
     data:
       - sentences:
-          - "vorige <media_item> [op|voor] <name>"
-          - "[ga|zet] [op] <name> [op|naar] [het|de] vorige <media_item>"
-          - "(ga naar|zet) [het|de] vorige <media_item> op <name> [op]"
-          - "ga ([een] <media_item>;op <name>) terug"
-          - "([op|voor] <name>;[de|het] vorige <media_item>) (opzetten|afspelen)"
+          - "vorige <media_item> [op|voor] {name}"
+          - "[ga|zet] [op] {name} [op|naar] [het|de] vorige <media_item>"
+          - "(ga naar|zet) [het|de] vorige <media_item> op {name} [op]"
+          - "ga ([een] <media_item>;op {name}) terug"
+          - "([op|voor] {name};[de|het] vorige <media_item>) (opzetten|afspelen)"
         requires_context:
           domain: media_player
       - sentences:
@@ -19,8 +19,8 @@ intents:
           area:
             slot: true
       - sentences:
-          - "vorige <media_item> [<in>] <area>"
-          - "[ga|zet] [<in>] <area> [op|naar] [het|de] vorige <media_item>"
-          - "(ga naar|zet) [het|de] vorige <media_item> [<in>] <area> [op]"
-          - "ga ([een] <media_item>;[<in>] <area>) terug"
-          - "([<in>] <area>;[de|het] vorige <media_item>) (opzetten|afspelen)"
+          - "vorige <media_item> [<in>] {area}"
+          - "[ga|zet] [<in>] {area} [op|naar] [het|de] vorige <media_item>"
+          - "(ga naar|zet) [het|de] vorige <media_item> [<in>] {area} [op]"
+          - "ga ([een] <media_item>;[<in>] {area}) terug"
+          - "([<in>] {area};[de|het] vorige <media_item>) (opzetten|afspelen)"

--- a/sentences/nl/media_player_HassMediaUnpause.yaml
+++ b/sentences/nl/media_player_HassMediaUnpause.yaml
@@ -3,10 +3,10 @@ intents:
   HassMediaUnpause:
     data:
       - sentences:
-          - "hervat [[de|het] <media_item> [op]] <name>"
-          - "[[de|het] <media_item> [op]] <name> hervatten"
-          - "[zet] <name> [weer] [op] ([af]spelen|play)"
-          - "ga verder met [de|het] <media_item> op <name>"
+          - "hervat [[de|het] <media_item> [op]] {name}"
+          - "[[de|het] <media_item> [op]] {name} hervatten"
+          - "[zet] {name} [weer] [op] ([af]spelen|play)"
+          - "ga verder met [de|het] <media_item> op {name}"
         requires_context:
           domain: media_player
       - sentences:
@@ -17,7 +17,7 @@ intents:
           area:
             slot: true
       - sentences:
-          - "hervat [[de|het] <media_item> [<in>]] <area>"
-          - "[[de|het] <media_item> [<in>]] <area> hervatten"
-          - "[zet] <area> [weer] [op] ([af]spelen|play)"
-          - "ga verder met [de|het] <media_item> [<in>] <area>"
+          - "hervat [[de|het] <media_item> [<in>]] {area}"
+          - "[[de|het] <media_item> [<in>]] {area} hervatten"
+          - "[zet] {area} [weer] [op] ([af]spelen|play)"
+          - "ga verder met [de|het] <media_item> [<in>] {area}"

--- a/sentences/nl/media_player_HassSetVolume.yaml
+++ b/sentences/nl/media_player_HassSetVolume.yaml
@@ -3,12 +3,12 @@ intents:
   HassSetVolume:
     data:
       - sentences:
-          - "<numeric_value_set> <name> volume (naar|op) <volume>"
-          - "zet <name> [volume] [omhoog|omlaag] (op|naar) <volume>"
-          - "<numeric_value_set> [het] volume ([omhoog|omlaag] (naar|op) <volume>;[van|op] <name>)"
-          - "zet [het] volume (omhoog|omlaag) ((naar|op) <volume>;[van|op] <name>)"
-          - "(<name>;volume) <volume>"
-          - "(<volume>;volume) [op] <name>"
+          - "<numeric_value_set> {name} volume (naar|op) <volume>"
+          - "zet {name} [volume] [omhoog|omlaag] (op|naar) <volume>"
+          - "<numeric_value_set> [het] volume ([omhoog|omlaag] (naar|op) <volume>;[van|op] {name})"
+          - "zet [het] volume (omhoog|omlaag) ((naar|op) <volume>;[van|op] {name})"
+          - "({name};volume) <volume>"
+          - "(<volume>;volume) [op] {name}"
         requires_context:
           domain: media_player
       - sentences:
@@ -20,9 +20,9 @@ intents:
           area:
             slot: true
       - sentences:
-          - "<numeric_value_set> [<in>] <area> [het] volume (naar|op) <volume>"
-          - "zet [<in>] <area> [volume] [omhoog|omlaag] (op|naar) <volume>"
-          - "<numeric_value_set> [het] volume ([omhoog|omlaag] (naar|op) <volume>;[<in>] <area>)"
-          - "zet [het] volume (omhoog|omlaag) ((naar|op) <volume>;[<in>] <area>)"
-          - "([<in>] <area>;volume) <volume>"
-          - "(<volume>;volume) [<in>] <area>"
+          - "<numeric_value_set> [<in>] {area} [het] volume (naar|op) <volume>"
+          - "zet [<in>] {area} [volume] [omhoog|omlaag] (op|naar) <volume>"
+          - "<numeric_value_set> [het] volume ([omhoog|omlaag] (naar|op) <volume>;[<in>] {area})"
+          - "zet [het] volume (omhoog|omlaag) ((naar|op) <volume>;[<in>] {area})"
+          - "([<in>] {area};volume) <volume>"
+          - "(<volume>;volume) [<in>] {area}"

--- a/sentences/nl/person_HassGetState.yaml
+++ b/sentences/nl/person_HassGetState.yaml
@@ -4,8 +4,8 @@ intents:
     data:
       # https://www.home-assistant.io/integrations/person/
       - sentences:
-          - "waar [is|zijn] <name>"
-          - "waar bevind[t|en] <name> zich"
+          - "waar [is|zijn] {name}"
+          - "waar bevind[t|en] {name} zich"
         response: where
         requires_context:
           domain: person
@@ -13,7 +13,7 @@ intents:
           domain: person
 
       - sentences:
-          - "[is|zijn] <name> thuis"
+          - "[is|zijn] {name} thuis"
         response: one_zone
         requires_context:
           domain: person
@@ -21,7 +21,7 @@ intents:
           domain: person
           state: home
       - sentences:
-          - "[is|zijn] <name> (niet thuis|weg)"
+          - "[is|zijn] {name} (niet thuis|weg)"
         response: one_zone
         requires_context:
           domain: person
@@ -29,7 +29,7 @@ intents:
           domain: person
           state: not_home
       - sentences:
-          - "[is|zijn] <name> [<in>] [de|het] [zone] {zone:state}"
+          - "[is|zijn] {name} [<in>] [de|het] [zone] {zone:state}"
         response: one_zone
         requires_context:
           domain: person

--- a/sentences/nl/scene_HassTurnOn.yaml
+++ b/sentences/nl/scene_HassTurnOn.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "(activeer|start|schakel) [scene|scène] <name>[ ][scene|scène] [<to>] [in]"
-          - "[<change>] [scene|scène] <name>[ ][scene|scène] [<to>] (aan|in)"
-          - "[<would>] (<name>[ ][scene|scène]|[scene|scène] <name>) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
+          - "(activeer|start|schakel) [scene|scène] {name}[ ][scene|scène] [<to>] [in]"
+          - "[<change>] [scene|scène] {name}[ ][scene|scène] [<to>] (aan|in)"
+          - "[<would>] ({name}[ ][scene|scène]|[scene|scène] {name}) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
         requires_context:
           domain: scene
         slots:

--- a/sentences/nl/script_HassTurnOn.yaml
+++ b/sentences/nl/script_HassTurnOn.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "(activeer|start|schakel) ([script] <name>|<name>[ ][script]) [<to>] [in]"
-          - "[<change>] ([script] <name>|<name>[ ][script]) [<to>] (aan|in)"
-          - "[<would>] ([script] <name>|<name>[ ][script]) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
+          - "(activeer|start|schakel) ([script] {name}|{name}[ ][script]) [<to>] [in]"
+          - "[<change>] ([script] {name}|{name}[ ][script]) [<to>] (aan|in)"
+          - "[<would>] ([script] {name}|{name}[ ][script]) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
         requires_context:
           domain: script
         slots:

--- a/sentences/nl/sensor_HassGetState.yaml
+++ b/sentences/nl/sensor_HassGetState.yaml
@@ -45,7 +45,7 @@ intents:
       # Battery
       - sentences:
           - "<what_is_the_class_of_name>"
-          - "hoe[ ]veel batterij (heeft <name> [nog] [over]|is [er] [nog] [over] in <name>)"
+          - "hoe[ ]veel batterij (heeft {name} [nog] [over]|is [er] [nog] [over] in {name})"
         response: one
         requires_context:
           domain: sensor
@@ -124,7 +124,7 @@ intents:
       # Date
       - sentences:
           - "<what_is_the_class_of_name>"
-          - "wanneer ((is|was) [de|het] <name>|zal [de|het] <name> zijn|is het [de|het] <name> geweest)"
+          - "wanneer ((is|was) [de|het] {name}|zal [de|het] {name} zijn|is het [de|het] {name} geweest)"
         response: one
         requires_context:
           domain: sensor
@@ -138,7 +138,7 @@ intents:
       # Distance
       - sentences:
           - "<what_is_the_class_of_name>"
-          - "hoe ver is <name> [weg]"
+          - "hoe ver is {name} [weg]"
         response: one
         requires_context:
           domain: sensor
@@ -152,7 +152,7 @@ intents:
       # Duration
       - sentences:
           - "<what_is_the_class_of_name>"
-          - "hoe lang duurt <name> nog"
+          - "hoe lang duurt {name} nog"
         response: one
         requires_context:
           domain: sensor

--- a/sentences/nl/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/nl/shopping_list_HassShoppingListAddItem.yaml
@@ -8,5 +8,5 @@ intents:
           - voeg <item> aan <my_list> toe
         response: item_added
         expansion_rules:
-          my_list: "[mijn|m'n|ons|onze|de|het] [boodschappen[ ]]lijst[je]"
+          my_list: "[<my>|ons|onze|de|het] [boodschappen[ ]]lijst[je]"
           item: "{shopping_list_item:item}"

--- a/sentences/nl/todo_HassListAddItem.yaml
+++ b/sentences/nl/todo_HassListAddItem.yaml
@@ -10,5 +10,5 @@ intents:
         requires_context:
           domain: todo
         expansion_rules:
-          my_list: "[mijn|m'n|ons|onze|de|het] {name}[[ ][boodschappen[ ]]lijst[je]]"
+          my_list: "[<my>|ons|onze|de|het] {name}[[ ][boodschappen[ ]]lijst[je]]"
           item: "{shopping_list_item:item}"

--- a/sentences/nl/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/nl/vacuum_HassVacuumReturnToBase.yaml
@@ -3,11 +3,11 @@ intents:
   HassVacuumReturnToBase:
     data:
       - sentences:
-          - "[stuur] <name> ([terug];[naar] <base>)"
-          - "[stuur] <name> terug"
-          - "laat <name> [terug] naar <base> (gaan|komen|rijden)"
-          - "[<would>] <name> terug sturen"
-          - "[<would>] <name> [terug] naar <base> laten (gaan|komen|rijden)"
+          - "[stuur] {name} ([terug];[naar] <base>)"
+          - "[stuur] {name} terug"
+          - "laat {name} [terug] naar <base> (gaan|komen|rijden)"
+          - "[<would>] {name} terug sturen"
+          - "[<would>] {name} [terug] naar <base> laten (gaan|komen|rijden)"
         requires_context:
           domain: vacuum
         expansion_rules:

--- a/sentences/nl/vacuum_HassVacuumStart.yaml
+++ b/sentences/nl/vacuum_HassVacuumStart.yaml
@@ -3,9 +3,9 @@ intents:
   HassVacuumStart:
     data:
       - sentences:
-          - "start <name>"
-          - "<change> <name> aan"
-          - "[<would>] <name> (starten|aan[ ](zetten|doen)|laten (stofzuigen|schoonmaken))"
-          - "[laat] <name> (stofzuigen|schoonmaken)"
+          - "start {name}"
+          - "<change> {name} aan"
+          - "[<would>] {name} (starten|aan[ ](zetten|doen)|laten (stofzuigen|schoonmaken))"
+          - "[laat] {name} (stofzuigen|schoonmaken)"
         requires_context:
           domain: vacuum

--- a/sentences/nl/valve_HassSetPosition.yaml
+++ b/sentences/nl/valve_HassSetPosition.yaml
@@ -3,8 +3,8 @@ intents:
   HassSetPosition:
     data:
       - sentences:
-          - "[<change>|open|sluit|draai] <name> [positie] [<to>] <position>"
-          - "[<would>] <name> [positie] [<to>]  <position> (draaien|zetten|veranderen|doen)"
+          - "[<change>|open|sluit|draai] {name} [positie] [<to>] <position>"
+          - "[<would>] {name} [positie] [<to>]  <position> (draaien|zetten|veranderen|doen)"
         requires_context:
           domain: valve
         slots:

--- a/sentences/nl/valve_HassTurnOff.yaml
+++ b/sentences/nl/valve_HassTurnOff.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[draai|doe|zet] <name> dicht"
-          - "sluit <name>"
-          - "[<would>] <name> (sluiten|dicht (draaien|doen|zetten))"
+          - "[draai|doe|zet] {name} dicht"
+          - "sluit {name}"
+          - "[<would>] {name} (sluiten|dicht (draaien|doen|zetten))"
         requires_context:
           domain: valve
         slots:

--- a/sentences/nl/valve_HassTurnOn.yaml
+++ b/sentences/nl/valve_HassTurnOn.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[draai|doe|zet] <name> open"
-          - "open <name>"
-          - "[<would>] <name> (openen|open (draaien|doen|zetten))"
+          - "[draai|doe|zet] {name} open"
+          - "open {name}"
+          - "[<would>] {name} (openen|open (draaien|doen|zetten))"
         requires_context:
           domain: valve
         slots:

--- a/sentences/nl/weather_HassGetWeather.yaml
+++ b/sentences/nl/weather_HassGetWeather.yaml
@@ -3,11 +3,11 @@ intents:
   HassGetWeather:
     data:
       - sentences:
-          - wat voor weer is het [nu] [buiten]
-          - (wat|hoe) is (het [huidige] weer|de [huidige] weersvoorspelling) [buiten]
+          - wat voor weer is [nu] [buiten]
+          - (wat|hoe) is ([huidige] weer|[huidige] weersvoorspelling) [buiten]
 
       - sentences:
-          - (wat|hoe) is (het weer|de weersvoorspelling) (voor|in|volgens) <name>
-          - wat voor weer is het [nu] (voor|in|volgens) <name>
+          - (wat|hoe) is (weer|weersvoorspelling) (voor|in|volgens) {name}
+          - wat voor weer is [nu] (voor|in|volgens) {name}
         requires_context:
           domain: weather

--- a/tests/nl/cover_HassGetState.yaml
+++ b/tests/nl/cover_HassGetState.yaml
@@ -52,7 +52,6 @@ tests:
       - "Zijn alle gordijnen dicht in de woonkamer?"
       - "Zijn alle gordijnen in de woonkamer dicht?"
       - "Zijn in de woonkamer alle gordijnen dicht?"
-      - "Zijn in de woonkamer de gordijnen dicht?"
     intent:
       name: HassGetState
       slots:

--- a/tests/nl/homeassistant_HassStartTimer.yaml
+++ b/tests/nl/homeassistant_HassStartTimer.yaml
@@ -160,6 +160,6 @@ tests:
       slots:
         minutes: 5
         conversation_command:
-          - "open de garagedeur"
-          - "de garagedeur openen"
+          - "open garagedeur"
+          - "garagedeur openen"
     response: Opdracht wordt uitgevoerd over 5 minuten


### PR DESCRIPTION
Adds `de` and `het` to skip list, which reduces the total possible sentence options from roughly 17 billion to roughly 380 million.

Will potentially give issues if articles are used in the name, eg `lamp in de hoek` (light in the corner)
Not stripping skip_words from names would prevent this issue.

More improvements could be made by adding words like `mijn` or `m'n` (my).