### PR TITLE
[DE] reduce overall sentence count by avoiding <artikel_bestimmt> expansion rule

### DIFF
--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -15,7 +15,7 @@ intents:
       - sentences:
           - "<heizung> <area_floor> auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area> auf <temperature> <heat_cool>"
-          - "[<artikel_bestimmt> ]<floor> auf <temperature> <heat_cool>"
+          - "[das ]<floor> auf <temperature> <heat_cool>"
           - "<setzen> <area_floor> <heizung> auf <temperature>"
           - "<stelle> <area_floor> <heizung> auf <temperature> ein"
           - "<setzen> <heizung> <area_floor> auf <temperature>"
@@ -25,9 +25,9 @@ intents:
           - "(<area_heizung>|<floor_heizung>) auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area_floor> <temperature>"
           - "heiz[e] <area> auf <temperature>[ auf]"
-          - "heiz[e] [<artikel_bestimmt> ]<floor> auf <temperature>[ auf]"
+          - "heiz[e] [(den|das) ]<floor> auf <temperature>[ auf]"
           - "kühl[e] <area> auf <temperature>[ (ab|[he]runter)]"
-          - "kühl[e] [<artikel_bestimmt> ]<floor> auf <temperature>[ (ab|[he]runter)]"
+          - "kühl[e] [(den|das) ]<floor> auf <temperature>[ (ab|[he]runter)]"
         expansion_rules:
           heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
           area_heizung: ([die ]{area}[ ]temperatur|[die ]{area}[ ]heizung|[(das|den) ]{area}[ ]thermostat|[die ]{area}[ ]klima(anlage|tisierung)|[das ]{area}[ ]klima)

--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -15,7 +15,7 @@ intents:
       - sentences:
           - "<heizung> <area_floor> auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area> auf <temperature> <heat_cool>"
-          - "[das ]<floor> auf <temperature> <heat_cool>"
+          - "[(den|das) ]<floor> auf <temperature> <heat_cool>"
           - "<setzen> <area_floor> <heizung> auf <temperature>"
           - "<stelle> <area_floor> <heizung> auf <temperature> ein"
           - "<setzen> <heizung> <area_floor> auf <temperature>"

--- a/sentences/de/media_player_HassMediaNext.yaml
+++ b/sentences/de/media_player_HassMediaNext.yaml
@@ -3,8 +3,8 @@ intents:
   HassMediaNext:
     data:
       - sentences:
-          - "[<starte> ][<artikel_bestimmt> ]<naechster>[ <song>][ ((an|auf)[ dem]|am)] <name>"
-          - "[<artikel_bestimmt> ]<naechster>[ <song>][ ((an|auf)[ dem]|am)] <name> <starten_end_of_sentence>"
+          - "[<starte> ][(den|das|der) ]<naechster>[ <song>][ ((an|auf)[ dem]|am)] <name>"
+          - "[(den|das) ]<naechster>[ <song>][ ((an|auf)[ dem]|am)] <name> <starten_end_of_sentence>"
           - "[(spring[e]|spul[e]) ]ein[en] <song> (vor[wärts]|weiter)[ ((an|auf)[ dem]|am)] <name>"
           - "ein[en] <song> (vor[wärts]|weiter)[ ](springen|spulen)[ ((an|auf)[ dem]|am)] <name>"
           - "[(spring[e]|spul[e]) ]<zu_dem> <naechster> <song>[ (vor[wärts]|weiter)][ ((an|auf)[ dem]|am)] <name>"
@@ -16,8 +16,8 @@ intents:
         requires_context:
           domain: media_player
       - sentences:
-          - "[<starte> ][<artikel_bestimmt> ]<naechster>[ <song>]"
-          - "[<artikel_bestimmt> ]<naechster>[ <song>] <starten_end_of_sentence>"
+          - "[<starte> ][(der|das|den) ]<naechster>[ <song>]"
+          - "[(den|das) ]<naechster>[ <song>] <starten_end_of_sentence>"
           - "[(spring[e]|spul[e]) ]ein[en] <song> (vor[wärts]|weiter)"
           - "ein[en] <song> (vor[wärts]|weiter)[ ](springen|spulen)"
           - "[(spring[e]|spul[e]) ]<zu_dem> <naechster> <song>[ (vor[wärts]|weiter)]"
