### PR TITLE
[EN] Update homeassistant_HassStartTimer.yaml

### DIFF
--- a/sentences/en/homeassistant_HassStartTimer.yaml
+++ b/sentences/en/homeassistant_HassStartTimer.yaml
@@ -12,6 +12,7 @@ intents:
           - "<timer_set> [a|an|the|my] <timer_duration> timer (named|called|for) {timer_name:name}"
           - "<timer_set> [a|an|the|my] <timer_duration> timer"
           - "<timer_set> [a|the|my] timer (named|called) {timer_name:name} for <timer_duration>"
+          - "<timer_set> [a|the|my] {timer_name:name} timer for <timer_duration>"
           - "<timer_set> [a|the|my] timer for <timer_duration> (named|called) {timer_name:name}"
       - sentences:
           - "{timer_command:conversation_command} in <timer_duration>"


### PR DESCRIPTION
Added a wording to start a named timer with "start a pasta timer for 5 minutes"