### PR TITLE
[DE] Reduce permutations for Light HassTurnOn/Off

### DIFF
--- a/sentences/de/light_HassTurnOff.yaml
+++ b/sentences/de/light_HassTurnOff.yaml
@@ -9,9 +9,7 @@ intents:
           - "(<licht>|<lichter>|<alle_lichter>) ((aus|ab)[schalten]|ausmachen) <area>"
           - "<area> (<licht>|<lichter>|<alle_lichter>) ((aus|ab)[schalten]|ausmachen)"
           - "(<schalten>|<machen>) <alle_lichter> (aus|ab)"
-          #- "(<schalten>|<machen>) <area> <alle_lichter> <aus>"
           - "<alle_lichter> ((aus|ab)[schalten]|ausmachen)"
-          #- "<area> <alle_lichter> (<aus>[schalten]|ausmachen)"
         response: "light"
         slots:
           domain: "light"

--- a/sentences/de/light_HassTurnOff.yaml
+++ b/sentences/de/light_HassTurnOff.yaml
@@ -3,25 +3,25 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <area> <aus>"
-          - "(<schalten>|<machen>) <area> (<licht>|<lichter>|<alle_lichter>) <aus>"
-          - "(<licht>|<lichter>|<alle_lichter>) <area> (<aus>[schalten]|ausmachen)"
-          - "(<licht>|<lichter>|<alle_lichter>) (<aus>[schalten]|ausmachen) <area>"
-          - "<area> (<licht>|<lichter>|<alle_lichter>) (<aus>[schalten]|ausmachen)"
-          - "(<schalten>|<machen>) <alle_lichter>[ <area>] <aus>"
-          - "(<schalten>|<machen>) <area> <alle_lichter> <aus>"
-          - "<alle_lichter>[ <area>] (<aus>[schalten]|ausmachen)"
-          - "<area> <alle_lichter> (<aus>[schalten]|ausmachen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <area> (aus|ab)"
+          - "(<schalten>|<machen>) <area> (<licht>|<lichter>|<alle_lichter>) (aus|ab)"
+          - "(<licht>|<lichter>|<alle_lichter>) <area> ((aus|ab)[schalten]|ausmachen)"
+          - "(<licht>|<lichter>|<alle_lichter>) ((aus|ab)[schalten]|ausmachen) <area>"
+          - "<area> (<licht>|<lichter>|<alle_lichter>) ((aus|ab)[schalten]|ausmachen)"
+          - "(<schalten>|<machen>) <alle_lichter> (aus|ab)"
+          #- "(<schalten>|<machen>) <area> <alle_lichter> <aus>"
+          - "<alle_lichter> ((aus|ab)[schalten]|ausmachen)"
+          #- "<area> <alle_lichter> (<aus>[schalten]|ausmachen)"
         response: "light"
         slots:
           domain: "light"
 
       # Turn off all lights in the same area as a satellite device
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>)[ hier] <aus>"
-          - "(<schalten>|<machen>) hier (<licht>|<lichter>) <aus>"
-          - "(<licht>|<lichter>)[ hier] (<aus>[schalten]|ausmachen)"
-          - "hier (<licht>|<lichter>) (<aus>[schalten]|ausmachen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>)[ hier] (aus|ab)"
+          - "(<schalten>|<machen>) hier (<licht>|<lichter>) (aus|ab)"
+          - "(<licht>|<lichter>)[ hier] ((aus|ab)[schalten]|ausmachen)"
+          - "hier (<licht>|<lichter>) ((aus|ab)[schalten]|ausmachen)"
         response: "light"
         slots:
           domain: "light"
@@ -31,11 +31,11 @@ intents:
 
       # Turn off all lights on a floor
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <floor> <aus>"
-          - "(<schalten>|<machen>) <floor> (<licht>|<lichter>|<alle_lichter>) <aus>"
-          - "(<licht>|<lichter>|<alle_lichter>) <floor> (<aus>[schalten]|ausmachen)"
-          - "(<licht>|<lichter>|<alle_lichter>) (<aus>[schalten]|ausmachen) <floor>"
-          - "<floor> (<licht>|<lichter>|<alle_lichter>) (<aus>[schalten]|ausmachen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <floor> (aus|ab)"
+          - "(<schalten>|<machen>) <floor> (<licht>|<lichter>|<alle_lichter>) (aus|ab)"
+          - "(<licht>|<lichter>|<alle_lichter>) <floor> ((aus|ab)[schalten]|ausmachen)"
+          - "(<licht>|<lichter>|<alle_lichter>) ((aus|ab)[schalten]|ausmachen) <floor>"
+          - "<floor> (<licht>|<lichter>|<alle_lichter>) ((aus|ab)[schalten]|ausmachen)"
         response: "light"
         slots:
           domain: "light"

