### PR TITLE
[DE] HassLightSet: color control by floor and satellite area

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -340,10 +340,14 @@ lists:
       to: 100
   brightness_level:
     values:
-      - in: (max[imal[e]|imum]|höchste|volle)
+      - in: (max[imal[e]|imum]|höchste|volle|grö(ss|ß)te|hell[ste])
         out: 100
-      - in: (min[imal[e]|imum]|niedrigste)
+      - in: (min[imal[e]|imum]|niedrigste|kleinste)
         out: 1
+  brightness_level_max:
+    values:
+      - in: (hell[ste Stufe]|(maximale|volle|grö(ss|ß)te|höchste) Helligkeit[sstufe]|Helligkeit ((maxim(al|um)|voll)|(maximale|volle|grö(ss|ß)te|höchste) Stufe))
+        out: 100
   cover_states:
     values:
       - in: "(offen|auf|oben|geöffnet)"
@@ -545,7 +549,7 @@ expansion_rules:
   artikel: "[<artikel_bestimmt>|<artikel_unbestimmt>]"
   name: "<artikel_bestimmt> {name}"
   area: "[([(in|an|auf|bei) ][<artikel_bestimmt> ]|(im|am|<von_dem>) )]{area}[s]"
-  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>) ]{floor}[ Geschoss]"
+  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>|(das|des)) ]{floor}[ Geschoss]"
   area_floor: "(<area>|<floor>)"
   an: "(an|ein|auf)"
   aus: "(aus|ab|zu)"
@@ -574,11 +578,14 @@ expansion_rules:
   alle_luefter: "<alle> (Ventilatoren|Lüfter)"
   brightness: "{brightness}[ (Prozent|%)]"
   temperature: "{temperature}[ ][°|Grad]"
-  licht: "[(das|die) ](Licht|Lampe|Beleuchtung)"
-  lichtes: "([des ](Lichts|Lichtes)|[der ](Lampe|Beleuchtung))"
-  lichter: "[(die|der|von den) ](Lichter|Lichtern|Lampen|Leuchten|Beleuchtungen)"
-  alle_lichter: "(<alle> (<lichter>|Beleuchtung)|von allen[ (Lichtern|Lampen|Leuchten|Beleuchtungen)])"
+  licht: "([das ]Licht|[die ]Lampe|[die ]Beleuchtung)"
+  licht_ohne_artikel: "(Licht|Lampe|Beleuchtung)"
+  lichtes: "([des ](Licht[s]|Lichtes)|[der ](Lampe|Beleuchtung))"
+  lichtes_mit_artikel: "(des (Licht[s]|Lichtes)|der (Lampe|Beleuchtung))"
+  lichter: "([(die|der) ]Lichter|[von den ]Lichtern|[(die|der|von den) ](Lampen|Leuchten|Beleuchtungen))"
+  alle_lichter: "(<alle> ((Lichter|Lampen|Leuchten|Beleuchtungen)|Beleuchtung)|von allen[ (Lichtern|Lampen|Leuchten|Beleuchtungen)])"
   leuchten_lassen: "([er]leuchten lassen|[ein]färben)"
+  hier: "(hier[ (im|in diesem) Raum]|[(im|in diesem|diesen|den) ]Raum)"
   tuer: "[die ]Tür[e|en]"
   schloss: "([das ]Schloss|[die ]Schlösser)"
   sperren: "(sperr|schlie(ss|ß))[e|en]"

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -47,11 +47,39 @@ intents:
         requires_context:
           domain: light
         response: color
+      # color all lights by area/floor
       - sentences:
-          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])][ <area>][ auf] {color}"
-          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])[ <area>] zu {color}"
-          - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <area>][ (auf|zu)] {color} <setzen_end_of_sentence>"
-          - "[<licht>|<lichtes>|<lichter>|<alle_lichter> ][<area> ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
-          - "[<licht>|<lichter>|<alle_lichter> ][<area> ][Farbe ]{color} <leuchten_lassen>"
-          - "Färbe[ (<licht>|<lichter>|<alle_lichter>)][ <area>] {color}[ ein]"
+          - "[<setze> ][(<licht>|[die ]Farbe[ (<lichtes_mit_artikel>|<lichter>|<alle_lichter>)]|(<lichter>|<alle_lichter>))] <area_floor>[ auf] {color}"
+          - "<stelle> [(<licht>|[die ]Farbe[ (<lichtes_mit_artikel>|<lichter>|<alle_lichter>)]|(<lichter>|<alle_lichter>))] <area_floor>[ auf] {color}[ ein]"
+          - "(änder[e]|veränder[e]) (<licht>|[die ]Farbe[ (<lichtes_mit_artikel>|<lichter>|<alle_lichter>)]|(<lichter>|<alle_lichter>)) <area_floor> zu {color}"
+          - "[die ]Farbe[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)] <area_floor>[ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "[[(bei[ allen]|beim) ](<licht>|<lichter>|<alle_lichter>) ]<area_floor> [die ]Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[(<licht>|<lichter>|<alle_lichter>) ]<area_floor> [([in ]Farbe|in) ]{color} <leuchten_lassen>"
+          - "Färbe[ (<licht>|<lichter>|<alle_lichter>)] <area_floor> {color}[ ein]"
         response: color
