### PR TITLE
[DE] ShoppingList/ToDo List: fix whitespaces and bracket placement in local expansion rules

### DIFF
--- a/sentences/de/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/de/shopping_list_HassShoppingListAddItem.yaml
@@ -14,7 +14,7 @@ intents:
           - "<item>[ (auf|in)] <meine_liste_akkusativ> hinzufügen"
         response: item_added
         expansion_rules:
-          mein_einkauf_dativ: "[meinem|dem] Einkauf"
-          meine_liste_dativ: "[meiner|der] [Einkaufs]Liste"
-          meine_liste_akkusativ: "[meine|die] [Einkaufs]Liste"
+          mein_einkauf_dativ: "[(meinem|dem) ]Einkauf"
+          meine_liste_dativ: "[(meiner|der) ][Einkaufs]Liste"
+          meine_liste_akkusativ: "[(meine|die) ][Einkaufs]Liste"
           item: "{shopping_list_item:item}"

--- a/sentences/de/shopping_list_HassShoppingListCompleteItem.yaml
+++ b/sentences/de/shopping_list_HassShoppingListCompleteItem.yaml
@@ -10,7 +10,7 @@ intents:
           - <item> (von|auf|aus) <meine_liste_dativ> (entfernen|löschen|streichen)
         response: item_completed
         expansion_rules:
-          mein_einkauf_dativ: "[meinem|dem] Einkauf"
-          meine_liste_dativ: "[meiner|der] [Einkaufs]Liste"
-          meine_liste_akkusativ: "[meine|die] [Einkaufs]Liste"
+          mein_einkauf_dativ: "[(meinem|dem) ]Einkauf"
+          meine_liste_dativ: "[(meiner|der) ][Einkaufs]Liste"
+          meine_liste_akkusativ: "[(meine|die) ][Einkaufs]Liste"
           item: "{shopping_list_item:item}"

--- a/sentences/de/todo_HassListAddItem.yaml
+++ b/sentences/de/todo_HassListAddItem.yaml
@@ -13,6 +13,6 @@ intents:
         requires_context:
           domain: todo
         expansion_rules:
-          meine_liste_dativ: "[meiner|der] ({name}[ Liste]|[Liste] {name})"
-          meine_liste_akkusativ: "[meine|die] ({name}[ Liste]|[Liste] {name})"
+          meine_liste_dativ: "[(meiner|der) ]({name}[ Liste]|[Liste ]{name})"
+          meine_liste_akkusativ: "[(meine|die) ]({name}[ Liste]|[Liste ]{name})"
           item: "{todo_list_item:item}"

--- a/sentences/de/todo_HassListCompleteItem.yaml
+++ b/sentences/de/todo_HassListCompleteItem.yaml
@@ -10,5 +10,5 @@ intents:
         requires_context:
           domain: todo
         expansion_rules:
-          meine_liste_dativ: "[meiner|der] ([Liste ]{name}|{name}[s] Liste|{name}[s]liste)"
+          meine_liste_dativ: "[(meiner|der) ]([Liste ]{name}|{name}[s] Liste|{name}[s]liste)"
           item: "{todo_list_item:item}"


### PR DESCRIPTION
This PR fixes the placement of whitespaces and adds some brackets where needed for local expansion rules in ShoppingList/ToDo add/complete