### PR TITLE
[DE] Improve processing of sentences

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -569,7 +569,7 @@ expansion_rules:
   preposition: "(in|an|bei|auf)"
   name: "[<artikel_bestimmt> ]{name}"
   area: "[(<preposition>|<artikel_bestimmt>) ]{area}|(<preposition> der|(an|in) die|in dem|im|am|<von_dem>) {area}|des {area}s"
-  floor: "[[in|auf] <artikel_bestimmt>|im|<von_dem>] {floor}[[ ]Geschoss]"
+  floor: "[([(in|auf) ]<artikel_bestimmt>|im|<von_dem>) ]{floor}[[ ]Geschoss]"
   area_floor: "(<area>|<floor>)"
   an: "(an|ein|auf)"
   aus: "(aus|ab|zu)"

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -563,12 +563,13 @@ lists:
       multiplier: -1
 
 expansion_rules:
-  artikel_bestimmt: "[(der|die|das|dem|den|des)]"
-  artikel_unbestimmt: "[(ein|eine|eines|einer|einem|einen)]"
-  artikel: "[<artikel_bestimmt>|<artikel_unbestimmt>]"
-  name: "<artikel_bestimmt> {name}"
-  area: "[([(in|an|auf|bei) ][<artikel_bestimmt> ]|(im|am|<von_dem>) )]{area}[s]"
-  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>|das|des) ]{floor}[ Geschoss]"
+  artikel_bestimmt: "(der|die|das|dem|den|des)"
+  artikel_unbestimmt: "(ein|eine|eines|einer|einem|einen)"
+  artikel: "<artikel_bestimmt>|<artikel_unbestimmt>"
+  preposition: "in|an|bei|auf"
+  name: "[<artikel_bestimmt>] {name}"
+  area: "[<preposition>|<artikel_bestimmt>] {area}|(<preposition> der|(an|in) die|in dem|im|am|<von_dem>) {area}|des {area}s"
+  floor: "[[in|auf] <artikel_bestimmt>|im|<von_dem>] {floor}[[ ]Geschoss]"
   area_floor: "(<area>|<floor>)"
   an: "(an|ein|auf)"
   aus: "(aus|ab|zu)"

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -566,7 +566,7 @@ expansion_rules:
   artikel_bestimmt: "(der|die|das|dem|den|des)"
   artikel_unbestimmt: "(ein|eine|eines|einer|einem|einen)"
   artikel: "<artikel_bestimmt>|<artikel_unbestimmt>"
-  preposition: "in|an|bei|auf"
+  preposition: "(in|an|bei|auf)"
   name: "[<artikel_bestimmt>] {name}"
   area: "[<preposition>|<artikel_bestimmt>] {area}|(<preposition> der|(an|in) die|in dem|im|am|<von_dem>) {area}|des {area}s"
   floor: "[[in|auf] <artikel_bestimmt>|im|<von_dem>] {floor}[[ ]Geschoss]"

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -568,7 +568,7 @@ expansion_rules:
   artikel: "<artikel_bestimmt>|<artikel_unbestimmt>"
   preposition: "(in|an|bei|auf)"
   name: "[<artikel_bestimmt> ]{name}"
-  area: "[<preposition>|<artikel_bestimmt>] {area}|(<preposition> der|(an|in) die|in dem|im|am|<von_dem>) {area}|des {area}s"
+  area: "[(<preposition>|<artikel_bestimmt>) ]{area}|(<preposition> der|(an|in) die|in dem|im|am|<von_dem>) {area}|des {area}s"
   floor: "[[in|auf] <artikel_bestimmt>|im|<von_dem>] {floor}[[ ]Geschoss]"
   area_floor: "(<area>|<floor>)"
   an: "(an|ein|auf)"

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -567,7 +567,7 @@ expansion_rules:
   artikel_unbestimmt: "(ein|eine|eines|einer|einem|einen)"
   artikel: "<artikel_bestimmt>|<artikel_unbestimmt>"
   preposition: "(in|an|bei|auf)"
-  name: "[<artikel_bestimmt>] {name}"
+  name: "[<artikel_bestimmt> ]{name}"
   area: "[<preposition>|<artikel_bestimmt>] {area}|(<preposition> der|(an|in) die|in dem|im|am|<von_dem>) {area}|des {area}s"
   floor: "[[in|auf] <artikel_bestimmt>|im|<von_dem>] {floor}[[ ]Geschoss]"
   area_floor: "(<area>|<floor>)"


### PR DESCRIPTION
German is one of the slowest languages in 🤖 **tests** processing, top seen are `sl, nl, hu, de` .

⚠️ Note that this is caused by the large amount of tests that are included, as there are lots of repeated sentences with variance of verbs (which indeed should be reduced to improve the processing times).

This PR refactors some sentences processing to improve _a bit_ the time in tests (and hopefully make computers a little more green 🍀)

Sentence generation changes from `81,601,867` to `35,355,696` (56.67% reduction).
Taken from changes in 6e9505a1db5de7198f18efb5ac2f20bfd0ece4ae , from `41,739,013` to `23,536,374` (43.61% reduction).