### PR TITLE
[DE] ClimateSetTemperature: adjust for new <floor> expansion rule

### DIFF
--- a/sentences/de/climate_HassClimateSetTemperature.yaml
+++ b/sentences/de/climate_HassClimateSetTemperature.yaml
@@ -15,7 +15,7 @@ intents:
       - sentences:
           - "<heizung> <area_floor> auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area> auf <temperature> <heat_cool>"
-          - "[(den|das) ]<floor> auf <temperature> <heat_cool>"
+          - "<floor> auf <temperature> <heat_cool>"
           - "<setzen> <area_floor> <heizung> auf <temperature>"
           - "<stelle> <area_floor> <heizung> auf <temperature> ein"
           - "<setzen> <heizung> <area_floor> auf <temperature>"
@@ -25,9 +25,9 @@ intents:
           - "(<area_heizung>|<floor_heizung>) auf <temperature>[ <setzen_end_of_sentence>]"
           - "<area_floor> <temperature>"
           - "heiz[e] <area> auf <temperature>[ auf]"
-          - "heiz[e] [(den|das) ]<floor> auf <temperature>[ auf]"
+          - "heiz[e] <floor> auf <temperature>[ auf]"
           - "kühl[e] <area> auf <temperature>[ (ab|[he]runter)]"
-          - "kühl[e] [(den|das) ]<floor> auf <temperature>[ (ab|[he]runter)]"
+          - "kühl[e] <floor> auf <temperature>[ (ab|[he]runter)]"
         expansion_rules:
           heizung: ([die ]temperatur|[die ]heizung|[(das|den) ]thermostat|[die ]klima(anlage|tisierung)|[das ]klima)
           area_heizung: ([die ]{area}[ ]temperatur|[die ]{area}[ ]heizung|[(das|den) ]{area}[ ]thermostat|[die ]{area}[ ]klima(anlage|tisierung)|[das ]{area}[ ]klima)


### PR DESCRIPTION
`<artikel_bestimmt>` is now(since #3340) an optional part of `<floor>` so the removed parts are already covered by the `<floor>` expansion rule