### PR TITLE
[DE] ClimateSetTemperature: Add support for floor, satellite area and cooling commands

### DIFF
--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -36,19 +36,15 @@ intents:
           - "<heizung> <local_hier> auf <temperature>[ <setzen_end_of_sentence>]"
           - "<heizung> auf <temperature> <local_hier>[ <setzen_end_of_sentence>]"
           - "<heizung> auf <temperature> <setzen_end_of_sentence> <local_hier>"
-
           - "[<local_hier> ]auf <temperature> [be]heizen"
           - "auf <temperature> [be]heizen <local_hier>"
-
           - "<setzen>[ <local_hier>] <heizung> auf <temperature>"
           - "<setzen> <heizung> <local_hier> auf <temperature>"
           - "<setzen> <heizung> auf <temperature> <local_hier>"
-
           - "<stelle>[ <local_hier>] <heizung> auf <temperature> ein"
           - "<stelle> <heizung> <local_hier> auf <temperature> ein"
           - "<stelle> <heizung> auf <temperature> <local_hier> ein"
           - "<stelle> <heizung> auf <temperature> ein <local_hier>"
-
           - "[<local_hier> ]<temperature>"
           - "<temperature> <local_hier>"
         requires_context:

--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -15,8 +15,8 @@ intents:
       # by area / floor
       - sentences:
           - "<heizung> <area_floor> auf <temperature>[ <setzen_end_of_sentence>]"
-          - "<area> auf <temperature> [be]heizen"
-          - "[<artikel_bestimmt> ]<floor> auf <temperature> [be]heizen"
+          - "<area> auf <temperature> <heat_cool>"
+          - "[<artikel_bestimmt> ]<floor> auf <temperature> <heat_cool>"
           - "<setzen> <area_floor> <heizung> auf <temperature>"
           - "<stelle> <area_floor> <heizung> auf <temperature> ein"
           - "<setzen> <heizung> <area_floor> auf <temperature>"
@@ -25,10 +25,15 @@ intents:
           - "<stelle> (<area_heizung>|<floor_heizung>) auf <temperature> ein"
           - "(<area_heizung>|<floor_heizung>) auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area_floor> <temperature>"
+          - "heiz[e] <area> auf <temperature>[ auf]"
+          - "heiz[e] [<artikel_bestimmt> ]<floor> auf <temperature>[ auf]"
+          - "kühl[e] <area> auf <temperature>[ (ab|[he]runter)]"
+          - "kühl[e] [<artikel_bestimmt> ]<floor> auf <temperature>[ (ab|[he]runter)]"
         expansion_rules:
           heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
           area_heizung: ([die ]{area}[ ]temperatur|[die ]{area}[ ]heizung|[(das|den) ]{area}[ ]thermostat|[die ]{area}[ ]klima(anlage|tisierung)|[das ]{area}[ ]klima)
           floor_heizung: ([die ]{floor}[ ]temperatur|[die ]{floor}[ ]heizung|[(das|den) ]{floor}[ ]thermostat|[die ]{floor}[ ]klima(anlage|tisierung)|[das ]{floor}[ ]klima)
+          heat_cool: ([be]heizen|[ab|[he]runter]kühlen)
 
       # by satellite area
       - sentences:
@@ -36,8 +41,8 @@ intents:
           - "<heizung> <local_hier> auf <temperature>[ <setzen_end_of_sentence>]"
           - "<heizung> auf <temperature> <local_hier>[ <setzen_end_of_sentence>]"
           - "<heizung> auf <temperature> <setzen_end_of_sentence> <local_hier>"
-          - "[<local_hier> ]auf <temperature> [be]heizen"
-          - "auf <temperature> [be]heizen <local_hier>"
+          - "[<local_hier> ]auf <temperature> <heat_cool>"
+          - "auf <temperature> <heat_cool> <local_hier>"
           - "<setzen>[ <local_hier>] <heizung> auf <temperature>"
           - "<setzen> <heizung> <local_hier> auf <temperature>"
           - "<setzen> <heizung> auf <temperature> <local_hier>"
