### PR TITLE
document count_sentences in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ You can add lists, ranges, and expansion rules as well:
 python3 -m script.intentfest sample_template 'set color to <color> and brightness to {brightness}' --values color red green --range brightness 1 2 --rule color '[the] {color}'
 ```
 
+## Determine sentence variations/permutations
+
+Using optional segments in sentence definitions can result in a wide range of sentence variations, sometimes growing unexpectedly large. This can impact performance, especially on lower-powered devices.
+
+To check the size of a language configuration, use the following command. It helps identify overly broad definitions, refine sentence structures, and ensure more natural, efficient interactions with Assist - without unnecessary complexity that could slow down processing.
+
+Summary per intent per language:
+```sh
+python3 -m script.intentfest count_sentences --language nl --summary
+```
+
+Details on permutations per intent per language:
+```sh
+python3 -m script.intentfest count_sentences --language nl
+```
+
 ## Generate LLM prompt to help with translations
 
 If you start to translate a new intent, you can generate a prompt to paste into ChatGPT or another LLM to help with translations


### PR DESCRIPTION
I always forget how to use `count_sentences` and think this should also be promoted better in `README` as not every language leader is aware that keeping an eye on permutations is beneficial.