### PR TITLE
[DE] HassLightSet: optimization of light controls by name of light

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -340,10 +340,14 @@ lists:
       to: 100
   brightness_level:
     values:
-      - in: (max[imal[e]|imum]|höchste|volle)
+      - in: (max[imal[e]|imum]|höchste|volle|grö(ss|ß)te|hell[ste])
         out: 100
-      - in: (min[imal[e]|imum]|niedrigste)
+      - in: (min[imal[e]|imum]|niedrigste|kleinste)
         out: 1
+  brightness_level_max:
+    values:
+      - in: (hell[ste Stufe]|(maximale|volle|grö(ss|ß)te|höchste) Helligkeit[sstufe]|Helligkeit ((maxim(al|um)|voll)|(maximale|volle|grö(ss|ß)te|höchste) Stufe))
+        out: 100
   cover_states:
     values:
       - in: "(offen|auf|oben|geöffnet)"
@@ -545,7 +549,7 @@ expansion_rules:
   artikel: "[<artikel_bestimmt>|<artikel_unbestimmt>]"
   name: "<artikel_bestimmt> {name}"
   area: "[([(in|an|auf|bei) ][<artikel_bestimmt> ]|(im|am|<von_dem>) )]{area}[s]"
-  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>) ]{floor}[ Geschoss]"
+  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>|(das|des)) ]{floor}[ Geschoss]"
   area_floor: "(<area>|<floor>)"
   an: "(an|ein|auf)"
   aus: "(aus|ab|zu)"
@@ -574,11 +578,14 @@ expansion_rules:
   alle_luefter: "<alle> (Ventilatoren|Lüfter)"
   brightness: "{brightness}[ (Prozent|%)]"
   temperature: "{temperature}[ ][°|Grad]"
-  licht: "[(das|die) ](Licht|Lampe|Beleuchtung)"
-  lichtes: "([des ](Lichts|Lichtes)|[der ](Lampe|Beleuchtung))"
-  lichter: "[(die|der|von den) ](Lichter|Lichtern|Lampen|Leuchten|Beleuchtungen)"
-  alle_lichter: "(<alle> (<lichter>|Beleuchtung)|von allen[ (Lichtern|Lampen|Leuchten|Beleuchtungen)])"
+  licht: "([das ]Licht|[die ]Lampe|[die ]Beleuchtung)"
+  licht_ohne_artikel: "(Licht|Lampe|Beleuchtung)"
+  lichtes: "([des ](Licht[s]|Lichtes)|[der ](Lampe|Beleuchtung))"
+  lichtes_mit_artikel: "(des (Licht[s]|Lichtes)|der (Lampe|Beleuchtung))"
+  lichter: "([(die|der) ]Lichter|[von den ]Lichtern|[(die|der|von den) ](Lampen|Leuchten|Beleuchtungen))"
+  alle_lichter: "(<alle> ((Lichter|Lampen|Leuchten|Beleuchtungen)|Beleuchtung)|von allen[ (Lichtern|Lampen|Leuchten|Beleuchtungen)])"
   leuchten_lassen: "([er]leuchten lassen|[ein]färben)"
+  hier: "(hier[ (im|in diesem) Raum]|[(im|in diesem|diesen|den) ]Raum)"
   tuer: "[die ]Tür[e|en]"
   schloss: "([das ]Schloss|[die ]Schlösser)"
   sperren: "(sperr|schlie(ss|ß))[e|en]"

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -10,6 +10,13 @@ intents:
           - "dimme[ [die ]Helligkeit[ (von|vom)]] <name> (auf|zu) <brightness>"
           - "<name>[ (auf|zu)] <brightness>[ dimmen]"
           - "<name> Helligkeit[ (auf|zu)] <brightness>"
+          # min/max
+          - "<setze> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)]"
+          - "<stelle> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)][ ein]"
+          - "<setze> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe]"
+          - "<stelle> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe][ ein]"
+          - "[die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe] <setzen_end_of_sentence>"
+          - "<name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)] <setzen_end_of_sentence>"
         requires_context:
           domain: light
         response: brightness