@@ -47,9 +52,16 @@ intents:
           - "<stelle> <heizung> auf <temperature> ein <local_hier>"
           - "[<local_hier> ]<temperature>"
           - "<temperature> <local_hier>"
+          - "heiz[e][ <local_hier>] auf <temperature>[ auf]"
+          - "heiz[e] auf <temperature> <local_hier>[ auf]"
+          - "heiz[e] auf <temperature> auf <local_hier>"
+          - "kühl[e][ <local_hier>] auf <temperature>[ (ab|[he]runter)]"
+          - "kühl[e] auf <temperature> <local_hier>[ (ab|[he]runter)]"
+          - "kühl[e] auf <temperature> (ab|[he]runter) <local_hier>"
         requires_context:
           area:
             slot: true
         expansion_rules:
           heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
           local_hier: "(hier[ (im|in diesem) Raum]|[(im|in diesem|diesen|den) ]Raum)"
+          heat_cool: ([be]heizen|[ab|[he]runter]kühlen)

--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -9,7 +9,6 @@ intents:
           - "<setzen> <heizung> <name>[s] auf <temperature>"
           - "<stelle> <heizung> <name>[s] auf <temperature> ein"
           - "<heizung> [<von_dem> ]<name> auf <temperature>[ <setzen_end_of_sentence>]"
-          - "<name> <temperature>"
         expansion_rules:
           heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
       # by area / floor

--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -4,12 +4,17 @@ intents:
     data:
       - sentences:
           - "<setzen> <heizung> <von_dem> <name> auf <temperature>"
+          - "<stelle> <heizung> <von_dem> <name> auf <temperature> ein"
           - "<setzen> <heizung> <name>[s] auf <temperature>"
+          - "<stelle> <heizung> <name>[s] auf <temperature> ein"
           - "<heizung>[ (<area>|[<von_dem> ]<name>)] auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area> auf <temperature> [be]heizen"
           - "<setzen>[ <area>] <heizung> auf <temperature>"
+          - "<stelle>[ <area>] <heizung> auf <temperature> ein"
           - "<setzen> <heizung> <area> auf <temperature>"
+          - "<stelle> <heizung> <area> auf <temperature> ein"
           - "<setzen> <area_heizung> auf <temperature>"
+          - "<stelle> <area_heizung> auf <temperature> ein"
           - "<area_heizung> auf <temperature>[ <setzen_end_of_sentence>]"
         expansion_rules:
           heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)

--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -2,20 +2,58 @@ language: de
 intents:
   HassClimateSetTemperature:
     data:
+      # by name
       - sentences:
           - "<setzen> <heizung> <von_dem> <name> auf <temperature>"
           - "<stelle> <heizung> <von_dem> <name> auf <temperature> ein"
           - "<setzen> <heizung> <name>[s] auf <temperature>"
           - "<stelle> <heizung> <name>[s] auf <temperature> ein"
-          - "<heizung>[ (<area>|[<von_dem> ]<name>)] auf <temperature>[ <setzen_end_of_sentence>]"
+          - "<heizung> [<von_dem> ]<name> auf <temperature>[ <setzen_end_of_sentence>]"
+          - "<name> <temperature>"
+        expansion_rules:
+          heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
+      # by area / floor
+      - sentences:
+          - "<heizung> <area_floor> auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area> auf <temperature> [be]heizen"
-          - "<setzen>[ <area>] <heizung> auf <temperature>"
-          - "<stelle>[ <area>] <heizung> auf <temperature> ein"
-          - "<setzen> <heizung> <area> auf <temperature>"
-          - "<stelle> <heizung> <area> auf <temperature> ein"
-          - "<setzen> <area_heizung> auf <temperature>"
-          - "<stelle> <area_heizung> auf <temperature> ein"
-          - "<area_heizung> auf <temperature>[ <setzen_end_of_sentence>]"
+          - "[<artikel_bestimmt> ]<floor> auf <temperature> [be]heizen"
+          - "<setzen> <area_floor> <heizung> auf <temperature>"
+          - "<stelle> <area_floor> <heizung> auf <temperature> ein"
+          - "<setzen> <heizung> <area_floor> auf <temperature>"
+          - "<stelle> <heizung> <area_floor> auf <temperature> ein"
+          - "<setzen> (<area_heizung>|<floor_heizung>) auf <temperature>"
+          - "<stelle> (<area_heizung>|<floor_heizung>) auf <temperature> ein"
+          - "(<area_heizung>|<floor_heizung>) auf <temperature>[ <setzen_end_of_sentence>]"
+          - "<area_floor> <temperature>"
         expansion_rules:
           heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
           area_heizung: ([die ]{area}[ ]temperatur|[die ]{area}[ ]heizung|[(das|den) ]{area}[ ]thermostat|[die ]{area}[ ]klima(anlage|tisierung)|[das ]{area}[ ]klima)
