### PR TITLE
[CA] Fix HassGetWeather spoken output with decimal and degrees

### DIFF
--- a/responses/ca/HassGetWeather.yaml
+++ b/responses/ca/HassGetWeather.yaml
@@ -21,4 +21,9 @@ responses:
           'windy': 'Vent',
           'windy-variant': 'Vent i núvols'
         } %}
-         {{ weather_condition.get((state.state | string).lower(), "") }}, amb una temperatura de {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }}
+        {% set weather_condition = weather_condition.get((state.state | string).lower(), "") %}
+        {% set temperature_raw = state.attributes.get('temperature') | float %}
+        {% set temperature = temperature_raw | abs | round(1) | replace('.0', '') | replace('.',',') %}
+        {% set temperature_units = 'grau' if temperature_raw | abs == 1 else 'graus' %}
+        {% set temperature_negative = 'sota zero' if temperature_raw < 0 else '' %}
+        {{ weather_condition }}, amb una temperatura de {{ temperature }} {{ temperature_units }} {{ temperature_negative }}

--- a/tests/ca/_fixtures.yaml
+++ b/tests/ca/_fixtures.yaml
@@ -105,14 +105,35 @@ entities:
     id: weather.barcelona
     state: rainy
     attributes:
-      temperature: "18"
+      temperature: "18.8"
       temperature_unit: "°C"
 
   - name: Empordà
     id: weather.emporda
     state: clear
     attributes:
-      temperature: "-4"
+      temperature: "-4.1"
+      temperature_unit: "°C"
+
+  - name: Sant Antoni de Vilamajor
+    id: weather.sant_antoni_de_vilamajor
+    state: snowy
+    attributes:
+      temperature: "1.0"
+      temperature_unit: "°C"
+
+  - name: Mataró
+    id: weather.mataro
+    state: lightning
+    attributes:
+      temperature: "1.6"
+      temperature_unit: "°C"
+
+  - name: Dosrius
+    id: weather.dosrius
+    state: fog
+    attributes:
+      temperature: "-1.0"
       temperature_unit: "°C"
 
   - name: Joan

--- a/tests/ca/weather_HassGetWeather.yaml
+++ b/tests/ca/weather_HassGetWeather.yaml
@@ -5,7 +5,7 @@ tests:
       - "com és el temps"
     intent:
       name: HassGetWeather
-    response: Pluja, amb una temperatura de 18 °C
+    response: Pluja, amb una temperatura de 18,8 graus
 
   - sentences:
       - quin temps fa a Barcelona?
@@ -24,7 +24,7 @@ tests:
       name: HassGetWeather
       slots:
         name: Barcelona
-    response: Pluja, amb una temperatura de 18 °C
+    response: Pluja, amb una temperatura de 18,8 graus
 
   - sentences:
       - "quin temps fa al Empordà"
@@ -32,4 +32,28 @@ tests:
       name: HassGetWeather
       slots:
         name: Empordà
-    response: Cel clar, amb una temperatura de -4 °C
+    response: Cel clar, amb una temperatura de 4,1 graus sota zero
+
+  - sentences:
+      - "quin temps fa a Sant Antoni de Vilamajor"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Sant Antoni de Vilamajor
+    response: Precipitacions de neu, amb una temperatura de 1 grau
+
+  - sentences:
+      - "quin temps fa a Mataró"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Mataró
+    response: Tempesta, amb una temperatura de 1,6 graus
+
+  - sentences:
+      - "quin temps fa a Dosrius"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Dosrius
+    response: Boira, amb una temperatura de 1 grau sota zero


### PR DESCRIPTION
This PR fixes the handling of temperature units in the Catalan (ca) language responses for the **HassGetWeather** intent.

Previously, temperatures such as `18.8` were spoken incorrectly by the TTS engine as `"divuit d'agost"` (interpreted as a date) instead of `"divuit coma vuit"`.

The following improvements were made:

- Temperatures are now correctly formatted with a decimal comma `(18,8)` as used in Catalan.

- The temperature unit has been changed from `"ºC"` to a localized form: `"grau"` when the value is exactly 1, and `"graus"` otherwise.

- When the temperature is below zero, the suffix `"sota zero"` is appended, which is the natural way to express negative temperatures in Catalan.

This ensures more natural and accurate voice output in Catalan.