### PR TITLE
[DE] HassLightSet: support for color by satellite area

### DIFF
--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -54,7 +54,7 @@ intents:
           - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])] <area>[ auf] {color}"
           - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)]) <area> zu {color}"
           - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area>[ (auf|zu)] {color} <setzen_end_of_sentence>"
-          - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ]<area>  Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ]<area> Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
           - "[(<licht>|<lichter>|<alle_lichter>) ]<area> [Farbe ]{color} <leuchten_lassen>"
           - "Färbe[ (<licht>|<lichter>|<alle_lichter>)] <area> {color}[ ein]"
         response: color

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -66,7 +66,7 @@ intents:
           - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
           - "[(<licht>|<lichter>|<alle_lichter>) ][Farbe ]{color} <leuchten_lassen>"
           - "Färbe (<licht>|<lichter>|<alle_lichter>) {color}[ ein]"
-        response: "brightness"
+        response: "color"
         requires_context:
           area:
             slot: true

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -51,10 +51,22 @@ intents:
         response: color
       # color by area
       - sentences:
-          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])][ <area>][ auf] {color}"
-          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])[ <area>] zu {color}"
-          - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <area>][ (auf|zu)] {color} <setzen_end_of_sentence>"
-          - "[<licht>|<lichtes>|<lichter>|<alle_lichter> ][<area> ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
-          - "[<licht>|<lichter>|<alle_lichter> ][<area> ][Farbe ]{color} <leuchten_lassen>"
-          - "Färbe[ (<licht>|<lichter>|<alle_lichter>)][ <area>] {color}[ ein]"
+          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])] <area>[ auf] {color}"
+          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)]) <area> zu {color}"
+          - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area>[ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ]<area>  Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[(<licht>|<lichter>|<alle_lichter>) ]<area> [Farbe ]{color} <leuchten_lassen>"
+          - "Färbe[ (<licht>|<lichter>|<alle_lichter>)] <area> {color}[ ein]"
         response: color
+      # color by satellite area
+      - sentences:
+          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])][ auf] {color}"
+          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)]) zu {color}"
+          - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[(<licht>|<lichter>|<alle_lichter>) ][Farbe ]{color} <leuchten_lassen>"
+          - "Färbe (<licht>|<lichter>|<alle_lichter>) {color}[ ein]"
+        response: "brightness"
+        requires_context:
+          area:
+            slot: true

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -276,4 +276,4 @@ tests:
       slots:
         color: blue
         area: Schlafzimmer
-    response: "Helligkeit eingestellt"
+    response: Farbe eingestellt

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -247,13 +247,33 @@ tests:
         color: blue
     response: Farbe eingestellt
 
+  # color by satellite area
   - sentences:
       - Stelle die Farbe auf blau
       - Alle Lichter blau färben
       - Alle Lichter blau leuchten lassen
       - Alle Lichter blau
+      - Stelle Farbe auf blau
+      - Farbe blau
+      - blau
+      - Färbe das Licht blau ein
+      - Färbe die Lampen blau
+      - blau einfärben
+      - Stelle die Farbe des Lichts auf blau
+      - Färbe das Licht blau
+      - Die Farbe des Lichts auf blau setzen
+      - stelle die Farbe der Lampen auf blau
+      - ändere die Farbe der Leuchten zu blau
+      - Farbe der Lichter auf blau einstellen
+      - Licht blau
+      - Lampen blau
+      - Licht Farbe auf blau ändern
+      - Lampen blau leuchten lassen
     intent:
       name: HassLightSet
+      context:
+        area: Schlafzimmer
       slots:
         color: blue
-    response: Farbe eingestellt
+        area: Schlafzimmer
+    response: "Helligkeit eingestellt"


### PR DESCRIPTION
This pr fixes color controls by area and introduces color controls by satellite area.
Similar to #3362 
i made `<area>` non-optional in the color by area section.
i fixed missing brackets which led to wrong spaces in the existing sentences.

the same sentences without `<area>` are now in a new color by satellite area section with `slot area`.
the last sentence was slightly adjusted because of the missing `<area>`(as well as in the brightness pr)