+          floor_heizung: ([die ]{floor}[ ]temperatur|[die ]{floor}[ ]heizung|[(das|den) ]{floor}[ ]thermostat|[die ]{floor}[ ]klima(anlage|tisierung)|[das ]{floor}[ ]klima)
+
+      # by satellite area
+      - sentences:
+          - "[<local_hier> ]<heizung> auf <temperature>[ <setzen_end_of_sentence>]"
+          - "<heizung> <local_hier> auf <temperature>[ <setzen_end_of_sentence>]"
+          - "<heizung> auf <temperature> <local_hier>[ <setzen_end_of_sentence>]"
+          - "<heizung> auf <temperature> <setzen_end_of_sentence> <local_hier>"
+
+          - "[<local_hier> ]auf <temperature> [be]heizen"
+          - "auf <temperature> [be]heizen <local_hier>"
+
+          - "<setzen>[ <local_hier>] <heizung> auf <temperature>"
+          - "<setzen> <heizung> <local_hier> auf <temperature>"
+          - "<setzen> <heizung> auf <temperature> <local_hier>"
+
+          - "<stelle>[ <local_hier>] <heizung> auf <temperature> ein"
+          - "<stelle> <heizung> <local_hier> auf <temperature> ein"
+          - "<stelle> <heizung> auf <temperature> <local_hier> ein"
+          - "<stelle> <heizung> auf <temperature> ein <local_hier>"
+
+          - "[<local_hier> ]<temperature>"
+          - "<temperature> <local_hier>"
+        requires_context:
+          area:
+            slot: true
+        expansion_rules:
+          heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
+          local_hier: "(hier[ (im|in diesem) Raum]|[(im|in diesem|diesen|den) ]Raum)"

--- a/tests/de/climate_HassClimateSetTemperature.yaml
+++ b/tests/de/climate_HassClimateSetTemperature.yaml
@@ -135,6 +135,7 @@ tests:
       - Die Wohnzimmerklimatisierung auf 30 ° stellen
       - Die Wohnzimmerklimatisierung auf 30 Grad ändern
       - Die Wohnzimmerklimatisierung auf 30 ° ändern
+      - Wohnzimmer 30 Grad
 
     intent:
       name: HassClimateSetTemperature
@@ -143,6 +144,150 @@ tests:
         temperature: 30
     response: "Temperatur auf 30 Grad gestellt"
 
