### PR TITLE
Add support for lawn mower intents

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -2586,3 +2586,55 @@ HassFanSetSpeed:
         - "floor"
         - "percentage"
       example: "set first floor fans to 50%"
+
+# -----------------------------------------------------------------------------
+# lawn_mower
+# -----------------------------------------------------------------------------
+
+HassLawnMowerStartMowing:
+  supported: true
+  domain: lawn_mower
+  description: "Starts a lawn mower"
+  slots:
+    name:
+      description: "Name of a device or entity"
+      required: false
+  slot_combinations:
+    default:
+      description: "Starts the only lawn mower"
+      slots: []
+      importance: "complete"
+
+    name_only:
+      description: "Starts a mower by name"
+      slots:
+        - "name"
+      name_domains:
+        complete:
+          - "lawn_mower"
+      example: "start clippy"
+
+# -----------------------------------------------------------------------------
+
+HassLawnMowerDock:
+  supported: true
+  domain: lawn_mower
+  description: "Sends a lawn mower to dock"
+  slots:
+    name:
+      description: "Name of a device or entity"
+      required: false
+  slot_combinations:
+    default:
+      description: "Sends the only lawn mower to dock"
+      slots: []
+      importance: "complete"
+
+    name_only:
+      description: "Sends a lawn mower to dock by name"
+      slots:
+        - "name"
+      name_domains:
+        complete:
+          - "lawn_mower"
+      example: "return clippy to base"

--- a/intents.yaml
+++ b/intents.yaml
@@ -2604,6 +2604,7 @@ HassLawnMowerStartMowing:
       description: "Starts the only lawn mower"
       slots: []
       importance: "complete"
+      example: "start mowing"
 
     name_only:
       description: "Starts a mower by name"
@@ -2629,6 +2630,7 @@ HassLawnMowerDock:
       description: "Sends the only lawn mower to dock"
       slots: []
       importance: "complete"
+      example: "stop mowing"
 
     name_only:
       description: "Sends a lawn mower to dock by name"

--- a/responses/en/HassLawnMowerDock.yaml
+++ b/responses/en/HassLawnMowerDock.yaml
@@ -1,0 +1,5 @@
+language: en
+responses:
+  intents:
+    HassLawnMowerDock:
+      default: "Docking"

--- a/responses/en/HassLawnMowerStartMowing.yaml
+++ b/responses/en/HassLawnMowerStartMowing.yaml
@@ -1,0 +1,5 @@
+language: en
+responses:
+  intents:
+    HassLawnMowerStartMowing:
+      default: "Started"

--- a/sentences/en/lawn_mower_HassLawnMowerDock.yaml
+++ b/sentences/en/lawn_mower_HassLawnMowerDock.yaml
@@ -1,0 +1,12 @@
+language: en
+intents:
+  HassLawnMowerDock:
+    data:
+      - sentences:
+          - "(stop|cancel) mowing [[<the> ]lawn]"
+          - "stop [<the>] mower"
+      - sentences:
+          - "(stop|dock) <name> [mower]"
+          - "return <name> [mower] [to (base|dock)]"
+        requires_context:
+          domain: lawn_mower

--- a/sentences/en/lawn_mower_HassLawnMowerStartMowing.yaml
+++ b/sentences/en/lawn_mower_HassLawnMowerStartMowing.yaml
@@ -1,0 +1,11 @@
+language: en
+intents:
+  HassLawnMowerStartMowing:
+    data:
+      - sentences:
+          - "(start mowing|mow) [[<the> ]lawn]"
+          - "start [<the>] mower"
+      - sentences:
+          - "start <name> [mower]"
+        requires_context:
+          domain: lawn_mower

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -774,6 +774,11 @@ entities:
     area: "living_room_id"
     state: "idle"
 
+  - name: "Clippy"
+    id: "lawn_mower.clippy"
+    area: "outside_id"
+    state: "docked"
+
 timers:
   - is_active: false
     start_hours: 1

--- a/tests/en/lawn_mower_HassLawnMowerDock.yaml
+++ b/tests/en/lawn_mower_HassLawnMowerDock.yaml
@@ -1,0 +1,21 @@
+language: en
+tests:
+  - sentences:
+      - "stop mowing"
+      - "stop mowing the lawn"
+      - "cancel mowing"
+      - "stop mower"
+    intent:
+      name: HassLawnMowerDock
+    response: "Docking"
+
+  - sentences:
+      - "stop clippy"
+      - "dock clippy mower"
+      - "return clippy to base"
+      - "return clippy mower to dock"
+    intent:
+      name: HassLawnMowerDock
+      slots:
+        name: "Clippy"
+    response: "Docking"

--- a/tests/en/lawn_mower_HassLawnMowerStartMowing.yaml
+++ b/tests/en/lawn_mower_HassLawnMowerStartMowing.yaml
@@ -1,0 +1,18 @@
+language: en
+tests:
+  - sentences:
+      - "start mowing"
+      - "start mowing the lawn"
+      - "start mower"
+    intent:
+      name: HassLawnMowerStartMowing
+    response: "Started"
+
+  - sentences:
+      - "start clippy"
+      - "start clippy mower"
+    intent:
+      name: HassLawnMowerStartMowing
+      slots:
+        name: "Clippy"
+    response: "Started"


### PR DESCRIPTION
Adds English sentences for new `HassLawnMowerStartMowing` and `HassLawnMowerDock` intents: https://github.com/home-assistant/core/pull/140525