+
+      # color all lights by satellite area
+      - sentences:
+          - "[(<setze>|mach[e]) ][(<licht>|[die ]Farbe[ (<lichtes_mit_artikel>|<lichter>)]|<lichter>)][ <hier>][ auf] {color}"
+          - "<stelle> [(<licht>|[die ]Farbe[ (<lichtes_mit_artikel>|<lichter>)]|<lichter>)][ <hier>][ auf] {color}[ ein]"
+          - "(änder[e]|veränder[e]) (<licht>|[die ]Farbe[ (<lichtes_mit_artikel>|<lichter>)]|<lichter>)[ <hier>] zu {color}"
+          - "[die ]Farbe[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>)][ <hier>][ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "[[(bei[ allen]|beim) ](<licht>|<lichter>) ][<hier> [die ]]Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[(<licht>|<lichter>) ][<hier> ][([in ]Farbe|in) ]{color} <leuchten_lassen>"
+          - "Färbe (<licht>|<lichter>)[ <hier>] {color}[ ein]"
+          - "Farbe <licht>[ <hier>] {color}"
+          - "{color}"
+
+          # <alle lichter> + <hier>
+          - "[(<setze>|mach[e]) ]([die ]Farbe (<alle_lichter>)|<alle_lichter>) <hier>[ auf] {color}"
+          - "<stelle> ([die ]Farbe (<alle_lichter>)|<alle_lichter>) <hier>[ auf] {color}[ ein]"
+          - "(änder[e]|veränder[e]) ([die ]Farbe (<alle_lichter>)|<alle_lichter>) <hier> zu {color}"
+          - "[die ]Farbe <alle_lichter> <hier>[ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "(bei allen (Lichter|Lampen|Leuchten|Beleuchtungen)|<alle_lichter>) <hier> [die ]Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "<alle_lichter> <hier> [([in ]Farbe|in) ]{color} <leuchten_lassen>"
+          - "Färbe <alle_lichter> <hier> {color}[ ein]"
+          - "Farbe <alle_lichter> <hier> {color}"
+        response: "color"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -10,6 +10,13 @@ intents:
           - "dimme[ [die ]Helligkeit[ (von|vom)]] <name> (auf|zu) <brightness>"
           - "<name>[ (auf|zu)] <brightness>[ dimmen]"
           - "<name> Helligkeit[ (auf|zu)] <brightness>"
+          # min/max
+          - "<setze> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)]"
+          - "<stelle> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)][ ein]"
+          - "<setze> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe]"
+          - "<stelle> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe][ ein]"
+          - "[die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe] <setzen_end_of_sentence>"
+          - "<name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)] <setzen_end_of_sentence>"
         requires_context:
           domain: light
         response: brightness
@@ -48,15 +55,3 @@ intents:
           - "[<licht>|<lichter>|<alle_lichter> ][<area> ][Farbe ]{color} <leuchten_lassen>"
           - "Färbe[ (<licht>|<lichter>|<alle_lichter>)][ <area>] {color}[ ein]"
         response: color
-
-        # Max/Min brightness
-      - sentences:
-          - "<setze> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)]"
-          - "<stelle> <name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)][ ein]"
-          - "<setze> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe]"
-          - "<stelle> [die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe][ ein]"
-          - "[die ]Helligkeit[ <von_dem>] <name> auf [(die|das) ]{brightness_level:brightness}[ Stufe] <setzen_end_of_sentence>"
-          - "<name> auf [(die|das) ]{brightness_level:brightness}[ (Helligkeit|Stufe)] <setzen_end_of_sentence>"
-        requires_context:
-          domain: light
-        response: brightness

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -2,11 +2,12 @@ language: de
 intents:
   HassLightSet:
     data:
+      # brightness by name
       - sentences:
-          - "<setze> [die ]Helligkeit[ von] <name>[ auf] <brightness>"
-          - "<stelle> [die ]Helligkeit[ von] <name>[ auf] <brightness>[ ein]"
-          - "[die ]Helligkeit[ von] <name>[ auf] <brightness>[ <setzen_end_of_sentence>]"
-          - "dimme[ [die ]Helligkeit[ von]] <name>[ (auf|zu)] <brightness>"
+          - "<setze> [die ]Helligkeit[ (von|vom)] <name>[ auf] <brightness>"
+          - "<stelle> [die ]Helligkeit[ (von|vom)] <name>[ auf] <brightness>[ ein]"
+          - "[die ]Helligkeit[ (von|vom)] <name>[ auf] <brightness>[ (<setzen_end_of_sentence>|dimmen)]"
+          - "dimme[ [die ]Helligkeit[ (von|vom)]] <name> (auf|zu) <brightness>"
           - "<name>[ (auf|zu)] <brightness>[ dimmen]"
           - "<name> Helligkeit[ (auf|zu)] <brightness>"
         requires_context:

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -23,17 +23,17 @@ intents:
       - sentences:
           - "[<setzen> ][die ]Helligkeit [<hier> ]auf <brightness>"
           - "[die ]Helligkeit [<hier> ]auf <brightness> dimmen"
