### PR TITLE
fix links to repo

### DIFF
--- a/docs/forking/README.md
+++ b/docs/forking/README.md
@@ -1,6 +1,6 @@
 # Forking Workflow
 
-1. [Fork the repository](https://github.com/home-assistant/intents/fork) on GitHub.
+1. [Fork the repository](https://github.com/OHF-Voice/intents/fork) on GitHub.
 2. Clone your fork locally with `git clone <url>`
 3. Set up a local development environment with `script/setup`
 4. Create a new branch off of `main` with `git checkout -b <branch>`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -22,7 +22,7 @@ This will set up a complete environment for you, and provide a code editor and t
 If you prefer a local environment, you will need to clone the repository:
 
 ```sh
-git clone https://github.com/home-assistant/intents
+git clone https://github.com/OHF-Voice/intents
 ```
 
 and then run the setup script:
@@ -101,7 +101,7 @@ turn on light
 When different sentence templates share collections of possible values (or ranges of numbers), a `{list}` is needed:
 
 ```sh
-python3 -m script.intentfest sample_template 'set color to {color}' --values color red green blue 
+python3 -m script.intentfest sample_template 'set color to {color}' --values color red green blue
 ```
 
 which prints the same thing as the earlier example:
@@ -155,7 +155,7 @@ For example, consider the `HassTurnOn` intent, which contains a `name` slot with
 When the text "turn on my light" is being matched to `HassTurnOn`, we would like "my light" to end up in `name`. This is done by:
 
 1. Creating a list called "name" with the possible light names (e.g., "my light")
-2. Using `{name}` in a sentence template for `HassTurnOn` 
+2. Using `{name}` in a sentence template for `HassTurnOn`
 
 In YAML, we can put this all together:
 
@@ -197,7 +197,7 @@ expansion_rules:
 On the command line, we can use them with `--rule`:
 
 ```sh
-python3 -m script.intentfest sample_template 'set color to <color>' --rule color '(red | green | blue)' 
+python3 -m script.intentfest sample_template 'set color to <color>' --rule color '(red | green | blue)'
 ```
 
 which again prints:
@@ -232,7 +232,7 @@ expansion_rules:
 On the command line, we now have:
 
 ```sh
-python3 -m script.intentfest sample_template 'set color to <color>' --rule color '[the color] {color}' --values color red green blue 
+python3 -m script.intentfest sample_template 'set color to <color>' --rule color '[the color] {color}' --values color red green blue
 ```
 
 which prints all 6 possible sentences:

--- a/tests/hr/homeassistant_HassTimerStatus.yaml
+++ b/tests/hr/homeassistant_HassTimerStatus.yaml
@@ -53,4 +53,4 @@ tests:
           - "kuhinji"
           - "kuhinja"
           - "kuhinjskom"
-    response: Nema timera. # ISSUE: https://github.com/home-assistant/intents/issues/2393
+    response: Nema timera. # ISSUE: https://github.com/OHF-Voice/intents/issues/2393

--- a/tests/pl/homeassistant_HassTimerStatus.yaml
+++ b/tests/pl/homeassistant_HassTimerStatus.yaml
@@ -53,7 +53,7 @@ tests:
       Pozostało 25 minut do zakończenia.
 
   # TODO: Bug in pytest, timer can not recognise area correctly, correct response: "Pozostały 3 minuty do zakończenia."
-  # ISSUE: https://github.com/home-assistant/intents/issues/2393
+  # ISSUE: https://github.com/OHF-Voice/intents/issues/2393
   - sentences:
       - "stan minutnika w kuchni"
       - "status minutnika w kuchni"

--- a/tests/ro/_fixtures.yaml
+++ b/tests/ro/_fixtures.yaml
@@ -447,7 +447,7 @@ timers:
     rounded_hours_left: 0
     rounded_minutes_left: 25
     rounded_seconds_left: 0
-  - area: Bucatarie #TODO https://github.com/home-assistant/intents/discussions/2193#discussioncomment-9617522
+  - area: Bucatarie #TODO https://github.com/OHF-Voice/intents/discussions/2193#discussioncomment-9617522
     start_minutes: 5
     total_seconds_left: 190
     rounded_hours_left: 0

--- a/tests/sk/homeassistant_HassGetState.yaml
+++ b/tests/sk/homeassistant_HassGetState.yaml
@@ -23,7 +23,7 @@ tests:
     intent:
       name: HassGetState
       slots:
-        #https://github.com/home-assistant/intents/issues/980#issuecomment-1426899721
+        #https://github.com/OHF-Voice/intents/issues/980#issuecomment-1426899721
         #area: kitchen
         domain: switch
         state: "on"

--- a/tests/sk/homeassistant_HassTimerStatus.yaml
+++ b/tests/sk/homeassistant_HassTimerStatus.yaml
@@ -33,7 +33,7 @@ tests:
       Zostáva 10 minút do vypršania.
 
   # TODO: Bug in pytest, timer can not recognise area correctly.
-  # ISSUE: https://github.com/home-assistant/intents/issues/2393
+  # ISSUE: https://github.com/OHF-Voice/intents/issues/2393
   - sentences:
       - "stav časovača v kuchyni"
       - "aký je stav časovača v kuchyni"

--- a/tests/sl/homeassistant_HassGetState.yaml
+++ b/tests/sl/homeassistant_HassGetState.yaml
@@ -16,7 +16,7 @@ tests:
       slots:
         name: "luč v spalnici"
         state: "on"
-    response: "Ne, off" #state is not translating - > https://github.com/home-assistant/intents/issues/1070
+    response: "Ne, off" #state is not translating - > https://github.com/OHF-Voice/intents/issues/1070
 
   - sentences:
       - "ali je kakšno stikalo vključeno v kuhinji?"

--- a/website/src-11ty/_includes/base.html
+++ b/website/src-11ty/_includes/base.html
@@ -27,13 +27,13 @@ Home Assistant Intents
         <ul>
           <li>
             <a
-              href="https://github.com/home-assistant/intents/blob/main/CONTRIBUTING.md"
+              href="https://github.com/OHF-Voice/intents/blob/main/CONTRIBUTING.md"
               target="_blank"
               >How to contribute</a
             >
           </li>
           <li>
-            <a href="https://github.com/home-assistant/intents" target="_blank"
+            <a href="https://github.com/OHF-Voice/intents" target="_blank"
               >GitHub</a
             >
           </li>

--- a/website/src-11ty/index.html
+++ b/website/src-11ty/index.html
@@ -43,7 +43,7 @@ Cell format:
     <tr class="{% if summary.usable %}usable{% endif %}">
       <td>
         <a
-          href="https://github.com/home-assistant/intents/blob/main/sentences/{{ summary.language }}/"
+          href="https://github.com/OHF-Voice/intents/blob/main/sentences/{{ summary.language }}/"
           target="_blank"
         >
           <code>{{summary.language}}</code> {{summary.native_name}}
@@ -54,14 +54,14 @@ Cell format:
       {% for intent in summary.intents %}
       <td class="multiple {% if intent[1] == 0 %}zero{% endif %} {% if intentSummary.intents[intent[0]].important %}important{% endif %}">
         <a
-          href="https://github.com/home-assistant/intents/blob/main/sentences/{{ summary.language }}/{{ intentSummary.intents[intent[0]].file_name }}"
+          href="https://github.com/OHF-Voice/intents/blob/main/sentences/{{ summary.language }}/{{ intentSummary.intents[intent[0]].file_name }}"
           target="_blank"
         >
           {{intent[1]}}
         </a>
         +
         <a
-          href="https://github.com/home-assistant/intents/blob/main/responses/{{ summary.language }}/{{ intent[0] }}.yaml"
+          href="https://github.com/OHF-Voice/intents/blob/main/responses/{{ summary.language }}/{{ intent[0] }}.yaml"
           target="_blank"
           class="{% if intent[1] > 0 and summary.intent_responses_translated[intent[0]] == false %}zero{% endif %}"
         >
@@ -72,7 +72,7 @@ Cell format:
 
       <td class="{% if summary.errors_translated != true %}zero{% endif %}">
         <a
-          href="https://github.com/home-assistant/intents/blob/main/sentences/{{ summary.language }}/_common.yaml"
+          href="https://github.com/OHF-Voice/intents/blob/main/sentences/{{ summary.language }}/_common.yaml"
           target="_blank"
         >
           {% if summary.errors_translated == true %}yes{% else %}no{% endif %}
@@ -115,7 +115,7 @@ List of languages that are usable, but not yet complete.
   <tr>
     <td>
       <a
-        href="https://github.com/home-assistant/intents/blob/main/sentences/{{ summary.language }}/"
+        href="https://github.com/OHF-Voice/intents/blob/main/sentences/{{ summary.language }}/"
         target="_blank"
       >
         <code>{{summary.language}}</code> {{summary.native_name}}
@@ -147,7 +147,7 @@ List of languages that are missing important intent coverage.
   <tr>
     <td>
       <a
-        href="https://github.com/home-assistant/intents/blob/main/sentences/{{ summary.language }}/"
+        href="https://github.com/OHF-Voice/intents/blob/main/sentences/{{ summary.language }}/"
         target="_blank"
       >
         <code>{{summary.language}}</code> {{summary.native_name}}
@@ -176,7 +176,7 @@ List of languages that are missing important intent coverage.
   <tr>
     <td>
       <a
-        href="https://github.com/home-assistant/intents/blob/main/sentences/{{ summary.language }}/"
+        href="https://github.com/OHF-Voice/intents/blob/main/sentences/{{ summary.language }}/"
         target="_blank"
       >
         <code>{{summary.language}}</code> {{summary.native_name}}


### PR DESCRIPTION
migrates all old links to `https://github.com/home-assistant/intents` to `https://github.com/OHF-Voice/intents`