@@ -48,15 +55,3 @@ intents:
           - "[<licht>|<lichter>|<alle_lichter> ][<area> ][Farbe ]{color} <leuchten_lassen>"
           - "Färbe[ (<licht>|<lichter>|<alle_lichter>)][ <area>] {color}[ ein]"
         response: color
-
-        # Max/Min brightness
-      - sentences:
-          - "<setze> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)]"
-          - "<stelle> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)][ ein]"
-          - "<setze> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe]"
-          - "<stelle> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe][ ein]"
-          - "[die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe] <setzen_end_of_sentence>"
-          - "<name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)] <setzen_end_of_sentence>"
-        requires_context:
-          domain: light
-        response: brightness

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -2,11 +2,12 @@ language: de
 intents:
   HassLightSet:
     data:
+      # brightness by name
       - sentences:
-          - "<setze> [die ]Helligkeit[ von] <name>[ auf] <brightness>"
-          - "<stelle> [die ]Helligkeit[ von] <name>[ auf] <brightness>[ ein]"
-          - "[die ]Helligkeit[ von] <name>[ auf] <brightness>[ <setzen_end_of_sentence>]"
-          - "dimme[ [die ]Helligkeit[ von]] <name>[ (auf|zu)] <brightness>"
+          - "<setze> [die ]Helligkeit[ (von|vom)] <name>[ auf] <brightness>"
+          - "<stelle> [die ]Helligkeit[ (von|vom)] <name>[ auf] <brightness>[ ein]"
+          - "[die ]Helligkeit[ (von|vom)] <name>[ auf] <brightness>[ (<setzen_end_of_sentence>|dimmen)]"
+          - "dimme[ [die ]Helligkeit[ (von|vom)]] <name> (auf|zu) <brightness>"
           - "<name>[ (auf|zu)] <brightness>[ dimmen]"
           - "<name> Helligkeit[ (auf|zu)] <brightness>"
         requires_context:

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -23,17 +23,17 @@ intents:
       - sentences:
           - "[<setzen> ][die ]Helligkeit [<hier> ]auf <brightness>"
           - "[die ]Helligkeit [<hier> ]auf <brightness> dimmen"
-        expansion_rules:
-          hier: "(hier|im Raum)"
         response: "brightness"
         requires_context:
           area:
             slot: true
+
+      # color by name
       - sentences:
-          - "[<setzen> ][[die ]Farbe[ von] ]<name>[ auf] {color}"
-          - "(änder[e]|veränder[e]) [[die ]Farbe[ von] ]<name> zu {color}"
-          - "[[die ]Farbe[ von] ]<name>[ (auf|zu)] {color} <setzen_end_of_sentence>"
-          - "<name>[ Farbe][ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[<setze> ][[die ]Farbe[ (von|vom)] ]<name>[ (auf|zu)] {color}"
+          - "<stelle> [[die ]Farbe[ (von|vom)] ]<name>[ auf] {color}[ ein]"
+          - "[[die ]Farbe[ (von|vom)] ]<name>[ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "<name> Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
           - "Lass[e] <name> {color}[ er]leuchten"
           - "<name> {color} <leuchten_lassen>"
           - "Färbe <name> {color}[ ein]"

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -187,15 +187,19 @@ tests:
         area: Schlafzimmer
     response: "Helligkeit eingestellt"
 
+  # color by name
   - sentences:
       - Stelle die Schlafzimmerlampe auf grün
       - Schlafzimmerlampe auf grün
       - Schlafzimmerlampe zu grün
       - Schlafzimmerlampe grün
       - Schlafzimmerlampe Farbe grün
+      - Schlafzimmerlampe Farbe auf Grün ändern
       - Farbe Schlafzimmerlampe grün
+      - ändere die Farbe von der Schlafzimmerlampe auf grün
       - Stelle die Farbe von der Schlafzimmerlampe auf grün
       - Farbe der Schlafzimmerlampe auf grün
