### PR TITLE
[CA] Support for binary sensor state queries (Battery and Charging)

### DIFF
--- a/responses/ca/HassGetState.yaml
+++ b/responses/ca/HassGetState.yaml
@@ -10,7 +10,8 @@ responses:
       one_yesno: |
         {% set negation = {
           "window": "està",
-          "door": "està"
+          "door": "està",
+          "battery": "està"
         } %}
         {% if query.matched %}
           Si

--- a/sentences/ca/_common.yaml
+++ b/sentences/ca/_common.yaml
@@ -203,6 +203,13 @@ lists:
       - in: "normal[s]|carregad(a|es)"
         out: "off"
 
+  bs_battery_charging_states:
+    values:
+      - in: "carregant[-se]"
+        out: "on"
+      - in: "no carregant[-se]"
+        out: "off"
+
 expansion_rules:
   actual: "(ara|actual[ment])"
   pronom_singular: "((el|la|es|sa) |l'|s')"
@@ -255,6 +262,8 @@ expansion_rules:
   volum: "(volum|so|veu)"
   esta_hiha: "est(à|an)|hi ha[n]"
   bateria: "bateri(a|es)"
+  nombre_indeterminat: "(algun[uns|a|es])"
+  tot: "tot[s|a|es]"
 
   # Timers
   temporitzador: "(temporitzador|compte enrere|minuter|cronòmetre)"

--- a/sentences/ca/_common.yaml
+++ b/sentences/ca/_common.yaml
@@ -196,6 +196,13 @@ lists:
       - in: tanca(t|ts|da|des)
         out: "off"
 
+  bs_battery_states:
+    values:
+      - in: "baix(a|es)|descarregad(a|es)"
+        out: "on"
+      - in: "normal[s]|carregad(a|es)"
+        out: "off"
+
 expansion_rules:
   actual: "(ara|actual[ment])"
   pronom_singular: "((el|la|es|sa) |l'|s')"
@@ -247,6 +254,7 @@ expansion_rules:
   can_you: "[pots|podries]"
   volum: "(volum|so|veu)"
   esta_hiha: "est(à|an)|hi ha[n]"
+  bateria: "bateri(a|es)"
 
   # Timers
   temporitzador: "(temporitzador|compte enrere|minuter|cronòmetre)"

--- a/sentences/ca/binary_sensor_HassGetState.yaml
+++ b/sentences/ca/binary_sensor_HassGetState.yaml
@@ -44,6 +44,51 @@ intents:
           domain: binary_sensor
           device_class: battery
 
+      # Battery charging
+
+      - sentences:
+          - "[<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state}[ <pronom>]<name>[ [<preposicio>]{area}]"
+          - "[<pronom>]<name> [<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state}[ [<preposicio>]{area}]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: battery_charging
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "[<pronom_singular>]<esta_hiha> <nombre_indeterminat> <bateria> {bs_battery_charging_states:state}[ [<preposicio>]{area}]"
+          - "[<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state} <nombre_indeterminat> <bateria>[ [<preposicio>]{area}]"
+          - "<nombre_indeterminat> <bateria> [<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state}[ [<preposicio>]{area}]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "<esta_hiha> <tot> <pronom> <bateria> {bs_battery_charging_states:state}[ [<preposicio>]{area}]"
+          - "[<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state} <tot> <pronom> <bateria>[ [<preposicio>]{area}]"
+          - "<tot> <pronom> <bateria> [<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state}[ [<preposicio>]{area}]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "quin(a|es) <bateria> [<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state}[ [<preposicio>]{area}]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
+      - sentences:
+          - "Quantes <bateria> [<pronom_singular>]<esta_hiha> {bs_battery_charging_states:state}[ [<preposicio>]{area}]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: battery_charging
+
       # window
 
       - sentences:

--- a/sentences/ca/binary_sensor_HassGetState.yaml
+++ b/sentences/ca/binary_sensor_HassGetState.yaml
@@ -15,15 +15,15 @@ intents:
           device_class: battery
 
       - sentences:
