### PR TITLE
[ES] Including 'café' as an option for brown.

### DIFF
--- a/sentences/es/_common.yaml
+++ b/sentences/es/_common.yaml
@@ -192,7 +192,7 @@ lists:
         out: "blue"
       - in: "(lila|morado|púrpura)"
         out: "purple"
-      - in: "marrón"
+      - in: "(marrón|café)"
         out: "brown"
       - in: "(rosa|rosado)"
         out: "pink"


### PR DESCRIPTION
In México we also use the word 'café' for the brown color. Including it as an additional option to 'marrón'.