+  - sentences:
+      - Stelle im Erdgeschoss die Temperatur auf 30 Grad
+      - Stelle im Erdgeschoss die Temperatur auf 30 ° ein
+      - Setze im Erdgeschoss die Temperatur auf 30 Grad
+      - Setze im Erdgeschoss die Temperatur auf 30 °
+      - Ändere im Erdgeschoss die Temperatur auf 30 Grad
+      - Ändere im Erdgeschoss die Temperatur auf 30 °
+      - Temperatur im Erdgeschoss auf 30 Grad
+      - Temperatur im Erdgeschoss auf 30 °
+      - Temperatur im Erdgeschoss auf 30 Grad stellen
+      - Temperatur im Erdgeschoss auf 30 ° stellen
+      - Temperatur im Erdgeschoss auf 30 Grad ändern
+      - Temperatur im Erdgeschoss auf 30 ° ändern
+      - Die Temperatur im Erdgeschoss auf 30 Grad
+      - Die Temperatur im Erdgeschoss auf 30 °
+      - Die Temperatur im Erdgeschoss auf 30 Grad stellen
+      - Die Temperatur im Erdgeschoss auf 30 ° stellen
+      - Die Temperatur im Erdgeschoss auf 30 Grad ändern
+      - Die Temperatur im Erdgeschoss auf 30 ° ändern
+      - Heizung im Erdgeschoss auf 30 Grad
+      - Heizung im Erdgeschoss auf 30 °
+      - Heizung im Erdgeschoss auf 30 Grad stellen
+      - Heizung im Erdgeschoss auf 30 ° stellen
+      - Heizung im Erdgeschoss auf 30 Grad ändern
+      - Heizung im Erdgeschoss auf 30 ° ändern
+      - Die Heizung im Erdgeschoss auf 30 Grad
+      - Die Heizung im Erdgeschoss auf 30 °
+      - Die Heizung im Erdgeschoss auf 30 Grad stellen
+      - Die Heizung im Erdgeschoss auf 30 ° stellen
+      - Die Heizung im Erdgeschoss auf 30 Grad ändern
+      - Die Heizung im Erdgeschoss auf 30 ° ändern
+      - Thermostat im Erdgeschoss auf 30 Grad
+      - Thermostat im Erdgeschoss auf 30 °
+      - Thermostat im Erdgeschoss auf 30 Grad stellen
+      - Thermostat im Erdgeschoss auf 30 ° stellen
+      - Thermostat im Erdgeschoss auf 30 Grad ändern
+      - Thermostat im Erdgeschoss auf 30 ° ändern
+      - Den Thermostat im Erdgeschoss auf 30 Grad
+      - Den Thermostat im Erdgeschoss auf 30 °
+      - Den Thermostat im Erdgeschoss auf 30 Grad stellen
+      - Den Thermostat im Erdgeschoss auf 30 ° stellen
+      - Den Thermostat im Erdgeschoss auf 30 Grad ändern
+      - Den Thermostat im Erdgeschoss auf 30 ° ändern
+      - Das Thermostat im Erdgeschoss auf 30 Grad
+      - Das Thermostat im Erdgeschoss auf 30 °
+      - Das Thermostat im Erdgeschoss auf 30 Grad stellen
+      - Das Thermostat im Erdgeschoss auf 30 ° stellen
+      - Das Thermostat im Erdgeschoss auf 30 Grad ändern
+      - Das Thermostat im Erdgeschoss auf 30 ° ändern
+      - Das Erdgeschoss auf 30 Grad heizen
+      - Das Erdgeschoss auf 30 Grad beheizen
+      - Klima im Erdgeschoss auf 30 Grad
+      - Klima im Erdgeschoss auf 30 °
+      - Klima im Erdgeschoss auf 30 Grad stellen
+      - Klima im Erdgeschoss auf 30 ° stellen
+      - Klima im Erdgeschoss auf 30 Grad ändern
+      - Klima im Erdgeschoss auf 30 ° ändern
+      - Klimaanlage im Erdgeschoss auf 30 Grad
+      - Klimaanlage im Erdgeschoss auf 30 °
+      - Klimaanlage im Erdgeschoss auf 30 Grad stellen
+      - Klimaanlage im Erdgeschoss auf 30 ° stellen
+      - Klimaanlage im Erdgeschoss auf 30 Grad ändern
+      - Klimaanlage im Erdgeschoss auf 30 ° ändern
+      - Die Klimaanlage im Erdgeschoss auf 30 Grad
+      - Die Klimaanlage im Erdgeschoss auf 30 °
+      - Die Klimaanlage im Erdgeschoss auf 30 Grad stellen
+      - Die Klimaanlage im Erdgeschoss auf 30 ° stellen
+      - Die Klimaanlage im Erdgeschoss auf 30 Grad ändern
+      - Die Klimaanlage im Erdgeschoss auf 30 ° ändern
+      - Klimatisierung im Erdgeschoss auf 30 Grad
+      - Klimatisierung im Erdgeschoss auf 30 °
+      - Klimatisierung im Erdgeschoss auf 30 Grad stellen
+      - Klimatisierung im Erdgeschoss auf 30 ° stellen
+      - Klimatisierung im Erdgeschoss auf 30 Grad ändern
+      - Klimatisierung im Erdgeschoss auf 30 ° ändern
+      - Die Klimatisierung im Erdgeschoss auf 30 Grad
+      - Die Klimatisierung im Erdgeschoss auf 30 °
+      - Die Klimatisierung im Erdgeschoss auf 30 Grad stellen
+      - Die Klimatisierung im Erdgeschoss auf 30 ° stellen
+      - Die Klimatisierung im Erdgeschoss auf 30 Grad ändern
+      - Die Klimatisierung im Erdgeschoss auf 30 ° ändern
+      - Erdgeschosstemperatur auf 30 Grad
+      - Erdgeschosstemperatur auf 30 °
+      - Erdgeschosstemperatur auf 30 Grad stellen
+      - Erdgeschosstemperatur auf 30 ° stellen
+      - Erdgeschosstemperatur auf 30 Grad ändern
+      - Erdgeschosstemperatur auf 30 ° ändern
+      - Die Erdgeschosstemperatur auf 30 Grad
+      - Die Erdgeschosstemperatur auf 30 °
+      - Die Erdgeschosstemperatur auf 30 Grad stellen
+      - Die Erdgeschosstemperatur auf 30 ° stellen
+      - Die Erdgeschosstemperatur auf 30 Grad ändern
+      - Die Erdgeschosstemperatur auf 30 ° ändern
+      - Erdgeschossheizung auf 30 Grad
+      - Erdgeschossheizung auf 30 °
+      - Erdgeschossheizung auf 30 Grad stellen
+      - Erdgeschossheizung auf 30 ° stellen
+      - Erdgeschossheizung auf 30 Grad ändern
+      - Erdgeschossheizung auf 30 ° ändern
+      - Die Erdgeschossheizung auf 30 Grad
+      - Die Erdgeschossheizung auf 30 °
+      - Die Erdgeschossheizung auf 30 Grad stellen
+      - Die Erdgeschossheizung auf 30 ° stellen
+      - Die Erdgeschossheizung auf 30 Grad ändern
+      - Die Erdgeschossheizung auf 30 ° ändern
+      - Erdgeschossklima auf 30 Grad
+      - Erdgeschossklima auf 30 °
+      - Erdgeschossklima auf 30 Grad stellen
+      - Erdgeschossklima auf 30 ° stellen
+      - Erdgeschossklima auf 30 Grad ändern
+      - Erdgeschossklima auf 30 ° ändern
+      - Erdgeschossklimaanlage auf 30 Grad
+      - Erdgeschossklimaanlage auf 30 °
+      - Erdgeschossklimaanlage auf 30 Grad stellen
+      - Erdgeschossklimaanlage auf 30 ° stellen
+      - Erdgeschossklimaanlage auf 30 Grad ändern
+      - Erdgeschossklimaanlage auf 30 ° ändern
+      - Die Erdgeschossklimaanlage auf 30 Grad
+      - Die Erdgeschossklimaanlage auf 30 °
+      - Die Erdgeschossklimaanlage auf 30 Grad stellen
+      - Die Erdgeschossklimaanlage auf 30 ° stellen
+      - Die Erdgeschossklimaanlage auf 30 Grad ändern
+      - Die Erdgeschossklimaanlage auf 30 ° ändern
+      - Erdgeschossklimatisierung auf 30 Grad
+      - Erdgeschossklimatisierung auf 30 °
+      - Erdgeschossklimatisierung auf 30 Grad stellen
+      - Erdgeschossklimatisierung auf 30 ° stellen
+      - Erdgeschossklimatisierung auf 30 Grad ändern
+      - Erdgeschossklimatisierung auf 30 ° ändern
+      - Die Erdgeschossklimatisierung auf 30 Grad
+      - Die Erdgeschossklimatisierung auf 30 °
+      - Die Erdgeschossklimatisierung auf 30 Grad stellen
+      - Die Erdgeschossklimatisierung auf 30 ° stellen
+      - Die Erdgeschossklimatisierung auf 30 Grad ändern
+      - Die Erdgeschossklimatisierung auf 30 ° ändern
+      - Erdgeschoss30 Grad
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        floor: Erdgeschoss
+        temperature: 30
+    response: "Temperatur auf 30 Grad gestellt"
+
+  # by satellite area
   - sentences:
       - Stelle die Temperatur auf 20 Grad
       - Stelle die Temperatur auf 20 ° ein
