### PR TITLE
[DE] HassLightSet: add consisten support for "stelle...ein"

### DIFF
--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -54,7 +54,8 @@ intents:
             slot: true
       # color by name
       - sentences:
-          - "[<setzen> ][[die ]Farbe[ <von_dem>] ]<name>[ auf] {color}"
+          - "[<setze> ][[die ]Farbe[ <von_dem>] ]<name>[ auf] {color}"
+          - "<stelle> [[die ]Farbe[ <von_dem>] ]<name>[ auf] {color}[ ein]"
           - "(änder[e]|veränder[e]) [[die ]Farbe[ <von_dem>] ]<name> zu {color}"
           - "[[die ]Farbe[ <von_dem>] ]<name>[ (auf|zu)] {color} <setzen_end_of_sentence>"
           - "<name>[ Farbe][ (auf|zu)] {color}[ <setzen_end_of_sentence>]"
@@ -76,7 +77,8 @@ intents:
         response: color
       # color by satellite area
       - sentences:
-          - "[<setzen> ][(<licht>|[[die ]Farbe ][(<lichtes_mit_artikel>|<lichter>|<alle_lichter>)]) ][<hier> ][auf ] {color}"
+          - "[<setze> ][(<licht>|[[die ]Farbe ][(<lichtes_mit_artikel>|<lichter>|<alle_lichter>)]) ][<hier> ][auf ] {color}"
+          - "<stelle> [(<licht>|[[die ]Farbe ][(<lichtes_mit_artikel>|<lichter>|<alle_lichter>)]) ][<hier> ][auf ] {color}[ ein]"
           - "(änder[e]|veränder[e]) (<licht>|[[die ]Farbe ][(<lichtes_mit_artikel>|<lichter>|<alle_lichter>)])[ <hier>] zu {color}"
           - "[die ]Farbe[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>][ (auf|zu)] {color} <setzen_end_of_sentence>"
           - "[(<licht>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>) ][<hier> ] Farbe[ (auf|zu)] {color}[ <setzen_end_of_sentence>]"

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -396,6 +396,8 @@ tests:
       - Färbe Schlafzimmerlampe grün
       - Schlafzimmerlampe grün einfärben
       - Schlafzimmerlampe grün färben
+      - Stelle die Farbe der Schlafzimmerlampe auf Grün ein
+      - stell die Schlafzimmerlampe auf Grün ein
     intent:
       name: HassLightSet
       slots:
@@ -484,6 +486,8 @@ tests:
       - alle Lampen hier Farbe auf blau stellen
       - Das Licht in diesem Raum blau leuchten lassen
       - Färbe alle Lampen im Raum blau ein
+      - stelle die Lampen auf blau ein
+      - stell alle Lampen in diesem raum auf blau ein
     intent:
       name: HassLightSet
       context:


### PR DESCRIPTION
This PR adds consistent support for `stelle...ein` sentences where they were still missing.
i split sentences with `<setzen>` into one sentence with `<setze>` and one with `<stelle>...[ ein]` to avoid unnecessary permutations.