### PR TITLE
Add possibility to start Timer only by telling assist the required duration

### DIFF
--- a/sentences/de/homeassistant_HassStartTimer.yaml
+++ b/sentences/de/homeassistant_HassStartTimer.yaml
@@ -3,7 +3,7 @@ intents:
   HassStartTimer:
     data:
       - sentences:
-          - "<timer_duration> Timer"
+          - "<timer_duration>[ Timer][ für {timer_name:name}]"
           - "Timer[ (auf|für)] <timer_duration>"
           - "<timer_duration> Timer für {timer_name:name}"
           - "Timer[ (auf|für)] <timer_duration> (namens|für) {timer_name:name}"

--- a/tests/de/homeassistant_HassStartTimer.yaml
+++ b/tests/de/homeassistant_HassStartTimer.yaml
@@ -12,6 +12,7 @@ tests:
       - "Timer auf 2 Stunden"
       - "Timer für 2 Stunden"
       - "Timer 2 Stunden"
+      - "2 Stunden"
     intent:
       name: HassStartTimer
       slots:
@@ -42,6 +43,7 @@ tests:
       - "Timer für 1 Stunde und 15 Minuten"
       - "Setze Timer für 1 Stunde und 15 Minuten"
       - "Timer 1 Stunde 15 Minuten"
+      - "1 Stunde 15 Minuten"
     intent:
       name: HassStartTimer
       context:
@@ -55,6 +57,7 @@ tests:
       - "Starte einen 1 Stunde und 30 Sekunden Timer"
       - "Timer für 1 Stunde und 30 Sekunden"
       - "Setze Timer für 1 Stunde und 30 Sekunden"
+      - "1 Stunde und 30 Sekunden"
     intent:
       name: HassStartTimer
       context:
@@ -68,6 +71,7 @@ tests:
       - "Starte einen 1 Stunde 15 Minuten und 30 Sekunden timer"
       - "1 Stunde 15 Minuten 30 Sekunden Timer"
       - "Stelle Timer für 1 Stunde, 15 Minuten und 30 Sekunden"
+      - "1 Stunde 15 Minuten und 30 Sekunden"
     intent:
       name: HassStartTimer
       context:
@@ -105,6 +109,7 @@ tests:
       - "Stelle einen Pizza Timer für 5 Minuten"
       - "Stelle Pizza Timer auf 5 Minuten"
       - "Stelle Pizza Timer für 5 Minuten"
+      - "5 Minuten für Pizza"
     intent:
       name: HassStartTimer
       context:
@@ -119,6 +124,7 @@ tests:
       - "Starte einen 5 Minuten und 10 Sekunden Timer"
       - "Timer für 5 Minuten und 10 Sekunden"
       - "5 Minuten 10 Sekunden Timer"
+      - "5 Minuten 10 Sekunden"
     intent:
       name: HassStartTimer
       context:
@@ -133,6 +139,7 @@ tests:
       - "Timer für 45 Sekunden"
       - "45 Sekunden Timer"
       - "Timer 45 Sekunden"
+      - "45 Sekunden"
     intent:
       name: HassStartTimer
       context:


### PR DESCRIPTION
I added the possibility to start Timers by only telling assist the required duration of the timer.
Since I was not sure whether something like "5 Minuten" (which I use on a regular basis) would be enough to assign the command globally to the timer-controls-category I put this one in an extra pull request.