-        expansion_rules:
-          hier: "(hier|im Raum)"
         response: "brightness"
         requires_context:
           area:
             slot: true
+
+      # color by name
       - sentences:
-          - "[<setzen> ][[die ]Farbe[ von] ]<name>[ auf] {color}"
-          - "(änder[e]|veränder[e]) [[die ]Farbe[ von] ]<name> zu {color}"
-          - "[[die ]Farbe[ von] ]<name>[ (auf|zu)] {color} <setzen_end_of_sentence>"
-          - "<name>[ Farbe][ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[<setze> ][[die ]Farbe[ (von|vom)] ]<name>[ (auf|zu)] {color}"
+          - "<stelle> [[die ]Farbe[ (von|vom)] ]<name>[ auf] {color}[ ein]"
+          - "[[die ]Farbe[ (von|vom)] ]<name>[ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "<name> Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
           - "Lass[e] <name> {color}[ er]leuchten"
           - "<name> {color} <leuchten_lassen>"
           - "Färbe <name> {color}[ ein]"

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -187,15 +187,19 @@ tests:
         area: Schlafzimmer
     response: "Helligkeit eingestellt"
 
+  # color by name
   - sentences:
       - Stelle die Schlafzimmerlampe auf grün
       - Schlafzimmerlampe auf grün
       - Schlafzimmerlampe zu grün
       - Schlafzimmerlampe grün
       - Schlafzimmerlampe Farbe grün
+      - Schlafzimmerlampe Farbe auf Grün ändern
       - Farbe Schlafzimmerlampe grün
+      - ändere die Farbe von der Schlafzimmerlampe auf grün
       - Stelle die Farbe von der Schlafzimmerlampe auf grün
       - Farbe der Schlafzimmerlampe auf grün
+      - Farbe von der Schlafzimmerlampe auf grün ändern
       - Farbe der Schlafzimmerlampe auf grün ändern
       - Farbe der Schlafzimmerlampe zu grün ändern
       - Ändere die Farbe der Schlafzimmerlampe zu grün

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -81,13 +81,17 @@ tests:
         name: Schlafzimmerlampe
         brightness: 1
     response: Helligkeit eingestellt
-
+  # brightness by name
   - sentences:
+      - Stelle die Helligkeit vom Schlafzimmerlampe auf 10
+      - Stelle die Helligkeit von der Schlafzimmerlampe auf 10 % ein
       - Stelle die Helligkeit von der Schlafzimmerlampe auf 10
       - Stelle die Helligkeit von dem Schlafzimmerlampe auf 10
+      - Ändere die Helligkeit vom Schlafzimmerlampe auf 10
       - Ändere die Helligkeit von der Schlafzimmerlampe auf 10
       - Setze die Helligkeit von der Schlafzimmerlampe auf 10
       - Dimme die Helligkeit von der Schlafzimmerlampe auf 10
+      - Dimme die Helligkeit vom Schlafzimmerlampe auf 10
       - Dimme die Schlafzimmerlampe auf 10
       - Dimme die Schlafzimmerlampe auf 10 Prozent
       - Dimme die Schlafzimmerlampe auf 10%
@@ -101,6 +105,14 @@ tests:
       - Setze Helligkeit der Schlafzimmerlampe auf 10%
       - Setze Helligkeit Schlafzimmerlampe auf 10%
       - Helligkeit von Schlafzimmerlampe auf 10%
+      - Helligkeit vom Schlafzimmerlampe 10%
+      - Helligkeit vom Schlafzimmerlampe auf 10%
+      - Helligkeit vom Schlafzimmerlampe auf 10% einstellen
+      - Helligkeit vom Schlafzimmerlampe auf 10% dimmen
+      - Die Helligkeit vom Schlafzimmerlampe 10%
+      - Die Helligkeit vom Schlafzimmerlampe auf 10%
+      - Die Helligkeit vom Schlafzimmerlampe auf 10% einstellen
+      - Die Helligkeit vom Schlafzimmerlampe auf 10% dimmen
       - Helligkeit von Schlafzimmerlampe 10%
       - Helligkeit Schlafzimmerlampe auf 10%
       - Helligkeit Schlafzimmerlampe 10%
@@ -109,6 +121,17 @@ tests:
       - Schlafzimmerlampe Helligkeit 10 %
       - Schlafzimmerlampe auf 10 % dimmen
       - Schlafzimmerlampe auf 10 %
