### PR TITLE
[DE] move area-aware sentences to "<hier> expansion rule

### DIFF
--- a/sentences/de/homeassistant_HassCancelAllTimers.yaml
+++ b/sentences/de/homeassistant_HassCancelAllTimers.yaml
@@ -16,9 +16,9 @@ intents:
 
       # cancel all timers in same area as the voice satellite
       - sentences:
-          - "<timer_cancel> (alle[ meine]|sämtliche) Timer (hier|in diesem [Bereich|Raum])"
-          - "<timer_cancel> (hier|in diesem [Bereich|Raum]) (alle[ meine]|sämtliche) Timer"
-          - "(alle[ meine]|sämtliche[ meiner]) Timer (hier|in diesem [Bereich|Raum]) <timer_cancel_end_of_sentence>"
+          - "<timer_cancel> (alle[ meine]|sämtliche) Timer <hier>"
+          - "<timer_cancel> <hier> (alle[ meine]|sämtliche) Timer"
+          - "(alle[ meine]|sämtliche[ meiner]) Timer <hier> <timer_cancel_end_of_sentence>"
         response: area
         requires_context:
           area:

--- a/sentences/de/light_HassTurnOff.yaml
+++ b/sentences/de/light_HassTurnOff.yaml
@@ -19,12 +19,12 @@ intents:
 
       # Turn off all lights in the same area as a satellite device
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>)[ hier] aus"
-          - "(<schalten>|dreh[e]) (<licht>|<lichter>)[ hier] ab"
-          - "(<schalten>|<machen>) hier (<licht>|<lichter>) aus"
-          - "(<schalten>|dreh[e]) hier (<licht>|<lichter>) ab"
-          - "(<licht>|<lichter>)[ hier] (aus[schalten]|abschalten|ausmachen|abdrehen)"
-          - "hier (<licht>|<lichter>) (aus[schalten]|abschalten|ausmachen|abdrehen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>)[ <hier>] aus"
+          - "(<schalten>|dreh[e]) (<licht>|<lichter>)[ <hier>] ab"
+          - "(<schalten>|<machen>) <hier> (<licht>|<lichter>) aus"
+          - "(<schalten>|dreh[e]) <hier> (<licht>|<lichter>) ab"
+          - "(<licht>|<lichter>)[ <hier>] (aus[schalten]|abschalten|ausmachen|abdrehen)"
+          - "<hier> (<licht>|<lichter>) (aus[schalten]|abschalten|ausmachen|abdrehen)"
         response: "light"
         slots:
           domain: "light"

--- a/sentences/de/light_HassTurnOn.yaml
+++ b/sentences/de/light_HassTurnOn.yaml
@@ -23,14 +23,14 @@ intents:
 
       # Turn on all lights in the same area as a satellite device
       - sentences:
-          - "(<schalten>|<machen>) (<licht>|<lichter>)[ hier] an"
-          - "<schalten> (<licht>|<lichter>)[ hier] ein"
-          - "dreh[e] (<licht>|<lichter>)[ hier] auf"
-          - "(<schalten>|<machen>) hier (<licht>|<lichter>) an"
-          - "<schalten> hier (<licht>|<lichter>) ein"
-          - "dreh[e] hier (<licht>|<lichter>) auf"
-          - "(<licht>|<lichter>)[ hier] ((an|ein)[schalten]|anmachen|aufdrehen)"
-          - "hier (<licht>|<lichter>) ((an|ein)[schalten]|anmachen|aufdrehen)"
+          - "(<schalten>|<machen>) (<licht>|<lichter>)[ <hier>] an"
+          - "<schalten> (<licht>|<lichter>)[ <hier>] ein"
+          - "dreh[e] (<licht>|<lichter>)[ <hier>] auf"
+          - "(<schalten>|<machen>) <hier> (<licht>|<lichter>) an"
+          - "<schalten> <hier> (<licht>|<lichter>) ein"
+          - "dreh[e] <hier> (<licht>|<lichter>) auf"
+          - "(<licht>|<lichter>)[ <hier>] ((an|ein)[schalten]|anmachen|aufdrehen)"
+          - "<hier> (<licht>|<lichter>) ((an|ein)[schalten]|anmachen|aufdrehen)"
         response: "light"
         slots:
           domain: "light"

--- a/tests/de/homeassistant_HassCancelAllTimers.yaml
+++ b/tests/de/homeassistant_HassCancelAllTimers.yaml
@@ -78,6 +78,7 @@ tests:
 
   - sentences:
       - "beende alle Timer hier"
+      - "beende alle Timer hier im Raum"
       - "beende sämtliche Timer hier"
       - "beende alle meine Timer hier"
       - "beende alle Timer in diesem Bereich"
@@ -87,6 +88,7 @@ tests:
       - "beende sämtliche Timer in diesem Raum"
       - "beende alle meine Timer in diesem Raum"
       - "beende hier alle Timer "
+      - "beende in diesem Raum alle Timer "
       - "beende hier sämtliche Timer"
       - "beende hier alle meine Timer"
       - "beende in diesem Bereich alle Timer"
@@ -126,6 +128,7 @@ tests:
       - "alle meine Timer hier abbrechen"
       - "alle meine Timer hier stoppen"
       - "alle meine Timer hier aus"
+      - "alle Timer in diesem Raum abbrechen"
       - "sämtliche Timer hier ausschalten"
       - "sämtliche Timer hier deaktivieren"
       - "sämtliche Timer hier abbrechen"

--- a/tests/de/light_HassTurnOff.yaml
+++ b/tests/de/light_HassTurnOff.yaml
@@ -104,6 +104,12 @@ tests:
       - Licht abdrehen
       - Hier die Lichter abdrehen
       - Hier das Licht abdrehen
+      - schalte die lichter in diesem Raum aus
+      - dreh die Lichter in diesem Bereich ab
+      - schalte in diesem Raum die Lichter aus
+      - schalte in diesem Raum die Lampen ab
+      - Das Licht im Raum ausschalten
+      - in diesem Raum die Lampen aus
     intent:
       name: HassTurnOff
       context:

--- a/tests/de/light_HassTurnOn.yaml
+++ b/tests/de/light_HassTurnOn.yaml
@@ -112,6 +112,11 @@ tests:
       - Drehe hier Die Lichter auf
       - Hier das Licht aufdrehen
       - Die Lichter hier aufdrehen
+      - mach das licht in diesem Raum an
+      - schalte die Lichter im Raum an
+      - dreh die Lichter in diesem Raum auf
+      - schalte hier im Raum das Licht an
+      - in diesem raum die Lampen anschalten
     intent:
       name: HassTurnOn
       context:


### PR DESCRIPTION
This PR extends area-aware sentences that used `hier` to the `<hier>` expansion rule to cover variations like
- im Raum
- in diesem Raum
- hier im Raum
- in diesem Bereich
- ...
