### PR TITLE
[HI] Add Hindi support for climate temperature intents

### DIFF
--- a/responses/hi/HassClimateGetTemperature.yaml
+++ b/responses/hi/HassClimateGetTemperature.yaml
@@ -2,4 +2,7 @@ language: hi
 responses:
   intents:
     HassClimateGetTemperature:
-      default: "{{ state.state }} degrees"
+      default: >
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
+        {{ temperature }} डिग्री

--- a/responses/hi/HassClimateSetTemperature.yaml
+++ b/responses/hi/HassClimateSetTemperature.yaml
@@ -2,4 +2,4 @@ language: hi
 responses:
   intents:
     HassClimateSetTemperature:
-      default: Temperature set to {{ slots.temperature }} degrees
+      default: "तापमान {{ slots.temperature }} डिग्री पर सेट कर दिया गया"

--- a/sentences/hi/_common.yaml
+++ b/sentences/hi/_common.yaml
@@ -7,6 +7,12 @@ responses:
     no_device_class_in_area: "{{ area }} नाम के क्षेत्र में कोई {{ device_class }} नहीं है"
     no_entity: "{{ entity }} नाम का कोई डिवाइस या एंटिटी नहीं है"
     handle_error: "इंटेंट को संभालते समय एक अनपेक्षित एरर हुआ"
-lists: {}
+lists:
+  temperature:
+    range:
+      type: "temperature"
+      from: 0
+      to: 100
+      fractions: "halves"
 expansion_rules: {}
 skip_words: []

--- a/sentences/hi/climate_HassClimateGetTemperature.yaml
+++ b/sentences/hi/climate_HassClimateGetTemperature.yaml
@@ -2,4 +2,24 @@ language: hi
 intents:
   HassClimateGetTemperature:
     data:
-      - sentences: []
+      # Get temperature of a climate in the same area as a satellite device
+      - sentences:
+          - "[वर्तमान] तापमान क्या है"
+          - "यहाँ [का] [वर्तमान] तापमान क्या है"
+          - "यहाँ कितना ठंडा है"
+          - "यहाँ कितना गर्म है"
+          - "तापमान बताओ"
+        requires_context:
+          area:
+            slot: true
+
+      # Get temperature of a climate in an area or with a name
+      - sentences:
+          - "{name} [का] [वर्तमान] तापमान क्या है"
+          - "{area} [में] [वर्तमान] तापमान क्या है"
+          - "{area} [का] तापमान क्या है"
+          - "{name} [का] तापमान क्या है"
+          - "{area} में कितना ठंडा है"
+          - "{area} में कितना गर्म है"
+          - "{name} कितना ठंडा है"
+          - "{name} कितना गर्म है"

--- a/sentences/hi/climate_HassClimateSetTemperature.yaml
+++ b/sentences/hi/climate_HassClimateSetTemperature.yaml
@@ -2,4 +2,22 @@ language: hi
 intents:
   HassClimateSetTemperature:
     data:
-      - sentences: []
+      # Current area or floor
+      - sentences:
+          - "तापमान {temperature} [डिग्री] [पर] सेट करो"
+          - "तापमान {temperature} [डिग्री] कर दो"
+          - "{temperature} [डिग्री] तापमान सेट करो"
+          - "{temperature} [डिग्री] [पर] तापमान रखो"
+
+      # By area name
+      - sentences:
+          - "{area} में तापमान {temperature} [डिग्री] [पर] सेट करो"
+          - "{area} का तापमान {temperature} [डिग्री] कर दो"
+          - "{area} में {temperature} [डिग्री] [पर] तापमान रखो"
+
+      # By climate entity name
+      - sentences:
+          - "{name} [का] तापमान {temperature} [डिग्री] [पर] सेट करो"
+          - "{name} को {temperature} [डिग्री] [पर] सेट करो"
+        requires_context:
+          domain: "climate"

--- a/tests/hi/_fixtures.yaml
+++ b/tests/hi/_fixtures.yaml
@@ -18,3 +18,15 @@ entities:
   - name: छत का पंखा
     id: fan.ceiling
     area: living_room