--- a/sentences/de/light_HassTurnOn.yaml
+++ b/sentences/de/light_HassTurnOn.yaml
@@ -3,16 +3,13 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <area> <an>"
-          - "(<schalten>|<machen>) <area> (<licht>|<lichter>|<alle_lichter>) <an>"
-          - "(<licht>|<lichter>|<alle_lichter>) <area> (<an>[schalten]|anmachen)"
-          - "(<licht>|<lichter>|<alle_lichter>) (<an>[schalten]|anmachen) <area>"
-          - "<area> (<licht>|<lichter>|<alle_lichter>) (<an>[schalten]|anmachen)"
-
-          - "(<schalten>|<machen>) <alle_lichter>[ <area>] <an>"
-          - "(<schalten>|<machen>) <area> <alle_lichter> <an>"
-          - "<alle_lichter>[ <area>] (<an>[schalten]|anmachen)"
-          - "<area> <alle_lichter> (<an>[schalten]|anmachen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <area> (an|ein)"
+          - "(<schalten>|<machen>) <area> (<licht>|<lichter>|<alle_lichter>) (an|ein)"
+          - "(<licht>|<lichter>|<alle_lichter>) <area> ((an|ein)[schalten]|anmachen)"
+          - "(<licht>|<lichter>|<alle_lichter>) ((an|ein)[schalten]|anmachen) <area>"
+          - "<area> (<licht>|<lichter>|<alle_lichter>) ((an|ein)[schalten]|anmachen)"
+          - "(<schalten>|<machen>) <alle_lichter> (an|ein)"
+          - "<alle_lichter> ((an|ein)[schalten]|anmachen)"
 
         response: "light"
         slots:
@@ -20,10 +17,10 @@ intents:
 
       # Turn on all lights in the same area as a satellite device
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>)[ hier] <an>"
-          - "(<schalten>|<machen>) hier (<licht>|<lichter>) <an>"
-          - "(<licht>|<lichter>)[ hier] (<an>[schalten]|anmachen)"
-          - "hier (<licht>|<lichter>) (<an>[schalten]|anmachen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>)[ hier] (an|ein)"
+          - "(<schalten>|<machen>) hier (<licht>|<lichter>) (an|ein)"
+          - "(<licht>|<lichter>)[ hier] ((an|ein)[schalten]|anmachen)"
+          - "hier (<licht>|<lichter>) ((an|ein)[schalten]|anmachen)"
         response: "light"
         slots:
           domain: "light"
@@ -33,11 +30,11 @@ intents:
 
       # Turn on all lights on a floor
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <floor> <an>"
-          - "(<schalten>|<machen>) <floor> (<licht>|<lichter>|<alle_lichter>) <an>"
-          - "(<licht>|<lichter>|<alle_lichter>) <floor> (<an>[schalten]|anmachen)"
-          - "(<licht>|<lichter>|<alle_lichter>) (<an>[schalten]|anmachen) <floor>"
-          - "<floor> (<licht>|<lichter>|<alle_lichter>) (<an>[schalten]|anmachen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <floor> (an|ein)"
+          - "(<schalten>|<machen>) <floor> (<licht>|<lichter>|<alle_lichter>) (an|ein)"
+          - "(<licht>|<lichter>|<alle_lichter>) <floor> ((an|ein)[schalten]|anmachen)"
+          - "(<licht>|<lichter>|<alle_lichter>) ((an|ein)[schalten]|anmachen) <floor>"
+          - "<floor> (<licht>|<lichter>|<alle_lichter>) ((an|ein)[schalten]|anmachen)"
         response: "light"
         slots:
           domain: "light"


### PR DESCRIPTION
This PR reduces unnecessary permutations of Light HassTurnOn/HassTurnOff by ~12 million.
I mainly adressed the <an> and <aus> expansion rules and removed complete sentences covered by others.