@@ -228,7 +373,10 @@ tests:
       - Die Klimatisierung auf 20 ° ändern
     intent:
       name: HassClimateSetTemperature
+      context:
+        area: Wohnzimmer
       slots:
+        area: "Wohnzimmer"
         temperature: 20
     response: "Temperatur auf 20 Grad gestellt"
 
@@ -293,6 +441,7 @@ tests:
       - Die Temperatur vom Wohnzimmerthermostat auf 25 ° stellen
       - Die Temperatur vom Wohnzimmerthermostat auf 25 Grad ändern
       - Die Temperatur vom Wohnzimmerthermostat auf 25 ° ändern
+      - Wohnzimmerthermostat 25 Grad
     intent:
       name: HassClimateSetTemperature
       slots:

--- a/tests/de/climate_HassClimateSetTemperature.yaml
+++ b/tests/de/climate_HassClimateSetTemperature.yaml
@@ -2,7 +2,7 @@ language: de
 tests:
   - sentences:
       - Stelle im Wohnzimmer die Temperatur auf 30 Grad
-      - Stelle im Wohnzimmer die Temperatur auf 30 °
+      - Stelle im Wohnzimmer die Temperatur auf 30 ° ein
       - Setze im Wohnzimmer die Temperatur auf 30 Grad
       - Setze im Wohnzimmer die Temperatur auf 30 °
       - Ändere im Wohnzimmer die Temperatur auf 30 Grad