-          - "<esta_hiha> [algun(a|es) ]<bateria> [que estigui ]{bs_battery_states:state}[ [<preposicio>]{area}]"
+          - "<esta_hiha> [<nombre_indeterminat> ]<bateria> [que estigui ]{bs_battery_states:state}[ [<preposicio>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: battery
 
       - sentences:
-          - "<esta_hiha> totes les bateries {bs_battery_states:state}[ [<preposicio>]{area}]"
-          - "totes les bateries <esta_hiha> {bs_battery_states:state}[ [<preposicio>]{area}]"
+          - "<esta_hiha> <tot> <pronom> <bateria> {bs_battery_states:state}[ [<preposicio>]{area}]"
+          - "<tot> <pronom> <bateria> <esta_hiha> {bs_battery_states:state}[ [<preposicio>]{area}]"
         response: all
         slots:
           domain: binary_sensor
@@ -104,7 +104,7 @@ intents:
           device_class: window
 
       - sentences:
-          - "<esta_hiha> totes les finestres {bs_open_close_states:state}[ <area>]"
+          - "<esta_hiha> <tot> <pronom> finestres {bs_open_close_states:state}[ <area>]"
         response: all
         slots:
           domain: binary_sensor
@@ -141,7 +141,7 @@ intents:
           device_class: door
 
       - sentences:
-          - "<esta_hiha> totes les portes {bs_open_close_states:state}[ <area>]"
+          - "<esta_hiha> <tot> <pronom> portes {bs_open_close_states:state}[ <area>]"
         response: all
         slots:
           domain: binary_sensor
@@ -192,16 +192,16 @@ intents:
           device_class: opening
 
       - sentences:
-          - "<esta_hiha> [algun(a|es) ]obertur(a|es) {bs_open_close_states:state}[ <area>]"
-          - "<esta_hiha> {bs_open_close_states:state}[ algun(a|es)] obertur(a|es)[ <area>]"
+          - "<esta_hiha> [<nombre_indeterminat> ]obertur(a|es) {bs_open_close_states:state}[ <area>]"
+          - "<esta_hiha> {bs_open_close_states:state}[ <nombre_indeterminat>] obertur(a|es)[ <area>]"
         response: any
         slots:
           domain: binary_sensor
           device_class: opening
 
       - sentences:
-          - "<esta_hiha> totes les obertures {bs_open_close_states:state}[ <area>]"
-          - "<esta_hiha> {bs_open_close_states:state}[s] totes les obertures[ <area>]"
+          - "<esta_hiha> <tot> <pronom> obertures {bs_open_close_states:state}[ <area>]"
+          - "<esta_hiha> {bs_open_close_states:state}[s] <tot> <pronom> obertures[ <area>]"
         response: all
         slots:
           domain: binary_sensor

--- a/sentences/ca/binary_sensor_HassGetState.yaml
+++ b/sentences/ca/binary_sensor_HassGetState.yaml
@@ -2,6 +2,48 @@ language: ca
 intents:
   HassGetState:
     data:
+      # Battery
+      - sentences:
+          - "<pronom> <bateria> <preposicio> <name> <esta_hiha> {bs_battery_states:state}[ [<preposicio>]{area}]"
+          - "<esta_hiha> {bs_battery_states:state} <pronom> <bateria> <preposicio> <name>[ [<preposicio>]{area}]"
+        response: one_yesno
+        requires_context:
+          domain: binary_sensor
+          device_class: battery
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "<esta_hiha> [algun(a|es) ]<bateria> [que estigui ]{bs_battery_states:state}[ [<preposicio>]{area}]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "<esta_hiha> totes les bateries {bs_battery_states:state}[ [<preposicio>]{area}]"
+          - "totes les bateries <esta_hiha> {bs_battery_states:state}[ [<preposicio>]{area}]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "quin(a|es) <bateria> <esta_hiha> {bs_battery_states:state}[ [<preposicio>]{area}]"
+          - "quin(a|es) <bateria> {bs_battery_states:state} <esta_hiha>[ [<preposicio>]{area}]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
+      - sentences:
+          - "quantes <bateria> <esta_hiha> {bs_battery_states:state}[ [<preposicio>]{area}]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: battery
+
       # window
 
       - sentences:

