### PR TITLE
[DE] Reduce overall sentence count by optimizing <floor> expansion rule

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -545,7 +545,7 @@ expansion_rules:
   artikel: "[<artikel_bestimmt>|<artikel_unbestimmt>]"
   name: "<artikel_bestimmt> {name}"
   area: "[([(in|an|auf|bei) ][<artikel_bestimmt> ]|(im|am|<von_dem>) )]{area}[s]"
-  floor: "[in|auf][ (<artikel_bestimmt>|im|<von_dem>)] {floor}[ Geschoss]"
+  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>) ]{floor}[ Geschoss]"
   area_floor: "(<area>|<floor>)"
   an: "(an|ein|auf)"
   aus: "(aus|ab|zu)"


### PR DESCRIPTION
This PR reduces overall sentence count by ~ 6 million by optimizing the expansion rule without losing tested sentences.
In general unnecessary permutations like

- auf vom FLOOR
- in im FLOOR

etc. are removed.