@@ -145,7 +145,7 @@ tests:
 
   - sentences:
       - Stelle die Temperatur auf 20 Grad
-      - Stelle die Temperatur auf 20 °
+      - Stelle die Temperatur auf 20 ° ein
       - Ändere die Temperatur auf 20 Grad
       - Ändere die Temperatur auf 20 °
       - Temperatur auf 20 Grad
@@ -234,7 +234,7 @@ tests:
 
   - sentences:
       - Stelle die Temperatur vom Wohnzimmerthermostat auf 25 Grad
-      - Stelle die Temperatur vom Wohnzimmerthermostat auf 25 °
+      - Stelle die Temperatur vom Wohnzimmerthermostat auf 25 ° ein
       - Setze die Temperatur vom Wohnzimmerthermostat auf 25 Grad
       - Setze die Temperatur vom Wohnzimmerthermostat auf 25 °
       - Ändere die Temperatur vom Wohnzimmerthermostat auf 25 Grad

--- a/tests/de/climate_HassClimateSetTemperature.yaml
+++ b/tests/de/climate_HassClimateSetTemperature.yaml
@@ -486,7 +486,6 @@ tests:
       - Die Temperatur vom Wohnzimmerthermostat auf 25 ° stellen
       - Die Temperatur vom Wohnzimmerthermostat auf 25 Grad ändern
       - Die Temperatur vom Wohnzimmerthermostat auf 25 ° ändern
-      - Wohnzimmerthermostat 25 Grad
     intent:
       name: HassClimateSetTemperature
       slots:

--- a/tests/de/climate_HassClimateSetTemperature.yaml
+++ b/tests/de/climate_HassClimateSetTemperature.yaml
@@ -136,6 +136,12 @@ tests:
       - Die Wohnzimmerklimatisierung auf 30 Grad ändern
       - Die Wohnzimmerklimatisierung auf 30 ° ändern
       - Wohnzimmer 30 Grad