@@ -27,10 +27,10 @@ intents:
           area:
             slot: true
       - sentences:
-          - "[<starte> ][<artikel_bestimmt> ]<naechster>[ <song>] <area>"
-          - "[<starte> ]<area>[ <artikel_bestimmt>] <naechster>[ <song>]"
-          - "[<artikel_bestimmt> ]<naechster>[ <song>] <area> <starten_end_of_sentence>"
-          - "<area> [<artikel_bestimmt> ]<naechster>[ <song>] <starten_end_of_sentence>"
+          - "[<starte> ][(den|das|der) ]<naechster>[ <song>] <area>"
+          - "[<starte> ]<area>[ (den|das|der)] <naechster>[ <song>]"
+          - "[(den|das) ]<naechster>[ <song>] <area> <starten_end_of_sentence>"
+          - "<area> [(den|das) ]<naechster>[ <song>] <starten_end_of_sentence>"
           - "[(spring[e]|spul[e]) ]<area> ein[en] <song> (vor[wärts]|weiter)"
           - "ein[en] <song> (vor[wärts]|weiter)[ ][(springen|spulen)] <area>"
           - "(spring[e]|spul[e]) ein[en] <song> (vor[wärts]|weiter) <area>"

--- a/sentences/de/media_player_HassMediaPrevious.yaml
+++ b/sentences/de/media_player_HassMediaPrevious.yaml
@@ -3,13 +3,13 @@ intents:
   HassMediaPrevious:
     data:
       - sentences:
-          - "[(<starte>[ <artikel_bestimmt>]|<wiederhole>) ]<vorheriger_letzter>[ <song>][ ((an|auf)[ dem]|am)] <name>"
-          - "[<artikel_bestimmt> ]<vorheriger_letzter>[ <song>][ ((an|auf)[ dem]|am)] <name> [nochmal ](<starten_end_of_sentence>|wiederholen)"
-          - "[(<starte>[ <artikel_bestimmt>]|<wiederhole>) ]<song>[ ((an|auf)[ dem]|am)] <name> nochmal[ ab]"
+          - "[(<starte>[ (den|das)]|<wiederhole>) ]<vorheriger_letzter>[ <song>][ ((an|auf)[ dem]|am)] <name>"
+          - "[(den|das) ]<vorheriger_letzter>[ <song>][ ((an|auf)[ dem]|am)] <name> [nochmal ](<starten_end_of_sentence>|wiederholen)"
+          - "[(<starte>[ (den|das)]|<wiederhole>) ]<song>[ ((an|auf)[ dem]|am)] <name> nochmal[ ab]"
           - "[(spring[e]|spul[e]) ]ein[en] <song> (zurück|rückwärts)[ ((an|auf)[ dem]|am)] <name>"
           - "ein[en] <song> (zurück|rückwärts)[ ](springen|spulen)[ ((an|auf)[ dem]|am)] <name>"
-          - "<wiederhole> [<artikel_bestimmt> ]<song>[ ((an|auf)[ dem]|am)] <name>[ nochmal]"
-          - "[<artikel_bestimmt> ]<song>[ ((an|auf)[ dem]|am)] <name> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen)"
+          - "<wiederhole> [(den|das) ]<song>[ ((an|auf)[ dem]|am)] <name>[ nochmal]"
+          - "[(den|das) ]<song>[ ((an|auf)[ dem]|am)] <name> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen)"
           - "[(spring[e]|spul[e]) ]ein[en] <song> (zurück|rückwärts)[ ((an|auf)[ dem]|am)] <name>"
           - "[(spring[e]|spul[e]) ]<zu_dem> <vorheriger_letzter> <song>[ (zurück|rückwärts)][ ((an|auf)[ dem]|am)] <name>"
           - "[(spring[e]|spul[e]) ][((an|auf)[ dem]|am) ]<name> <zu_dem> <vorheriger_letzter> <song>[ (zurück|rückwärts)]"