--- a/tests/ca/_fixtures.yaml
+++ b/tests/ca/_fixtures.yaml
@@ -309,6 +309,14 @@ entities:
     attributes:
       device_class: battery
 
+  - name: "Telèfon"
+    id: "binary_sensor.phone_battery_charging"
+    state:
+      in: "carregant"
+      out: "on"
+    attributes:
+      device_class: battery_charging
+
 timers:
   - is_active: false
     start_hours: 1

--- a/tests/ca/_fixtures.yaml
+++ b/tests/ca/_fixtures.yaml
@@ -301,6 +301,14 @@ entities:
     attributes:
       device_class: opening
 
+  - name: "Telèfon"
+    id: "binary_sensor.phone_battery"
+    state:
+      in: "normal"
+      out: "off"
+    attributes:
+      device_class: battery
+
 timers:
   - is_active: false
     start_hours: 1

--- a/tests/ca/binary_sensor_HassGetState.yaml
+++ b/tests/ca/binary_sensor_HassGetState.yaml
@@ -92,6 +92,75 @@ tests:
         state: "on"
     response: "0"
 
+  # Battery charging
+  - sentences:
+      - "S'està carregant el telèfon?"
+      - "Està carregant-se el telèfon?"
+      - "El telèfon s'està carregant?"
+      - "El telèfon està carregant-se?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "battery_charging"
+        name: "Telèfon"
+        state: "on"
+    response: "Si"
+
+  - sentences:
+      - "S'està carregant alguna bateria?"
+      - "Alguna bateria s'està carregant?"
+      - "Hi ha alguna bateria carregant-se?"
+      - "Hi ha carregant-se alguna bateria?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery_charging
+        state: "on"
+    response: "Si, Telèfon"
+
+  - sentences:
+      - "Hi ha totes les bateries carregant-se?"
+      - "Hi ha totes les bateries carregant?"
+      - "Hi ha carregant totes les bateries?"
+      - "Estan totes les bateries carregant-se?"
+      - "Estan totes les bateries carregant?"
+      - "Estan carregant-se totes les bateries?"
+      - "S'estan carregant totes les bateries?"
+      - "Totes les bateries s'estan carregant?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery_charging
+        state: "on"
+    response: "Si"
+
+  - sentences:
+      - "Quines bateries s'estan carregant?"
+      - "Quines bateries estan carregant-se?"
+      - "Quines bateries hi ha carregant-se?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery_charging
+        state: "on"
+    response: "Telèfon"
+
+  - sentences:
+      - "Quantes bateries s'estan carregant?"
+      - "Quantes bateries estan carregant-se?"
+      - "Quantes bateries hi ha carregant-se?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery_charging
+        state: "on"
+    response: "1"
+
   # window
 
   - sentences:

--- a/tests/ca/binary_sensor_HassGetState.yaml
+++ b/tests/ca/binary_sensor_HassGetState.yaml
@@ -1,5 +1,97 @@
 language: ca
 tests:
