### PR TITLE
[EN] Match articles "a" and "an" for <the>

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -357,7 +357,7 @@ lists:
     wildcard: true
 
 expansion_rules:
-  the: "(the|my|our)"
+  the: "(a[n]|the|my|our)"
   name: "[<the>] {name}"
   area: "[<the>] {area}"
   floor: "[<the>] {floor} [floor]"


### PR DESCRIPTION
Whisper (for me) seems to always put article `a` after vacuum commands `start` or `return`.
Someone might also actually say it this way so let's handle that.