### PR TITLE
[DE] Reduce overall sentence count by optimizing <irgend> expansion rule

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -586,7 +586,7 @@ expansion_rules:
   szene: "[die ]Szene"
   skript: "[das ]Skript"
   batterie: "[(der|des) ](Batterie[n]|Akku[s])"
-  irgend: "(irgend(<artikel_unbestimmt>[s]|welche[s]|wo)|(einige|manche)[s]|<artikel_unbestimmt>[s]) <artikel_bestimmt>"
+  irgend: "(irgend(ein[s]|eine[s]|einer|einem|einen)[ der]|(irgendwelche[s][ (der|die|des)])|(irgendwo|einige[s]|manche[s]|ein[s]|eine[s]|einer|einem|einen) <artikel_bestimmt>)"
   etwas: "[irgend][et]was"
   welche: "(welche[r|s|n]|was für[ <artikel_unbestimmt>[s]]) <artikel_bestimmt>"
   wieviel: "(wie[ ]viel[e]|welche Anzahl[ (an|von)])"


### PR DESCRIPTION
This PR reduces overall sentence count by ~ 12 million by optimizing the <irgend> expansion rule without losing tested sentences.
In general unnecessary permutations like

- s
- einems dem
- einers der
- einess dem
- irgendeinems 

etc. are removed.