+  - name: रसोईघर का थर्मोस्टेट
+    id: climate.kitchen_thermostat
+    area: kitchen
+    state: "1"
+  - name: बैठक कक्ष का थर्मोस्टेट
+    id: climate.living_room_thermostat
+    area: living_room
+    state: "1"
+  - name: शयनकक्ष का थर्मोस्टेट
+    id: climate.bedroom_thermostat
+    area: bedroom
+    state: "1"

--- a/tests/hi/climate_HassClimateGetTemperature.yaml
+++ b/tests/hi/climate_HassClimateGetTemperature.yaml
@@ -1,6 +1,38 @@
 language: hi
 tests:
-  - sentences: []
+  - sentences:
+      - "तापमान क्या है"
+      - "वर्तमान तापमान क्या है"
+      - "यहाँ तापमान क्या है"
+      - "यहाँ का तापमान क्या है"
+      - "यहाँ कितना गर्म है"
+      - "यहाँ कितना ठंडा है"
+      - "तापमान बताओ"
     intent:
       name: HassClimateGetTemperature
-      slots: {}
+      context:
+        area: रसोईघर
+      slots:
+        area: रसोईघर
+    response: "1 डिग्री"
+
+  - sentences:
+      - "बैठक कक्ष में तापमान क्या है"
+      - "बैठक कक्ष का तापमान क्या है"
+      - "बैठक कक्ष में कितना गर्म है"
+      - "बैठक कक्ष में कितना ठंडा है"
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        area: बैठक कक्ष
+    response: "1 डिग्री"
+
+  - sentences:
+      - "शयनकक्ष में तापमान क्या है"
+      - "शयनकक्ष का तापमान क्या है"
+      - "शयनकक्ष में कितना ठंडा है"
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        area: शयनकक्ष
+    response: "1 डिग्री"

--- a/tests/hi/climate_HassClimateSetTemperature.yaml
+++ b/tests/hi/climate_HassClimateSetTemperature.yaml
@@ -1,6 +1,46 @@
 language: hi
 tests:
-  - sentences: []
+  # Current area or floor
+  - sentences:
+      - "तापमान 25 डिग्री पर सेट करो"
+      - "तापमान 25 डिग्री कर दो"
+      - "25 डिग्री तापमान सेट करो"
+      - "25 डिग्री पर तापमान रखो"
     intent:
       name: HassClimateSetTemperature
-      slots: {}
+      slots:
+        temperature: 25
+    response: "तापमान 25 डिग्री पर सेट कर दिया गया"
+
+  # By area name - living room
+  - sentences:
+      - "बैठक कक्ष में तापमान 22 डिग्री पर सेट करो"
+      - "बैठक कक्ष का तापमान 22 डिग्री कर दो"
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        area: बैठक कक्ष
+        temperature: 22
+    response: "तापमान 22 डिग्री पर सेट कर दिया गया"
+
+  # By area name - bedroom
+  - sentences:
+      - "शयनकक्ष में 20 डिग्री पर तापमान रखो"
+      - "शयनकक्ष का तापमान 20 डिग्री कर दो"
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        area: शयनकक्ष
+        temperature: 20
+    response: "तापमान 20 डिग्री पर सेट कर दिया गया"
+
+  # By climate entity name
+  - sentences:
+      - "रसोईघर का थर्मोस्टेट का तापमान 24 डिग्री पर सेट करो"
+      - "रसोईघर का थर्मोस्टेट को 24 डिग्री पर सेट करो"
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        name: रसोईघर का थर्मोस्टेट
+        temperature: 24
+    response: "तापमान 24 डिग्री पर सेट कर दिया गया"


### PR DESCRIPTION
## HassClimateGetTemperature & HassClimateSetTemperature
Adding `HassClimateGetTemperature` and `HassClimateSetTemperature ` intent to HomeAssistant in `Hindi` language.
- Add HassClimateGetTemperature with natural Hindi queries
- Add HassClimateSetTemperature with Hindi temperature setting commands
- Add temperature slot list to _common.yaml (range 0-100)
- Add comprehensive test coverage for both intents
- Add climate entities to test fixtures
- Support context-aware and area-specific temperature control

Tested: All climate intent tests passing (4/4)