### PR TITLE
[DE] reduce overall sentence count by optimizing light-related expansion rules

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -344,6 +344,10 @@ lists:
         out: 100
       - in: (min[imal[e]|imum]|niedrigste)
         out: 1
+  brightness_level_max:
+    values:
+      - in: (hell[ste Stufe]|(maximale|volle|grö(ss|ß)te|höchste) Helligkeit[sstufe]|Helligkeit ((maxim(al|um)|voll)|(maximale|volle|grö(ss|ß)te|höchste) Stufe))
+        out: 100
   cover_states:
     values:
       - in: "(offen|auf|oben|geöffnet)"

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -18,6 +18,7 @@ intents:
           - "[die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <area>] auf <brightness> <setzen_end_of_sentence>"
           - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ <area>][ (auf|zu)] <brightness>"
           - "[<licht>|<lichter>|<alle_lichter>][ <area>][ (auf|zu)] <brightness> dimmen"
+          - "<area> [auf ]{brightness_level:brightness}[ Stufe]"
         response: brightness
       - sentences:
           - "[<setzen> ][die ]Helligkeit [<hier> ]auf <brightness>"

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -18,7 +18,7 @@ intents:
           - "[die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <area>] auf <brightness> <setzen_end_of_sentence>"
           - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ <area>][ (auf|zu)] <brightness>"
           - "[<licht>|<lichter>|<alle_lichter>][ <area>][ (auf|zu)] <brightness> dimmen"
-          - "<area> [auf ]{brightness_level:brightness}[ Stufe]"
+          - "<area> [auf ]{brightness_level_max:brightness}"
         response: brightness
       - sentences:
           - "[<setzen> ][die ]Helligkeit [<hier> ]auf <brightness>"

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -137,6 +137,11 @@ tests:
   # brightness by area - maximum
   - sentences:
       - Schlafzimmer hell
+      - Schlafzimmer auf hell
+      - Schlafzimmer auf maximale Helligkeit
+      - Schlafzimmer auf maximale Helligkeitsstufe
+      - Schlafzimmer volle Helligkeit
+      - Schlafzimmer auf hellste Stufe
     intent:
       name: HassLightSet
       slots:

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -134,6 +134,16 @@ tests:
         name: Schlafzimmerlampe
         brightness: 10
     response: Helligkeit eingestellt
+  # brightness by area - maximum
+  - sentences:
+      - Schlafzimmer hell
+    intent:
+      name: HassLightSet
+      slots:
+        area: Schlafzimmer
+        brightness: 100
+    response: Helligkeit eingestellt
+
 
   - sentences:
       - Stelle die Helligkeit im Schlafzimmer auf 11

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -149,7 +149,6 @@ tests:
         brightness: 100
     response: Helligkeit eingestellt
 
-
   - sentences:
       - Stelle die Helligkeit im Schlafzimmer auf 11
       - Stelle Helligkeit im Schlafzimmer auf 11


### PR DESCRIPTION
This PR reduces overall sentence count by ~25 million without loosing tested sentences.
Down to currently 58 million