+      - Farbe von der Schlafzimmerlampe auf grün ändern
       - Farbe der Schlafzimmerlampe auf grün ändern
       - Farbe der Schlafzimmerlampe zu grün ändern
       - Ändere die Farbe der Schlafzimmerlampe zu grün

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -81,13 +81,17 @@ tests:
         name: Schlafzimmerlampe
         brightness: 1
     response: Helligkeit eingestellt
-
+  # brightness by name
   - sentences:
+      - Stelle die Helligkeit vom Schlafzimmerlampe auf 10
+      - Stelle die Helligkeit von der Schlafzimmerlampe auf 10 % ein
       - Stelle die Helligkeit von der Schlafzimmerlampe auf 10
       - Stelle die Helligkeit von dem Schlafzimmerlampe auf 10
+      - Ändere die Helligkeit vom Schlafzimmerlampe auf 10
       - Ändere die Helligkeit von der Schlafzimmerlampe auf 10
       - Setze die Helligkeit von der Schlafzimmerlampe auf 10
       - Dimme die Helligkeit von der Schlafzimmerlampe auf 10
+      - Dimme die Helligkeit vom Schlafzimmerlampe auf 10
       - Dimme die Schlafzimmerlampe auf 10
       - Dimme die Schlafzimmerlampe auf 10 Prozent
       - Dimme die Schlafzimmerlampe auf 10%
@@ -101,6 +105,14 @@ tests:
       - Setze Helligkeit der Schlafzimmerlampe auf 10%
       - Setze Helligkeit Schlafzimmerlampe auf 10%
       - Helligkeit von Schlafzimmerlampe auf 10%
+      - Helligkeit vom Schlafzimmerlampe 10%
+      - Helligkeit vom Schlafzimmerlampe auf 10%
+      - Helligkeit vom Schlafzimmerlampe auf 10% einstellen
+      - Helligkeit vom Schlafzimmerlampe auf 10% dimmen
+      - Die Helligkeit vom Schlafzimmerlampe 10%
+      - Die Helligkeit vom Schlafzimmerlampe auf 10%
+      - Die Helligkeit vom Schlafzimmerlampe auf 10% einstellen
+      - Die Helligkeit vom Schlafzimmerlampe auf 10% dimmen
       - Helligkeit von Schlafzimmerlampe 10%
       - Helligkeit Schlafzimmerlampe auf 10%
       - Helligkeit Schlafzimmerlampe 10%
@@ -109,6 +121,17 @@ tests:
       - Schlafzimmerlampe Helligkeit 10 %
       - Schlafzimmerlampe auf 10 % dimmen
       - Schlafzimmerlampe auf 10 %
+
+      - setze Helligkeit Schlafzimmerlampe 10%
+      - Stelle die Helligkeit von dem Schlafzimmerlampe auf 10 prozent ein
+      - helligkeit Schlafzimmerlampe 10%
+      - Die Helligkeit der Schlafzimmerlampe auf 10% einstellen
+      - die Helligkeit von der Schlafzimmerlampe auf 10 Prozent ändern
+      - Die Helligkeit der Schlafzimmerlampe auf 10% dimmen
+      - die Helligkeit von der Schlafzimmerlampe auf 10 Prozent dimmen
+      - dimme Helligkeit der Schlafzimmerlampe zu 10%
+      - dimme die Helligkeit von der Schlafzimmerlampe auf 10 Prozent
+      - Schlafzimmerlampe 10 Prozent
     intent:
       name: HassLightSet
       slots:


### PR DESCRIPTION
This is the second step in a bigger change process for HassLightSet. ( see PR #3294 )
This PR covers sentences that control lights(brightness and color) by their name.
I moved lines 53-58 to the top(14-19) so the final file will be grouped by the following structure:
- brightness by name
- brightness all lights by area/floor
- brightness all lights by satellite area
- color by name
- color all lights by area/floor
- color all lights by satellite area

(so no real deletion here)
overall sentence count ~+ 3000

the changes to the commons file in this PR are covered by #3314 and will be removed as soon as that PR is merged.