+      - Das Wohnzimmer auf 30 Grad herunterkühlen
+      - Heize das Wohnzimmer auf 30 Grad
+      - Heiz das Wohnzimmer auf 30 Grad auf
+      - Kühl das Wohnzimmer auf 30 Grad ab
+      - Kühle das Wohnzimmer auf 30 Grad herunter
+      - Kühl das Wohnzimmer auf 30 Grad Runter
 
     intent:
       name: HassClimateSetTemperature
@@ -279,7 +285,15 @@ tests:
       - Die Erdgeschossklimatisierung auf 30 ° stellen
       - Die Erdgeschossklimatisierung auf 30 Grad ändern
       - Die Erdgeschossklimatisierung auf 30 ° ändern
-      - Erdgeschoss30 Grad
+      - Erdgeschoss 30 Grad
+      - Das Erdgeschoss auf 30 Grad abkühlen
+      - Erdgeschoss auf 30 Grad kühlen
+      - Heize das Erdgeschoss auf 30 Grad
+      - Heiz das Erdgeschoss auf 30 Grad auf
+      - Kühl das Erdgeschoss auf 30 Grad
+      - Kühle das Erdgeschoss auf 30 Grad ab
+      - Kühl das Erdgeschoss auf 30 Grad herunter
+      - Kühl das Erdgeschoss auf 30 Grad runter
     intent:
       name: HassClimateSetTemperature
       slots:
@@ -371,6 +385,37 @@ tests:
       - Die Klimatisierung auf 20 ° stellen
       - Die Klimatisierung auf 20 Grad ändern
       - Die Klimatisierung auf 20 ° ändern
+      - Hier die Temperatur auf 20 Grad einstellen
+      - Die Temperatur hier im Raum auf 20 Grad ändern
+      - Die Temperatur auf 20 Grad in diesem Raum
+      - Die Heizung auf 20 Grad ändern in diesem Raum
+      - Hier auf 20 Grad heizen
+      - diesen Raum auf 20 Grad abkühlen
+      - Auf 20 Grad abkühlen in diesem Raum
+      - Auf 20 Grad heizen in diesem Raum
+      - Ändere in diesem Raum die Temperatur auf 20 Grad
+      - Änder die Temperatur in diesem Raum auf 20 Grad
+      - Änder die Temperatur auf 20 Grad in diesem Raum
+      - Stell hier die Temperatur auf 20 Grad
+      - Stelle die Temperatur im Raum auf 20 Grad
+      - Stell die Temperatur auf 20 Grad in diesem Raum
+      - Stell hier die Temperatur auf 20 Grad ein
+      - Stelle die Temperatur im Raum auf 20 Grad ein
+      - Stell die Temperatur auf 20 Grad in diesem Raum ein
+      - Stell die Temperatur auf 20 Grad ein in diesem Raum
+      - 20 Grad
+      - in diesem Raum 20 Grad
+      - 20 Grad hier
+      - 20 Grad in diesem Raum
+      - Heiz auf 20 Grad
+      - Heize diesen Raum auf 20 Grad auf
+      - Heize auf 20 Grad hier auf
+      - Heize auf 20 Grad in diesem Raum
+      - Heiz auf 20 Grad auf in diesem Raum
+      - Kühle auf 20 Grad
+      - Kühl auf 20 Grad runter
+      - Kühle auf 20 Grad in diesem Raum runter
+      - Kühle auf 20 Grad runter in diesem Raum
     intent:
       name: HassClimateSetTemperature
       context:


### PR DESCRIPTION
This PR extends the functionality of HassClimateSetTemperature.
It is now possible to set a temperature for a whole floor. Besides that commands like
> Temperatur auf 20 Grad einstellen

are now aware of the corresponding satellite´s area.
Also sentences with `stelle...ein` and `kühle...runter` like
> Stelle die Temperatur auf 20 Grad ein
> Kühle das Wohnzimmer auf 20 Grad
> Kühle diesen Raum auf 20 Grad runter

are now recognized.