### PR TITLE
[DE] HassNeverMind test for empty response

### DIFF
--- a/tests/de/homeassistant_HassNevermind.yaml
+++ b/tests/de/homeassistant_HassNevermind.yaml
@@ -12,3 +12,4 @@ tests:
       - "doch nix"
     intent:
       name: HassNevermind
+    response: ""


### PR DESCRIPTION
get rid of `[WARN] tests/de/homeassistant_HassNevermind.yaml: 1 test(s) missing response check` in `intentfest validate`