### PR TITLE
Handle no match in get state response

### DIFF
--- a/responses/en/HassGetState.yaml
+++ b/responses/en/HassGetState.yaml
@@ -67,8 +67,12 @@ responses:
         {{ query.matched | length }}
 
       where: |
-        {% if state == "not_home" %}
-          {{ slots.name | capitalize }} is away
-        {% else %}
-          {{ slots.name | capitalize }} is at {{ state.state }}
+        {% if not query.matched %}
+          Sorry, I am not aware of any person named {{ slots.name | capitalize }}
+        {% else: %}
+          {% if state == "not_home" %}
+            {{ slots.name | capitalize }} is away
+          {% else %}
+            {{ slots.name | capitalize }} is at {{ state.state }}
+          {% endif %}
         {% endif %}

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -349,6 +349,7 @@ TESTS_FIXTURES = vol.Schema(
                     str, {vol.Required("in"): str, vol.Required("out"): str}
                 ),
                 vol.Optional("attributes"): {str: match_anything},
+                vol.Optional("is_exposed"): bool,
             }
         ],
         vol.Optional("timers"): [

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -27,6 +27,7 @@ class State:
     area_id: Optional[str] = None
     human_state: Optional[str] = None
     aliases: Set[str] = field(default_factory=set)
+    is_exposed: bool = True
     _domain: Optional[str] = None
 
     @property
@@ -174,6 +175,10 @@ def get_matched_states(
     unmatched: List[State] = []
 
     for state in states:
+        if not state.is_exposed:
+            # Ignore unexposed entities
+            continue
+
         if entity_name is not None:
             name_match = _normalize_name(state.name) == entity_name
 
@@ -470,6 +475,7 @@ def get_states(fixtures: dict[str, Any]) -> List[State]:
                 human_state=human_state,
                 area_id=entity.get("area"),
                 attributes=entity.get("attributes", {}),
+                is_exposed=entity.get("is_exposed", True),
             )
         )
     return states

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -743,6 +743,10 @@ entities:
   - name: "John"
     id: "person.john"
     state: "not_home"
+  - name: "Bob"
+    id: "person.bob"
+    state: "home"
+    is_exposed: false
 
   - name: "Trader Joe[']s"
     id: "todo.trader_joes"

--- a/tests/en/person_HassGetState.yaml
+++ b/tests/en/person_HassGetState.yaml
@@ -63,3 +63,12 @@ tests:
         domain: person
         state: home
     response: "1"
+
+  - sentences:
+      - "where is Bob"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        name: Bob
+    response: "Sorry, I am not aware of any person named Bob"


### PR DESCRIPTION
Related: https://github.com/home-assistant/core/pull/148241

Adds an `is_exposed` field to test fixture entities so we can check sentences like "where is Bob" with "Bob" being a person entity that is not exposed.

The `where` response for English checks `query.matched` and gives an appropriate response.