### PR TITLE
ci: use more workers from public runners

### DIFF
--- a/script/test
+++ b/script/test
@@ -15,5 +15,11 @@ if [ -d "${venv}" ]; then
     source "${venv}/bin/activate"
 fi
 
+JOBS=auto
+if [ -n "${GITHUB_ACTIONS}" ]; then
+    # If running in GitHub Actions, set jobs to the number of CPUs
+    JOBS=$(nproc)
+fi
+
 python3 -m script.intentfest validate
-pytest -vv -n auto "$@"
+pytest -vv -n "${JOBS}" "$@"


### PR DESCRIPTION
GitHub Actions Public Runners (for `public` repositories) have 4 VCPU, while the `pytest -n auto` would only pick 2.
Force to use `$(nproc)` to use all cores available to run tests in GitHub Actions only.

This will speed up the test execution.