@@ -18,10 +18,10 @@ intents:
         requires_context:
           domain: media_player
       - sentences:
-          - "[(<starte>[ <artikel_bestimmt>]|<wiederhole>) ]<vorheriger_letzter>[ <song>]"
-          - "[<artikel_bestimmt> ]<vorheriger_letzter>[ <song>][ nochmal] (<starten_end_of_sentence>|wiederholen)"
-          - "[(<starte>[ <artikel_bestimmt>]|<wiederhole>) ][<vorheriger_letzter> ]<song> nochmal[ ab]"
-          - "[<artikel_bestimmt> ]<song> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen)"
+          - "[(<starte>[ (den|das)]|<wiederhole>) ]<vorheriger_letzter>[ <song>]"
+          - "[(den|das) ]<vorheriger_letzter>[ <song>][ nochmal] (<starten_end_of_sentence>|wiederholen)"
+          - "[(<starte>[ (den|das)]|<wiederhole>) ][<vorheriger_letzter> ]<song> nochmal[ ab]"
+          - "[(den|das) ]<song> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen)"
           - "[(spring[e]|spul[e]) ]ein[en] <song> (zurück|rückwärts)"
           - "ein[en] <song> (zurück|rückwärts)[ ](springen|spulen)"
           - "[(spring[e]|spul[e]) ]<zu_dem> <vorheriger_letzter> <song>[ (zurück|rückwärts)]"
@@ -31,12 +31,12 @@ intents:
           area:
             slot: true
       - sentences:
-          - "[(<starte>[ <artikel_bestimmt>]|<wiederhole>) ]<vorheriger_letzter>[ <song>] <area>"
-          - "[(<starte>|<wiederhole>) ]<area>[ <artikel_bestimmt>] <vorheriger_letzter>[ <song>]"
-          - "[<artikel_bestimmt> ]<vorheriger_letzter>[ <song>] <area>[ nochmal][ (<starten_end_of_sentence>|wiederholen)]"
-          - "<area> [<artikel_bestimmt> ]<vorheriger_letzter>[ <song>][ nochmal] (<starten_end_of_sentence>|wiederholen)"
-          - "[<artikel_bestimmt> ]<song> <area> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen)"
-          - "[<artikel_bestimmt> ]<song> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen) <area>"
+          - "[(<starte>[ (den|das)]|<wiederhole>) ]<vorheriger_letzter>[ <song>] <area>"
+          - "[(<starte>|<wiederhole>) ]<area>[ (den|das)] <vorheriger_letzter>[ <song>]"
+          - "[(den|das|der) ]<vorheriger_letzter>[ <song>] <area>[ nochmal][ (<starten_end_of_sentence>|wiederholen)]"
+          - "<area> [(den|das) ]<vorheriger_letzter>[ <song>][ nochmal] (<starten_end_of_sentence>|wiederholen)"
+          - "[(den|das) ]<song> <area> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen)"
+          - "[(den|das) ]<song> (nochmal <starten_end_of_sentence>|[nochmal ]wiederholen) <area>"
           - "[(spring[e]|spul[e]) ]<area> ein[en] <song> (zurück|rückwärts)"
           - "[(spring[e]|spul[e]) ]ein[en] <song> (zurück|rückwärts) <area>"
           - "<area> ein[en] <song> (zurück[[ ](springen|spulen)]|rückwärts)"


### PR DESCRIPTION
For this PR i went through all 3 remaining files(besides common.yaml) containing the `<artikel_bestimmt>` expansion rule and exchanged the expansion rule with only the actually used variations.
OSC reduced by another ~2 million down to currently 39.7 million without loosing any tested sentences