### PR TITLE
[DE] HassLightSet: add support for color/brightness by floor

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -568,7 +568,7 @@ expansion_rules:
   artikel: "[<artikel_bestimmt>|<artikel_unbestimmt>]"
   name: "<artikel_bestimmt> {name}"
   area: "[([(in|an|auf|bei) ][<artikel_bestimmt> ]|(im|am|<von_dem>) )]{area}[s]"
-  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>|des) ]{floor}[ Geschoss]"
+  floor: "[((in|auf)[ <artikel_bestimmt>]|im|<von_dem>|das|des) ]{floor}[ Geschoss]"
   area_floor: "(<area>|<floor>)"
   an: "(an|ein|auf)"
   aus: "(aus|ab|zu)"

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -56,14 +56,14 @@ intents:
         requires_context:
           domain: light
         response: color
-      # color by area
+      # color by area/floor
       - sentences:
-          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])] <area>[ auf] {color}"
-          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)]) <area> zu {color}"
-          - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area>[ (auf|zu)] {color} <setzen_end_of_sentence>"
-          - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ]<area> Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
-          - "[(<licht>|<lichter>|<alle_lichter>) ]<area> [Farbe ]{color} <leuchten_lassen>"
-          - "Färbe[ (<licht>|<lichter>|<alle_lichter>)] <area> {color}[ ein]"
+          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])] <area_floor>[ auf] {color}"
+          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)]) <area_floor> zu {color}"
+          - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area_floor>[ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ]<area_floor> Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[(<licht>|<lichter>|<alle_lichter>) ]<area_floor> [Farbe ]{color} <leuchten_lassen>"
+          - "Färbe[ (<licht>|<lichter>|<alle_lichter>)] <area_floor> {color}[ ein]"
         response: color
       # color by satellite area
       - sentences:

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -22,14 +22,14 @@ intents:
         requires_context:
           domain: light
         response: brightness
-      # brightness by area
+      # brightness by area/floor
       - sentences:
-          - "[<setze> ][die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area>[ auf] <brightness>"
-          - "<stelle> [die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area>[ auf] <brightness>[ ein]"
-          - "[die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area> auf <brightness> <setzen_end_of_sentence>"
-          - "dimme[ (<licht>|<lichter>|<alle_lichter>)] <area>[ (auf|zu)] <brightness>"
-          - "[<licht>|<lichter>|<alle_lichter>] <area>[ (auf|zu)] <brightness> dimmen"
-          - "<area> [auf ]{brightness_level_max:brightness}"
+          - "[<setze> ][die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area_floor>[ auf] <brightness>"
+          - "<stelle> [die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area_floor>[ auf] <brightness>[ ein]"
+          - "[die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] <area_floor> auf <brightness> <setzen_end_of_sentence>"
+          - "dimme[ (<licht>|<lichter>|<alle_lichter>)] <area_floor>[ (auf|zu)] <brightness>"
+          - "[<licht>|<lichter>|<alle_lichter>] <area_floor>[ (auf|zu)] <brightness> dimmen"
+          - "<area_floor> [auf ]{brightness_level_max:brightness}"
         response: brightness
       # brightness by satellite area
       - sentences:

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -319,7 +319,27 @@ tests:
         area: Schlafzimmer
         color: blue
     response: Farbe eingestellt
-
+  # color by floor
+  - sentences:
+      - Stelle die Farbe im Erdgeschoss auf blau
+      - Stelle Farbe im Erdgeschoss auf blau
+      - Stelle Farbe Erdgeschoss auf blau
+      - Stelle Farbe Erdgeschoss blau
+      - Farbe Erdgeschoss blau
+      - Erdgeschoss Farbe blau
+      - Erdgeschoss blau
+      - Färbe das Erdgeschoss blau ein
+      - Färbe Erdgeschoss blau
+      - Erdgeschoss blau färben
+      - Stelle die Farbe des Lichts im Erdgeschoss auf blau
+      - Färbe das Licht im Erdgeschoss blau
+      - Die Farbe des Lichts im Erdgeschoss auf blau setzen
+    intent:
+      name: HassLightSet
+      slots:
+        floor: Erdgeschoss
+        color: blue
+    response: Farbe eingestellt
   # color by satellite area
   - sentences:
       - Stelle die Farbe auf blau

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -202,6 +202,38 @@ tests:
         area: Schlafzimmer
         brightness: 11
     response: Helligkeit eingestellt
+  # brightness by floor
+  - sentences:
+      - Stelle die Helligkeit im Erdgeschoss auf 15
+      - Stelle Helligkeit im Erdgeschoss auf 15
+      - Stelle Helligkeit Erdgeschoss auf 15
+      - Helligkeit im Erdgeschoss auf 15 setzen
+      - Helligkeit im Erdgeschoss auf 15
+      - Helligkeit Erdgeschoss auf 15 Prozent
+      - Helligkeit Erdgeschoss 15%
+      - Stelle die Helligkeit im Erdgeschoss auf 15 ein
+      - Ändere die Helligkeit im Erdgeschoss auf 15
+      - Setze die Helligkeit im Erdgeschoss auf 15
+      - Dimme die Lichter im Erdgeschoss auf 15
+      - Ändere die Helligkeit der Lichter im Erdgeschoss auf 15
+      - Ändere die Helligkeit aller Lichter im Erdgeschoss auf 15
+      - Helligkeit aller Lichter im Erdgeschoss auf 15
+      - Helligkeit aller Lichter im Erdgeschoss 15%
+      - Ändere die Helligkeit sämtlicher Lichter im Erdgeschoss auf 15
+      - Ändere Helligkeit sämtlicher Lichter im Erdgeschoss auf 15
+      - Helligkeit sämtlicher Lichter im Erdgeschoss auf 15
+      - Ändere die Helligkeit der ganzen Lichter im Erdgeschoss auf 15
+      - Ändere die Helligkeit der kompletten Lichter im Erdgeschoss auf 15
+      - Ändere die Helligkeit der sämtlichen Lichter im Erdgeschoss auf 15
+      - Dimme das Licht im Erdgeschoss auf 15
+      - Setze die Helligkeit des Lichts im Erdgeschoss auf 15
+      - Setze die Helligkeit des Lichtes im Erdgeschoss auf 15
+    intent:
+      name: HassLightSet
+      slots:
+        floor: Erdgeschoss
+        brightness: 15
+    response: Helligkeit eingestellt
   # brightness by satellite area
   - sentences:
       - Helligkeit hier auf 10


### PR DESCRIPTION
...as the title mentions - support for `<floor>`
while making these changes i noticed that 
> das Erdgeschos

was not covered by `<floor>` so i adjusted it to cover this case as well.