### PR TITLE
[NL] scene and script: add sentence structures

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -659,6 +659,7 @@ expansion_rules:
   area: "[de|het] {area}"
   floor: "[de|het] {floor}"
   in: "[in|op|van|bij]"
+  aan: "(in|aan)"
   by: "(door|met|bij)"
   here: "(hier|in deze (kamer|ruimte))"
   name_area: >
@@ -673,7 +674,10 @@ expansion_rules:
       |[<in> [<area>]] [<by>] <name>
       |[<by>] <name> [<in>] <area>
     )
-  change: "(zet|mag|mogen|doe|verander|maak|schakel)"
+  # conjugated verb
+  change: "(zet|mag|mogen|doe|verander|maak|schakel|activeer|start)"
+  # infinitive verb
+  start: "(aan[ ](zetten|doen)|inschakelen|starten|activeren)"
   would: "(kan|kun|wil) (je|jij)"
   to: "(naar|op)"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"

--- a/sentences/nl/scene_HassTurnOn.yaml
+++ b/sentences/nl/scene_HassTurnOn.yaml
@@ -2,10 +2,46 @@ language: nl
 intents:
   HassTurnOn:
     data:
+      # scene named after a modus/state (e.g. party mode); without area
       - sentences:
-          - "(activeer|start|schakel) [scene|scène] <name>[ ][scene|scène] [<to>] [in]"
-          - "[<change>] [scene|scène] <name>[ ][scene|scène] [<to>] (aan|in)"
-          - "[<would>] (<name>[ ][scene|scène]|[scene|scène] <name>) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
+          # commands
+          - "[<change>] [scene|scène] <name>[ ][scene|scène] [<to>] [<aan>]"
+          - "[scene|scène] <name>[ ][scene|scène] <start>"
+          # requests
+          - "[<would>] (<name>[ ][scene|scène]|[scene|scène] <name>) [<to>] <start>"
+        requires_context:
+          domain: scene
+        slots:
+          domain: scene
+        response: scene
+
+      # scene named after a modus/state (e.g. party mode); with area
+      - sentences:
+          # commands
+          - "[<change>] ([scene|scène] <name>[ ][scene|scène] [<to>] [<aan>];[<in>] (<area>|<floor>))"
+          - "[scene|scène] <name>[ ][scene|scène] <start> [<in>] (<area>|<floor>)"
+          - "[scene|scène] <name>[ ][scene|scène] [<in>] (<area>|<floor>) <start>"
+          - "[<in>] (<area>|<floor>) [scene|scène] <name>[ ][scene|scène] <start>"
+          # requests
+          - "[<would>] ((<name>[ ][scene|scène]|[scene|scène] <name>) [<to>] <start>;[<in>] (<area>|<floor>))"
+        requires_context:
+          domain: scene
+        slots:
+          domain: scene
+        response: scene
+
+      # scene named after an activity (e.g. watch television); without area
+      - sentences:
+          - "[ik ga|ik wil|we gaan|wij gaan|we willen|wij willen] <name>"
+        requires_context:
+          domain: scene
+        slots:
+          domain: scene
+        response: scene
+
+      # scene named after an activity (e.g. watch television); with area
+      - sentences:
+          - "[ik ga|ik wil|we gaan|wij gaan|we willen|wij willen] (<name>;[<in>] (<area>|<floor>))"
         requires_context:
           domain: scene
         slots:

--- a/sentences/nl/script_HassTurnOn.yaml
+++ b/sentences/nl/script_HassTurnOn.yaml
@@ -2,10 +2,46 @@ language: nl
 intents:
   HassTurnOn:
     data:
+      # script named after a modus/state (e.g. party mode); without area
       - sentences:
-          - "(activeer|start|schakel) ([script] <name>|<name>[ ][script]) [<to>] [in]"
-          - "[<change>] ([script] <name>|<name>[ ][script]) [<to>] (aan|in)"
-          - "[<would>] ([script] <name>|<name>[ ][script]) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
+          # commands
+          - "[<change>] [script] <name>[ ][script] [<to>] [<aan>]"
+          - "[script] <name>[ ][script] <start>"
+          # requests
+          - "[<would>] (<name>[ ][script]|[script] <name>) [<to>] <start>"
+        requires_context:
+          domain: script
+        slots:
+          domain: script
+        response: script
+
+      # script named after a modus/state (e.g. party mode); with area
+      - sentences:
+          # commands
+          - "[<change>] ([script] <name>[ ][script] [<to>] [<aan>];[<in>] (<area>|<floor>))"
+          - "[script] <name>[ ][script] <start> [<in>] (<area>|<floor>)"
+          - "[script] <name>[ ][script] [<in>] (<area>|<floor>) <start>"
+          - "[<in>] (<area>|<floor>) [script] <name>[ ][script] <start>"
+          # requests
+          - "[<would>] ((<name>[ ][script]|[script] <name>) [<to>] <start>;[<in>] (<area>|<floor>))"
+        requires_context:
+          domain: script
+        slots:
+          domain: script
+        response: script
+
+      # script named after an activity (e.g. 'sleep' or 'watch television'); without area
+      - sentences:
+          - "[ik ga|ik wil|we gaan|wij gaan|we willen|wij willen] <name>"
+        requires_context:
+          domain: script
+        slots:
+          domain: script
+        response: script
+
+      # script named after an activity (e.g. 'sleep' or 'watch television'); with area
+      - sentences:
+          - "[ik ga|ik wil|we gaan|wij gaan|we willen|wij willen] (<name>;[<in>] (<area>|<floor>))"
         requires_context:
           domain: script
         slots:

--- a/tests/nl/_fixtures.yaml
+++ b/tests/nl/_fixtures.yaml
@@ -167,11 +167,21 @@ entities:
     attributes:
       unit_of_measurement: "°C"
 
+  # scene named after a state/mode
   - name: "Feestmodus"
     id: "scene.party_mode"
 
+  # scene named after an activity
+  - name: "Televisie kijken"
+    id: "scene.watch_tv"
+
+  # script named after a state/mode
   - name: "Stealthmodus"
     id: "script.stealth_mode"
+
+  # script named after an activity
+  - name: "Slapen"
+    id: "script.sleep"
 
   - name: "Voordeur"
     id: "lock.front_door"

--- a/tests/nl/scene_HassTurnOn.yaml
+++ b/tests/nl/scene_HassTurnOn.yaml
@@ -1,17 +1,90 @@
 language: nl
 tests:
+  # scene named after a mode/status; no area
   - sentences:
-      - "Zet feestmodus aan"
-      - "Activeer feestmodus"
-      - "Start feestmodus"
+      # commands
+      - "Feestmodus"
       - "Feestmodus aan"
+      - "Feestmodus scene"
+      - "Feestmodus scene aan"
+      - "Zet feestmodus aan"
+      - "Scene feestmodus aan zetten"
+      - "Doe feestmodus aan"
+      - "Activeer feestmodus"
+      - "Feestmodusscène activeren"
+      - "Feestmodus activeren"
+      - "Start feestmodus"
+      - "Schakel feestmodus in"
+      - "Schakel de feestmodus in"
+      # requests
       - "wil je feestmodus aan zetten"
-      - "feestmodusscène activeren"
-      - "scene feestmodus aan zetten"
       - "kun je feestmodus aanzetten"
     intent:
       name: HassTurnOn
       slots:
         domain: scene
         name: "Feestmodus"
+    response: "Geactiveerd"
+
+  # scene named after a mode/status; with area
+  - sentences:
+      # commands
+      - "Feestmodus in de woonkamer"
+      - "Feestmodus aan in de woonkamer"
+      - "In de woonkamer feestmodus aan"
+      - "Feestmodus scene in de woonkamer"
+      - "Feestmodus scene aan in de woonkamer"
+      - "In de woonkamer feestmodus scene aan"
+      - "Zet feestmodus aan in de woonkamer"
+      - "Zet in de woonkamer de feestmodus aan"
+      - "Scene feestmodus aan zetten in de woonkamer"
+      - "In de woonkamer scene feestmodus aan zetten"
+      - "Doe feestmodus aan in de woonkamer"
+      - "Doe in de woonkamer de feestmodus aan"
+      - "Activeer feestmodus in de woonkamer"
+      - "Activeer in de woonkamer de feestmodus"
+      - "Feestmodus activeren in de woonkamer"
+      - "In de woonkamer feestmodus activeren"
+      - "Feestmodus in de woonkamer activeren"
+      - "Start feestmodus in de woonkamer"
+      - "Start in de woonkamer de feestmodus"
+      - "Schakel feestmodus in in de woonkamer"
+      - "Schakel de feestmodus in in de woonkamer"
+      - "Schakel in de woonkamer feestmodus in"
+      # requests
+      - "wil je feestmodus aan zetten in de woonkamer"
+      - "kun je feestmodus aanzetten in de woonkamer"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: scene
+        area: Woonkamer
+        name: "Feestmodus"
+    response: "Geactiveerd"
+
+  # scene named after an activity; without area
+  - sentences:
+      - "ik wil televisie kijken"
+      - "ik ga televisie kijken"
+      - "we willen televisie kijken"
+      - "wij gaan televisie kijken"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: scene
+        name: "Televisie kijken"
+    response: "Geactiveerd"
+
+  # scene named after an activity; with area
+  - sentences:
+      - "ik wil televisie kijken in de woonkamer"
+      - "ik ga in de woonkamer televisie kijken"
+      - "we willen televisie kijken in de woonkamer"
+      - "wij gaan in de woonkamer televisie kijken"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: scene
+        area: Woonkamer
+        name: "Televisie kijken"
     response: "Geactiveerd"