+  # Battery
+
+  - sentences:
+      - "La bateria del telèfon està baixa?"
+      - "Està baixa la bateria del telèfon?"
+      - "La bateria del telèfon està descarregada?"
+      - "Està descarregada la bateria del telèfon?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "battery"
+        name: "Telèfon"
+        state: "on"
+    response: "No, està normal"
+
+  - sentences:
+      - "La bateria del telèfon està normal?"
+      - "La bateria del telèfon està carregada?"
+      - "Està normal la bateria del telèfon?"
+      - "Està carregada la bateria del telèfon?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "battery"
+        name: "Telèfon"
+        state: "off"
+    response: "Si"
+
+  - sentences:
+      - "Hi ha alguna bateria baixa?"
+      - "Hi ha bateries baixes?"
+      - "Hi han bateries baixes?"
+      - "Hi ha alguna bateria que estigui baixa?"
+      - "Hi ha alguna bateria descarregada?"
+      - "Hi ha bateries descarregades?"
+      - "Hi han bateries descarregades?"
+      - "Hi ha alguna bateria que estigui descarregada?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery
+        state: "on"
+    response: "No"
+
+  - sentences:
+      - "Hi ha totes les bateries baixes?"
+      - "Estan totes les bateries baixes?"
+      - "Totes les bateries estan baixes?"
+      - "Hi ha totes les bateries descarregades?"
+      - "Estan totes les bateries descarregades?"
+      - "Totes les bateries estan descarregades?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery
+        state: "on"
+    response: "No, el dispositiu Telèfon no"
+
+  - sentences:
+      - "Quines bateries hi ha baixes?"
+      - "Quines bateries hi han baixes?"
+      - "Quines bateries baixes hi ha?"
+      - "Quines bateries baixes hi han?"
+      - "Quines bateries hi ha descarregades?"
+      - "Quines bateries hi han descarregades?"
+      - "Quines bateries estan baixes?"
+      - "Quina bateria està baixa?"
+      - "Quines bateries estan descarregades?"
+      - "Quina bateria està descarregada?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery
+        state: "on"
+    response: "Cap dispositiu"
+
+  - sentences:
+      - "Quantes bateries hi ha baixes?"
+      - "Quantes bateries hi ha descarregades?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: battery
+        state: "on"
+    response: "0"
+
   # window
 
   - sentences:


### PR DESCRIPTION
This pull request adds comprehensive support for battery and battery charging binary sensors to the Catalan language intent and test files. It introduces new sentence patterns, slot lists, expansion rules, and test cases to handle queries about battery status (e.g., low, normal, charging) for devices. Additionally, it updates and refines some existing patterns for consistency and expands test coverage.

**Battery and Charging Support:**

* Added new sentence patterns in `sentences/ca/binary_sensor_HassGetState.yaml` for querying battery and battery charging states, covering yes/no, any, all, which, and how many questions.
* Introduced new slot lists `bs_battery_states` and `bs_battery_charging_states` in `sentences/ca/_common.yaml` to map Catalan phrases to battery states (low/normal, charging/not charging).
* Added expansion rules for "bateria", indeterminate number, and "tot" in `sentences/ca/_common.yaml` to support new sentence patterns.

**Test and Fixture Enhancements:**

* Added test entities for battery and battery charging sensors in `tests/ca/_fixtures.yaml` and a comprehensive set of test cases in `tests/ca/binary_sensor_HassGetState.yaml`, covering all new sentence patterns and expected responses. [[1]](diffhunk://#diff-038f878a7c3f96e5141c3191e67cfaabf35286947ecc6f46c92969b114205371R304-R319) [[2]](diffhunk://#diff-2480cb82f91ac58d2825a9d5f36145924c0941ac770851d05e860af156df89c0R3-R163)

**Generalization and Consistency Improvements:**

* Updated existing patterns for windows, doors, and openings to use new expansion rules (`<tot>`, `<nombre_indeterminat>`, `<pronom>`) for consistency and improved natural language coverage. [[1]](diffhunk://#diff-cb218cc709790b47f4c32e776be728398e363b69d93362c1c783c71ad86f3118L20-R107) [[2]](diffhunk://#diff-cb218cc709790b47f4c32e776be728398e363b69d93362c1c783c71ad86f3118L57-R144) [[3]](diffhunk://#diff-cb218cc709790b47f4c32e776be728398e363b69d93362c1c783c71ad86f3118L108-R204)
* Extended the negation mapping in `responses/ca/HassGetState.yaml` to include "battery" for correct response generation.