### PR TITLE
[DE] HassLightSet: further optimize sentences

### DIFF
--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -43,9 +43,9 @@ intents:
         response: brightness
       # brightness by satellite area
       - sentences:
-          - "[<setze> ][die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <hier>][ auf] <brightness>"
-          - "<stelle> [die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <hier>][ auf] <brightness>[ ein]"
-          - "[die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <hier>] auf <brightness> (<setzen_end_of_sentence>|dimmen)"
+          - "[<setze> ][die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>][ auf] <brightness>"
+          - "<stelle> [die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>][ auf] <brightness>[ ein]"
+          - "[die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>] auf <brightness> (<setzen_end_of_sentence>|dimmen)"
           - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ <hier>][ (auf|zu)] <brightness>"
           - "[(<licht>|<lichter>|<alle_lichter>) ][<hier> ](auf|zu) <brightness> dimmen"
         response: "brightness"
@@ -75,11 +75,11 @@ intents:
         response: color
       # color by satellite area
       - sentences:
-          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)]) ][<hier> ][auf ] {color}"
-          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes>|<lichter>|<alle_lichter>)])[ <hier>] zu {color}"
-          - "[die ]Farbe[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <hier>][ (auf|zu)] {color} <setzen_end_of_sentence>"
-          - "[(<licht>|<lichtes>|<lichter>|<alle_lichter>) ][<hier> ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
-          - "[(<licht>|<lichter>|<alle_lichter>) ][<hier> ][Farbe ]{color} <leuchten_lassen>"
+          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes_mit_artikel>|<lichter>|<alle_lichter>)]) ][<hier> ][auf ] {color}"
+          - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes_mit_artikel>|<lichter>|<alle_lichter>)])[ <hier>] zu {color}"
+          - "[die ]Farbe[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>][ (auf|zu)] {color} <setzen_end_of_sentence>"
+          - "[(<licht>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>) ][<hier> ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
+          - "[(<licht>|<lichtes_mit_artikel>|<alle_lichter>) ][<hier> ][Farbe ]{color} <leuchten_lassen>"
           - "Färbe (<licht>|<lichter>|<alle_lichter>)[ <hier>] {color}[ ein]"
         response: "color"
         requires_context:

--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -79,7 +79,7 @@ intents:
           - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes_mit_artikel>|<lichter>|<alle_lichter>)])[ <hier>] zu {color}"
           - "[die ]Farbe[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>][ (auf|zu)] {color} <setzen_end_of_sentence>"
           - "[(<licht>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>) ][<hier> ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
-          - "[(<licht>|<lichtes_mit_artikel>|<alle_lichter>) ][<hier> ][Farbe ]{color} <leuchten_lassen>"
+          - "[(<licht>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>) ][<hier> ][Farbe ]{color} <leuchten_lassen>"
           - "Färbe (<licht>|<lichter>|<alle_lichter>)[ <hier>] {color}[ ein]"
         response: "color"
         requires_context:


### PR DESCRIPTION
This PR applies the new `<licht_ohne_artikel>` and `<lichtes_mit_artikel>` to the remaining sentences in `light_HassLightSet.yaml`.
reduction of OSC by ~32.000