+
+      - setze Helligkeit Schlafzimmerlampe 10%
+      - Stelle die Helligkeit von dem Schlafzimmerlampe auf 10 prozent ein
+      - helligkeit Schlafzimmerlampe 10%
+      - Die Helligkeit der Schlafzimmerlampe auf 10% einstellen
+      - die Helligkeit von der Schlafzimmerlampe auf 10 Prozent ändern
+      - Die Helligkeit der Schlafzimmerlampe auf 10% dimmen
+      - die Helligkeit von der Schlafzimmerlampe auf 10 Prozent dimmen
+      - dimme Helligkeit der Schlafzimmerlampe zu 10%
+      - dimme die Helligkeit von der Schlafzimmerlampe auf 10 Prozent
+      - Schlafzimmerlampe 10 Prozent
     intent:
       name: HassLightSet
       slots:

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -217,6 +217,133 @@ tests:
         color: green
     response: Farbe eingestellt
 
+  # color by floor
+  - sentences:
+      - Stelle die Farbe im Erdgeschoss auf blau
+      - Stelle Farbe im Erdgeschoss auf blau
+      - Stelle Farbe Erdgeschoss auf blau
+      - Stelle Farbe Erdgeschoss blau
+      - Farbe Erdgeschoss blau
+      - Erdgeschoss Farbe blau
+      - Erdgeschoss blau
+      - Färbe das Erdgeschoss blau ein
+      - Färbe Erdgeschoss blau
+      - Erdgeschoss blau färben
+      - Stelle die Farbe des Lichts im Erdgeschoss auf blau
+      - Färbe das Licht im Erdgeschoss blau
+      - Die Farbe des Lichts im Erdgeschoss auf blau setzen
+      - Erdgeschoss auf Blau
+      - Licht Erdgeschoss Blau
+      - Licht im Erdgeschoss Blau
+      - Das Licht im Erdgeschoss auf Blau
+      - Farbe Erdgeschoss Blau
+      - Farbe Erdgeschoss auf Blau
+      - Farbe des Licht Erdgeschoss Blau
+      - Farbe des Lichts im Erdgeschoss Blau
+      - die Farbe des Lichtes im Erdgeschoss blau
+      - Farbe aller Lichter im Erdgeschoss auf Blau
+      - Die Farbe aller Lampen im Erdgeschoss auf Blau
+      - Lichter im Erdgeschoss Blau
+      - Die Lampen im Erdgeschoss Blau
+      - Die Leuchten im Erdgeschoss auf Blau
+      - Alle Lichter im Erdgeschoss Blau
+      - Alle Leuchten im Erdgeschoss auf Blau
+      - Ändere das Erdgeschoss blau
+      - setze das Erdgeschoss auf Blau
+      - verändere Licht Erdgeschoss Blau
+      - änder das Licht im Erdgeschoss Blau
+      - setze Das Licht im Erdgeschoss auf Blau
+      - Setze die Farbe des Erdgeschoss Blau
+      - änder die Farbe im Erdgeschoss auf Blau
+      - setz die Farbe des Licht Erdgeschoss Blau
+      - ändere die Farbe des Lichtes im Erdgeschoss blau
+      - setz die Farbe aller Lichter im Erdgeschoss auf Blau
+      - ändere Die Farbe aller Lampen im Erdgeschoss auf Blau
+      - verändere die Lichter im Erdgeschoss Blau
+      - veränder Die Lampen im Erdgeschoss Blau
+      - änder Die Leuchten im Erdgeschoss auf Blau
+      - veränder Alle Lichter im Erdgeschoss Blau
+      - setz Alle Leuchten im Erdgeschoss auf Blau
+      - Stell das Erdgeschoss blau
+      - stelle das Erdgeschoss auf Blau
+      - Stell das Licht im Erdgeschoss Blau
+      - Stell Das Licht im Erdgeschoss auf Blau
+      - Stell die Farbe im Erdgeschoss Blau
+      - Stelle die Farbe des Erdgeschoss auf Blau
+      - Stell die Farbe des Licht im Erdgeschoss Blau
+      - Stelle die Farbe des Lichts im Erdgeschoss Blau
+      - Stell die Farbe des Lichtes im Erdgeschoss blau
+      - Stelle die Farbe aller Lichter im Erdgeschoss auf Blau
+      - Stell Die Farbe aller Lampen im Erdgeschoss auf Blau
+      - Stell die Lichter im Erdgeschoss Blau
+      - Stell Die Lampen im Erdgeschoss Blau
+      - stelle Die Leuchten im Erdgeschoss auf Blau
+      - Stell Alle Lichter im Erdgeschoss Blau
+      - Stell Alle Leuchten im Erdgeschoss auf Blau
+      - änder Das Licht im Erdgeschoss zu Blau
+      - änder die Farbe im Erdgeschoss zu Blau
+      - ändere die Farbe aller Lichter im Erdgeschoss zu Blau
+      - ändere Die Farbe aller Lampen im Erdgeschoss zu Blau
+      - änder Die Leuchten im Erdgeschoss zu Blau
+      - ändere Alle Leuchten im Erdgeschoss zu Blau
+      - Farbe im Erdgeschoss Blau einstellen
+      - Farbe im Erdgeschoss auf Blau einstellen
+      - Farbe im Erdgeschoss zu blau verändern
+      - Die Farbe im Erdgeschoss Blau einstellen
+      - Die Farbe im Erdgeschoss auf Blau einstellen
+      - Die Farbe im Erdgeschoss zu blau verändern
+      - Farbe Licht im Erdgeschoss Blau einstellen
+      - Farbe Licht im Erdgeschoss auf Blau einstellen
+      - Farbe Licht im Erdgeschoss zu blau verändern
+      - Farbe des Licht im Erdgeschoss Blau einstellen
+      - Farbe des Lichtes im Erdgeschoss auf Blau einstellen
+      - Farbe der Lampen im Erdgeschoss zu blau verändern
+      - Die Farbe der Leuchten im Erdgeschoss Blau einstellen
+      - Die Farbe der Beleuchtung im Erdgeschoss auf Blau einstellen
+      - Die Farbe der Lichter im Erdgeschoss zu blau verändern
+      - Farbe aller Lampen im Erdgeschoss Blau einstellen
+      - Farbe aller Beleuchtungen im Erdgeschoss auf Blau einstellen
+      - Farbe aller Leuchten im Erdgeschoss zu blau verändern
+      - Die Farbe aller Lampen im Erdgeschoss Blau einstellen
+      - Die Farbe aller Leuchten im Erdgeschoss auf Blau einstellen
+      - Die Farbe aller Lampen im Erdgeschoss zu blau verändern
+      - Erdgeschoss Farbe Blau einstellen
+      - Erdgeschoss Farbe auf Blau einstellen
+      - Erdgeschoss Farbe zu Blau verändern
+      - Im Erdgeschoss Farbe Blau einstellen
+      - im Erdgeschoss Farbe auf Blau einstellen
+      - im Erdgeschoss die Farbe zu Blau verändern
+      - Licht Erdgeschoss Farbe Blau einstellen
+      - Licht im Erdgeschoss Farbe auf Blau einstellen
+      - Beim Licht im Erdgeschoss die Farbe zu blau verändern
+      - Lichter Erdgeschoss Farbe Blau einstellen
+      - Leuchten im Erdgeschoss Farbe auf Blau einstellen
+      - Die Lampen im Erdgeschoss Farbe zu blau verändern
+      - Alle Lampen im Erdgeschoss Farbe Blau einstellen
+      - Bei allen Lampen im Erdgeschoss Farbe auf Blau einstellen
+      - Alle Lichter im Erdgeschoss die Farbe zu blau verändern
+      - Erdgeschoss blau leuchten lassen
+      - Erdgeschoss in Farbe Blau einfärben
+      - Erdgeschoss in Blau leuchten lassen
+      - Licht im Erdgeschoss blau leuchten lassen
+      - Lampen im Erdgeschoss in Farbe Blau einfärben
+      - Leuchten im Erdgeschoss in Blau leuchten lassen
+      - Lichter im Erdgeschoss in Blau leuchten lassen
+      - Alle Lichter im Erdgeschoss blau leuchten lassen
+      - Alle Lampen im Erdgeschoss in Farbe Blau einfärben
+      - Alle Leuchten im Erdgeschoss in Blau leuchten lassen
+      - Färbe die Lichter im Erdgeschoss blau ein
+      - Färbe die Lampen im Erdgeschoss blau
+      - Färbe alle Lichter im Erdgeschoss blau
+      - Färbe alle Lampen im Erdgeschoss blau ein
+    intent:
+      name: HassLightSet
+      slots:
+        floor: Erdgeschoss
+        color: blue
+    response: Farbe eingestellt
+
+  # color by area
   - sentences:
       - Stelle die Farbe im Schlafzimmer auf blau
       - Stelle Farbe im Schlafzimmer auf blau