--- a/tests/nl/script_HassTurnOn.yaml
+++ b/tests/nl/script_HassTurnOn.yaml
@@ -1,17 +1,90 @@
 language: nl
 tests:
+  # script named after a mode/status (e.g. stealth mode); no area
   - sentences:
-      - "Zet Stealthmodus aan"
-      - "Activeer Stealthmodus"
-      - "Start Stealthmodus"
+      # commands
+      - "Stealthmodus"
       - "Stealthmodus aan"
-      - "kun je stealthmodus aan zetten"
-      - "stealthmodusscript activeren"
-      - "script stealthmodus aan zetten"
-      - "wil je stealthmodus aandoen"
+      - "Stealthmodus script"
+      - "Stealthmodus script aan"
+      - "Zet stealthmodus aan"
+      - "Script stealthmodus aan zetten"
+      - "Doe stealthmodus aan"
+      - "Activeer stealthmodus"
+      - "Stealthmodusscript activeren"
+      - "Stealthmodus activeren"
+      - "Start stealthmodus"
+      - "Schakel stealthmodus in"
+      - "Schakel de stealthmodus in"
+      # requests
+      - "wil je stealthmodus aan zetten"
+      - "kun je stealthmodus aanzetten"
     intent:
       name: HassTurnOn
       slots:
         domain: script
         name: "Stealthmodus"
+    response: "Gestart"
+
+  # script named after a mode/status (e.g.stealth mode); with area
+  - sentences:
+      # commands
+      - "Stealthmodus in de woonkamer"
+      - "Stealthmodus aan in de woonkamer"
+      - "In de woonkamer stealthmodus aan"
+      - "Stealthmodus script in de woonkamer"
+      - "Stealthmodus script aan in de woonkamer"
+      - "In de woonkamer stealthmodus script aan"
+      - "Zet stealthmodus aan in de woonkamer"
+      - "Zet in de woonkamer de stealthmodus aan"
+      - "Script stealthmodus aan zetten in de woonkamer"
+      - "In de woonkamer script stealthmodus aan zetten"
+      - "Doe stealthmodus aan in de woonkamer"
+      - "Doe in de woonkamer de stealthmodus aan"
+      - "Activeer stealthmodus in de woonkamer"
+      - "Activeer in de woonkamer de stealthmodus"
+      - "Stealthmodus activeren in de woonkamer"
+      - "In de woonkamer stealthmodus activeren"
+      - "Stealthmodus in de woonkamer activeren"
+      - "Start stealthmodus in de woonkamer"
+      - "Start in de woonkamer de stealthmodus"
+      - "Schakel stealthmodus in in de woonkamer"
+      - "Schakel de stealthmodus in in de woonkamer"
+      - "Schakel in de woonkamer stealthmodus in"
+      # requests
+      - "wil je stealthmodus aan zetten in de woonkamer"
+      - "kun je stealthmodus aanzetten in de woonkamer"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: script
+        area: Woonkamer
+        name: "Stealthmodus"
+    response: "Gestart"
+
+  # script named after an activity (e.g. 'sleep' or 'watch tv'); without area
+  - sentences:
+      - "ik wil slapen"
+      - "ik ga slapen"
+      - "we willen slapen"
+      - "wij gaan slapen"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: script
+        name: "Slapen"
+    response: "Gestart"
+
+  # script named after an activity (e.g. 'sleep' or 'watch tv'); with area
+  - sentences:
+      - "ik wil slapen in de slaapkamer"
+      - "ik ga in de slaapkamer slapen"
+      - "we willen slapen in de slaapkamer"
+      - "wij gaan in de slaapkamer slapen"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: script
+        area: Slaapkamer
+        name: "Slapen"
     response: "Gestart"


### PR DESCRIPTION
* add sentence structure more suitable for scenes/scripts named after an activity (the existing sentence structure are suitable for scenes/scripts named after a mode/state)
* move several activation verbs from scene/script specific files to common