### PR TITLE
[Various languages] Fix AM/PM for times with hour of 12

### DIFF
--- a/responses/ar/HassGetCurrentTime.yaml
+++ b/responses/ar/HassGetCurrentTime.yaml
@@ -5,8 +5,12 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour < 12: %}
+        {% if slots.time.hour == 0: %}
+        12:{{ minute_str }} صباحا
+        {% elif slots.time.hour < 12: %}
         {{ slots.time.hour }}:{{ minute_str }} صباحا
+        {% elif slots.time.hour == 12: %}
+        12:{{ minute_str }} مساءا
         {% else: %}
         {{ slots.time.hour - 12 }}:{{ minute_str }} مساءا
         {% endif %}

--- a/responses/ar/HassGetCurrentTime.yaml
+++ b/responses/ar/HassGetCurrentTime.yaml
@@ -5,7 +5,7 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour <= 12: %}
+        {% if slots.time.hour < 12: %}
         {{ slots.time.hour }}:{{ minute_str }} صباحا
         {% else: %}
         {{ slots.time.hour - 12 }}:{{ minute_str }} مساءا

--- a/responses/en/HassGetCurrentTime.yaml
+++ b/responses/en/HassGetCurrentTime.yaml
@@ -5,8 +5,12 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour < 12: %}
+        {% if slots.time.hour == 0: %}
+        12:{{ minute_str }} AM
+        {% elif slots.time.hour < 12: %}
         {{ slots.time.hour }}:{{ minute_str }} AM
+        {% elif slots.time.hour == 12: %}
+        12:{{ minute_str }} PM
         {% else: %}
         {{ slots.time.hour - 12 }}:{{ minute_str }} PM
         {% endif %}

--- a/responses/en/HassGetCurrentTime.yaml
+++ b/responses/en/HassGetCurrentTime.yaml
@@ -5,7 +5,7 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour <= 12: %}
+        {% if slots.time.hour < 12: %}
         {{ slots.time.hour }}:{{ minute_str }} AM
         {% else: %}
         {{ slots.time.hour - 12 }}:{{ minute_str }} PM

--- a/responses/he/HassGetCurrentTime.yaml
+++ b/responses/he/HassGetCurrentTime.yaml
@@ -5,8 +5,12 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour < 12: %}
+        {% if slots.time.hour == 0: %}
+        12:{{ minute_str }} לפנות בוקר
+        {% elif slots.time.hour < 12: %}
         {{ slots.time.hour }}:{{ minute_str }} לפנות בוקר
+        {% elif slots.time.hour == 12: %}
+        12:{{ minute_str }} אחרי הצהריים
         {% else: %}
         {{ slots.time.hour - 12 }}:{{ minute_str }} אחרי הצהריים
         {% endif %}

--- a/responses/he/HassGetCurrentTime.yaml
+++ b/responses/he/HassGetCurrentTime.yaml
@@ -5,7 +5,7 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour <= 12: %}
+        {% if slots.time.hour < 12: %}
         {{ slots.time.hour }}:{{ minute_str }} לפנות בוקר
         {% else: %}
         {{ slots.time.hour - 12 }}:{{ minute_str }} אחרי הצהריים

--- a/responses/th/HassGetCurrentTime.yaml
+++ b/responses/th/HassGetCurrentTime.yaml
@@ -4,7 +4,14 @@ responses:
     HassGetCurrentTime:
       default: "TODO: {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour < 12: %} {{ slots.time.hour }}:{{ minute_str }} AM
-        {% else: %} {{ slots.time.hour - 12 }}:{{ minute_str }} PM {% endif %}
+        {% if slots.time.hour == 0: %}
+        12:{{ minute_str }} AM
+        {% elif slots.time.hour < 12: %}
+        {{ slots.time.hour }}:{{ minute_str }} AM
+        {% elif slots.time.hour == 12: %}
+        12:{{ minute_str }} PM
+        {% else: %}
+        {{ slots.time.hour - 12 }}:{{ minute_str }} PM
+        {% endif %}
 
         "

--- a/responses/th/HassGetCurrentTime.yaml
+++ b/responses/th/HassGetCurrentTime.yaml
@@ -4,7 +4,7 @@ responses:
     HassGetCurrentTime:
       default: "TODO: {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour <= 12: %} {{ slots.time.hour }}:{{ minute_str }} AM
+        {% if slots.time.hour < 12: %} {{ slots.time.hour }}:{{ minute_str }} AM
         {% else: %} {{ slots.time.hour - 12 }}:{{ minute_str }} PM {% endif %}
 
         "

--- a/responses/zh-cn/HassGetCurrentTime.yaml
+++ b/responses/zh-cn/HassGetCurrentTime.yaml
@@ -5,7 +5,7 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour <= 12: %}
+        {% if slots.time.hour < 12: %}
         上午{{ slots.time.hour }}点{{ minute_str }}分
         {% else: %}
         下午{{ slots.time.hour - 12 }}点{ minute_str }}分

--- a/responses/zh-cn/HassGetCurrentTime.yaml
+++ b/responses/zh-cn/HassGetCurrentTime.yaml
@@ -5,8 +5,12 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour < 12: %}
+        {% if slots.time.hour == 0: %}
+        上午12点{{ minute_str }}分
+        {% elif slots.time.hour < 12: %}
         上午{{ slots.time.hour }}点{{ minute_str }}分
+        {% elif slots.time.hour == 12: %}
+        下午12点{{ minute_str }}分
         {% else: %}
-        下午{{ slots.time.hour - 12 }}点{ minute_str }}分
+        下午{{ slots.time.hour - 12 }}点{{ minute_str }}分
         {% endif %}

--- a/responses/zh-hk/HassGetCurrentTime.yaml
+++ b/responses/zh-hk/HassGetCurrentTime.yaml
@@ -5,7 +5,7 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour <= 12: %}
+        {% if slots.time.hour < 12: %}
         上晝 {{ slots.time.hour }}點{{ minute_str }}分
         {% else: %}
         下晝 {{ slots.time.hour - 12 }}點{{ minute_str }}分

--- a/responses/zh-hk/HassGetCurrentTime.yaml
+++ b/responses/zh-hk/HassGetCurrentTime.yaml
@@ -5,8 +5,12 @@ responses:
       default: >
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
 
-        {% if slots.time.hour < 12: %}
+        {% if slots.time.hour == 0: %}
+        上晝 12點{{ minute_str }}分
+        {% elif slots.time.hour < 12: %}
         上晝 {{ slots.time.hour }}點{{ minute_str }}分
+        {% elif slots.time.hour == 12: %}
+        下晝 12點{{ minute_str }}分
         {% else: %}
         下晝 {{ slots.time.hour - 12 }}點{{ minute_str }}分
         {% endif %}


### PR DESCRIPTION
**What**
Change condition for when to use AM vs PM

**Why**
Currently a time of 12:xx is given suffix of AM which is incorrect. 00:xx is AM, 12:xx is PM.