### PR TITLE
[DE] remove "Garagentore" from <alle_tore>

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -569,7 +569,7 @@ expansion_rules:
   garage: "([die ]Garage[n]|[das ]Garagentor|[die ]Garagentore)"
   alle_garagen: "<alle> (Garagen[tore])"
   tor: "[(das|die) ]Tor[e]"
-  alle_tore: "<alle> (Tore|Garagentore)"
+  alle_tore: "<alle> Tore"
   luefter: "[(der|die|den) ](Ventilator[en]|Lüfter)"
   alle_luefter: "<alle> (Ventilatoren|Lüfter)"
   brightness: "{brightness}[ (Prozent|%)]"


### PR DESCRIPTION
...since this is covered by `<alle_garagen>` and there is currently no usage of `<alle_tore>` where `<alle_garagen>` is not used in the same context.
-1.2 million 😉