### PR TITLE
Fix "ligar" command to work with other devices

### DIFF
--- a/sentences/pt-br/homeassistant_HassTurnOn.yaml
+++ b/sentences/pt-br/homeassistant_HassTurnOn.yaml
@@ -13,4 +13,3 @@ intents:
             - script
             - sensor
             - valve
-            - vacuum

--- a/sentences/pt/homeassistant_HassTurnOn.yaml
+++ b/sentences/pt/homeassistant_HassTurnOn.yaml
@@ -12,4 +12,3 @@ intents:
             - scene
             - script
             - sensor
-            - vacuum


### PR DESCRIPTION
Remove domain vacuum from turnOn intent, since it already has its own intent.

This was done according the discussion https://community.home-assistant.io/t/problem-with-multipart-aliases-for-a-device-in-portuguese/901819/3