@@ -231,6 +358,110 @@ tests:
       - Stelle die Farbe des Lichts im Schlafzimmer auf blau
       - Färbe das Licht im Schlafzimmer blau
       - Die Farbe des Lichts im Schlafzimmer auf blau setzen
+      - Schlafzimmer auf Blau
+      - Licht Schlafzimmer Blau
+      - Licht im Schlafzimmer Blau
+      - Das Licht im Schlafzimmer auf Blau
+      - Farbe Schlafzimmer Blau
+      - Farbe Schlafzimmer auf Blau
+      - Farbe des Licht Schlafzimmer Blau
+      - Farbe des Lichts im Schlafzimmer Blau
+      - die Farbe des Lichtes im Schlafzimmer blau
+      - Farbe aller Lichter im Schlafzimmer auf Blau
+      - Die Farbe aller Lampen im Schlafzimmer auf Blau
+      - Lichter im Schlafzimmer Blau
+      - Die Lampen im Schlafzimmer Blau
+      - Die Leuchten im Schlafzimmer auf Blau
+      - Alle Lichter im Schlafzimmer Blau
+      - Alle Leuchten im Schlafzimmer auf Blau
+      - Ändere das Schlafzimmer blau
+      - setze das Schlafzimmer auf Blau
+      - verändere Licht Schlafzimmer Blau
+      - änder das Licht im Schlafzimmer Blau
+      - setze Das Licht im Schlafzimmer auf Blau
+      - Setze die Farbe des Schlafzimmers Blau
+      - änder die Farbe im Schlafzimmer auf Blau
+      - setz die Farbe des Licht Schlafzimmer Blau
+      - ändere die Farbe des Lichtes im Schlafzimmer blau
+      - setz die Farbe aller Lichter im Schlafzimmer auf Blau
+      - ändere Die Farbe aller Lampen im Schlafzimmer auf Blau
+      - verändere die Lichter im Schlafzimmer Blau
+      - veränder Die Lampen im Schlafzimmer Blau
+      - änder Die Leuchten im Schlafzimmer auf Blau
+      - veränder Alle Lichter im Schlafzimmer Blau
+      - setz Alle Leuchten im Schlafzimmer auf Blau
+      - Stell das Schlafzimmer blau
+      - stelle das Schlafzimmer auf Blau
+      - Stell das Licht im Schlafzimmer Blau
+      - Stell Das Licht im Schlafzimmer auf Blau
+      - Stell die Farbe im Schlafzimmer Blau
+      - Stelle die Farbe des Schlafzimmers auf Blau
+      - Stell die Farbe des Licht im Schlafzimmer Blau
+      - Stelle die Farbe des Lichts im Schlafzimmer Blau
+      - Stell die Farbe des Lichtes im Schlafzimmer blau
+      - Stelle die Farbe aller Lichter im Schlafzimmer auf Blau
+      - Stell Die Farbe aller Lampen im Schlafzimmer auf Blau
+      - Stell die Lichter im Schlafzimmer Blau
+      - Stell Die Lampen im Schlafzimmer Blau
+      - stelle Die Leuchten im Schlafzimmer auf Blau
+      - Stell Alle Lichter im Schlafzimmer Blau
+      - Stell Alle Leuchten im Schlafzimmer auf Blau
+      - änder Das Licht im Schlafzimmer zu Blau
+      - änder die Farbe im Schlafzimmer zu Blau
+      - ändere die Farbe aller Lichter im Schlafzimmer zu Blau
+      - ändere Die Farbe aller Lampen im Schlafzimmer zu Blau
+      - änder Die Leuchten im Schlafzimmer zu Blau
+      - ändere Alle Leuchten im Schlafzimmer zu Blau
+      - Farbe im Schlafzimmer Blau einstellen
+      - Farbe im Schlafzimmer auf Blau einstellen
+      - Farbe im Schlafzimmer zu blau verändern
+      - Die Farbe im Schlafzimmer Blau einstellen
+      - Die Farbe im Schlafzimmer auf Blau einstellen
+      - Die Farbe im Schlafzimmer zu blau verändern
+      - Farbe Licht im Schlafzimmer Blau einstellen
+      - Farbe Licht im Schlafzimmer auf Blau einstellen
+      - Farbe Licht im Schlafzimmer zu blau verändern
+      - Farbe des Licht im Schlafzimmer Blau einstellen
+      - Farbe des Lichtes im Schlafzimmer auf Blau einstellen
+      - Farbe der Lampen im Schlafzimmer zu blau verändern
+      - Die Farbe der Leuchten im Schlafzimmer Blau einstellen
+      - Die Farbe der Beleuchtung im Schlafzimmer auf Blau einstellen
+      - Die Farbe der Lichter im Schlafzimmer zu blau verändern
+      - Farbe aller Lampen im Schlafzimmer Blau einstellen
+      - Farbe aller Beleuchtungen im Schlafzimmer auf Blau einstellen
+      - Farbe aller Leuchten im Schlafzimmer zu blau verändern
+      - Die Farbe aller Lampen im Schlafzimmer Blau einstellen
+      - Die Farbe aller Leuchten im Schlafzimmer auf Blau einstellen
+      - Die Farbe aller Lampen im Schlafzimmer zu blau verändern
+      - Schlafzimmer Farbe Blau einstellen
+      - Schlafzimmer Farbe auf Blau einstellen
+      - Schlafzimmer Farbe zu Blau verändern
+      - Im Schlafzimmer Farbe Blau einstellen
+      - im Schlafzimmer Farbe auf Blau einstellen
+      - im Schlafzimmer die Farbe zu Blau verändern
+      - Licht Schlafzimmer Farbe Blau einstellen
+      - Licht im Schlafzimmer Farbe auf Blau einstellen
+      - Beim Licht im Schlafzimmer die Farbe zu blau verändern
+      - Lichter Schlafzimmer Farbe Blau einstellen
+      - Leuchten im Schlafzimmer Farbe auf Blau einstellen
+      - Die Lampen im Schlafzimmer Farbe zu blau verändern
+      - Alle Lampen im Schlafzimmer Farbe Blau einstellen
+      - Bei allen Lampen im Schlafzimmer Farbe auf Blau einstellen
+      - Alle Lichter im Schlafzimmer die Farbe zu blau verändern
+      - Schlafzimmer blau leuchten lassen
+      - Schlafzimmer in Farbe Blau einfärben
+      - Schlafzimmer in Blau leuchten lassen
+      - Licht im Schlafzimmer blau leuchten lassen
+      - Lampen im Schlafzimmer in Farbe Blau einfärben
+      - Leuchten im Schlafzimmer in Blau leuchten lassen
+      - Lichter im Schlafzimmer in Blau leuchten lassen
+      - Alle Lichter im Schlafzimmer blau leuchten lassen
+      - Alle Lampen im Schlafzimmer in Farbe Blau einfärben
+      - Alle Leuchten im Schlafzimmer in Blau leuchten lassen
+      - Färbe die Lichter im Schlafzimmer blau ein
+      - Färbe die Lampen im Schlafzimmer blau
+      - Färbe alle Lichter im Schlafzimmer blau
+      - Färbe alle Lampen im Schlafzimmer blau ein
     intent:
       name: HassLightSet
       slots:
@@ -238,13 +469,173 @@ tests:
         color: blue
     response: Farbe eingestellt
 
+  # color by satellite area
   - sentences:
       - Stelle die Farbe auf blau
-      - Alle Lichter blau färben
-      - Alle Lichter blau leuchten lassen
-      - Alle Lichter blau
+      - Alle Lichter hier blau färben
+      - Alle Lichter in diesem Raum blau leuchten lassen
+      - Alle Lichter hier blau
+      - Farbe des Lichts auf blau
+      - Farbe des Lichts blau
+      - Farbe der Lichter blau
+      - Farbe Licht blau
+      - Lichter auf blau
+      - Lichter blau
+      - Licht auf blau
+      - Licht blau
+      - Farbe des Lichts hier auf blau
+      - Farbe des Lichts hier blau
+      - Farbe der Lichter hier blau
+      - Farbe Licht hier blau
+      - Lichter hier auf blau
+      - Lichter hier blau
+      - Licht hier auf blau
+      - Licht hier blau
+      - setz die Farbe des Lichts auf blau
+      - mache die Farbe des Lichts blau
+      - verändere die Farbe der Lichter blau
+      - ändere die Lichter auf blau
+      - mach die Lichter blau
+      - änder das Licht auf blau
+      - ändere das Licht blau
+      - Ändere die Farbe des Lichts hier auf blau
+      - setz die Farbe des Lichts hier blau
+      - mach die Farbe der Lichter hier blau
+      - änder die Lichter hier auf blau
+      - mache die Lichter hier blau
+      - änder das Licht hier auf blau
+      - mach das Licht hier blau
+      - stell die Farbe des Lichts auf blau
+      - stelle die Farbe des Lichts blau
+      - stell die Farbe der Lichter blau
+      - stelle die Lichter auf blau
+      - stell die Lichter blau
+      - stell das Licht auf blau
+      - stell das Licht blau
+      - stell die Farbe des Lichts hier auf blau
+      - stelle die Farbe des Lichts hier blau
+      - stell die Farbe der Lichter hier blau
+      - stelle die Lichter hier auf blau
+      - stell die Lichter hier blau
+      - stell das Licht hier auf blau
+      - stell das Licht hier blau
+      - änder das Licht zu blau
+      - ändere die Farbe zu blau
+      - ändere die Farbe des Lichts zu blau
+      - veränder die Farbe der Lichter zu blau
+      - änder die Lichter zu blau
+      - änder das Licht hier zu blau
+      - ändere die Farbe hier zu blau
+      - ändere die Farbe des Lichts hier zu blau
+      - veränder die Farbe der Lichter hier zu blau
+      - änder die Lichter hier zu blau
+      - Farbe Blau einstellen
+      - Farbe blau ändern
+      - Die Farbe auf Blau einstellen
+      - Farbe zu blau ändern
+      - Farbe auf Blau setzen
+      - Farbe Licht Blau einstellen
+      - Farbe Licht blau ändern
+      - Farbe Licht auf Blau einstellen
+      - Farbe Licht zu blau ändern
+      - Farbe Licht auf Blau setzen
+      - Farbe des Lichts Blau einstellen
+      - Farbe des Lichtes blau ändern
+      - Farbe des Licht auf Blau einstellen
+      - Farbe des Lichtes zu blau ändern
+      - Farbe des Lichts auf Blau setzen
+      - Farbe Lichter Blau einstellen
+      - Farbe der Lichter blau ändern
+      - Die Farbe der Lampen auf Blau einstellen
+      - Farbe der beleuchtung zu blau ändern
+      - Die Farbe der Lichter auf Blau setzen
+      - Farbe hier Blau einstellen
+      - Farbe hier blau ändern
+      - Die Farbe hier auf Blau einstellen
+      - Farbe hier zu blau ändern
+      - Farbe hier auf Blau setzen
+      - Farbe Licht hier Blau einstellen
+      - Farbe Licht hier blau ändern
+      - Farbe Licht hier auf Blau einstellen
+      - Farbe Licht hier zu blau ändern
+      - Farbe Licht hier auf Blau setzen
+      - Farbe des Lichts hier Blau einstellen
+      - Farbe des Lichtes hier blau ändern
+      - Farbe des Licht hier auf Blau einstellen
+      - Farbe des Lichtes hier zu blau ändern
+      - Farbe des Lichts hier auf Blau setzen
+      - Farbe Lichter hier Blau einstellen
+      - Farbe der Lichter hier blau ändern
+      - Die Farbe der Lampen im Raum auf Blau einstellen
+      - Farbe der beleuchtung im Raum zu blau ändern
+      - Die Farbe der Lichter hier auf Blau setzen
+      - Blau
+      - Farbe Blau
+      - Farbe auf Blau ändern
+      - Farbe zu Blau verändern
+      - Hier Farbe Blau
+      - Hier die Farbe Blau einstellen
+      - Im Raum die Farbe auf Blau ändern
+      - im Raum die Farbe zu Blau verändern
+      - Licht Farbe Blau
+      - Licht Farbe Blau einstellen
+      - Licht hier Farbe Blau einstellen
+      - Beim Licht im Raum die Farbe auf Blau ändern
+      - Licht hier Farbe zu Blau ändern
+      - Lichter Farbe Blau
+      - Lampen Farbe Blau einstellen
+      - Leuchten hier Farbe Blau einstellen
+      - Beleuchtungen im Raum Farbe auf Blau ändern
+      - Lichter hier Farbe zu Blau ändern
+      - Blau leuchten lassen
+      - Farbe Blau erleuchten lassen
+      - Hier blau leuchten lassen
+      - hier farbe blau erleuchten lassen
+      - diesen Raum Blau erleuchten lassen
+      - Licht hier blau erleuchten lassen
+      - Licht in diesem Raum Blau leuchten lassen
+      - Diesen Raum in Blau leuchten lassen
+      - Das Licht hier in diesem Raum Blau leuchten lassen
+      - Lichter hier blau erleuchten lassen
+      - Lichter in diesem Raum Blau leuchten lassen
+      - Die Lichter hier in diesem Raum Blau leuchten lassen
+      - Färbe das Licht blau
+      - Färbe die Lichter Blau
+      - Färbe das Licht blau ein
+      - Färbe die Lichter Blau ein
+      - Färbe das Licht hier blau
+      - Färbe die Lichter in diesem Raum Blau
+      - Färbe das Licht hier im Raum blau ein
+      - Färbe die Lichter hier in diesem Raum Blau ein
+      - Farbe Licht Blau
+      - Farbe Licht in diesem Raum Blau
+      # <alle lichter> + <hier>
+      - Die Farbe aller Lichter hier auf blau
+      - Farbe aller Lichter hier Blau
+      - alle Lichter hier blau
+      - alle Lichter in diesem Raum auf Blau
+      - ändere die Farbe aller Lichter in diesem Raum auf Blau
+      - stell die Farbe aller Lampen hier auf blau
+      - stelle alle Lichter in diesem Raum auf blau ein
+      - ändere die Farbe aller Lichter in diesem raum zu blau
+      - verändere alle Lampen hier zu blau
+      - die Farbe aller Lampen hier auf blau ändern
+      - bei allen Lampen in diesem Raum die Farbe zu blau verändern
+      - alle Lampen in diesem Raum Farbe auf blau
+      - alle lampen hier blau leuchten lassen
+      - alle lampen in diesem Raum in blau leuchten lassen
+      - alle lampen in diesem Raum in Farbe blau leuchten lassen
+      - Färbe alle lampen in diesem Raum blau
+      - Färbe alle lampen in diesem Raum blau ein
+      - Farbe aller Lampen hier blau
+      - Farbe aller Leuchten in diesem Raum blau einstellen
+
+
     intent:
       name: HassLightSet
+      context:
+        area: Schlafzimmer
       slots:
         color: blue
+        area: Schlafzimmer
     response: Farbe eingestellt


### PR DESCRIPTION
This is the third step in a bigger change process for HassLightSet. ( see PR #3294 )

This PR optimizes color controls by area.
Color controls by floor and by corresponding satellite area are also introduced in this PR.
This PR also removes previously allowed but not working slot combinations - so hopefully no more "Es ist ein Fehler aufgetreten".

I decided to implement sentences with `<alle_lichter>` only together with either `<hier>` or `<area_floor>` since without one of those two the behavior of hassLightSet would not be consistent with Light turnOn/Off where `<alle_lichter>` without any further context turns on or off all lights everywhere.

overall sentence count compared to step 2 ( #3315 ) ~ + 6 million. while this is quite a lot there is a lot of new functionality introduced with this PR as well and #3314 reduced OSC quite a lot 😉
If you find potential to further reduce sentence count within this PR I´m happy to adjust!

changes to the commons file are covered by #3314 and will be removed/unnecessary once that PR is merged.
changes to light_HassLightSet in lines 25/26, 32-35 and 53-58 are covered by previous PRs (#3314 #3315 ) and will be removed or unnecessary as well once the previous PRs are merged.