### PR TITLE
[DE] optimization of expansion rule <alle_lichter>

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -605,7 +605,7 @@ expansion_rules:
   lichtes: "([des ](Licht[s]|Lichtes)|[der ](Lampe|Beleuchtung))"
   lichtes_mit_artikel: "(des (Licht[s]|Lichtes)|der (Lampe|Beleuchtung))"
   lichter: "([(die|der) ]Lichter|[von den ]Lichtern|[(die|der|von den) ](Lampen|Leuchten|Beleuchtungen))"
-  alle_lichter: "(<alle> ((Lichter|Lampen|Leuchten|Beleuchtungen)|Beleuchtung)|von allen[ (Lichtern|Lampen|Leuchten|Beleuchtungen)])"
+  alle_lichter: "(<alle> ((Lichter|Lampen|Leuchten|Beleuchtungen)|Beleuchtung)|von allen (Lichtern|Lampen|Leuchten|Beleuchtungen))"
   leuchten_lassen: "([er]leuchten lassen|[ein]färben)"
   hier: "(hier[ (im|in diesem) (Raum|Bereich)]|[(im|in diesem|diesen|den) ](Raum|Bereich))"
   tuer: "[die ]Tür[e|en]"


### PR DESCRIPTION
this pr removes an unnecessary bracket from the `<alle_lichter>` expansion rule and reduces osc by ~63.000 by this