### PR TITLE
intents: improved description of HassClimateGetTemperature

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -746,7 +746,7 @@ HassClimateSetTemperature:
 HassClimateGetTemperature:
   supported: true
   domain: climate
-  description: "Gets the indoor temperature"
+  description: "Gets the actual indoor temperature (not the desired indoor temperature as set by HassClimateSetTemperature)"
   slots:
     name:
       description: "Name of a device or entity"


### PR DESCRIPTION
The climate intents `HassClimateGetTemperature` and `HassClimateSetTemperature` are not about the same temperature. One is about the *actual* temperature, the other is about the *desired* temperature. 
Description of `HassClimateGetTemperature` is extended to make this explicit to prevent confusion.