### PR TITLE
ci: Add intentfest validate with errors for changed files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,8 @@ jobs:
       - name: Register intentfest problem matcher
         run: |
           echo "::add-matcher::.github/workflows/matchers/intentfest.json"
-      - run: script/lint
+      - name: Run lint
+        run: script/lint
       - name: Get changed files
         if: github.event_name == 'pull_request'
         id: changed-files
@@ -63,6 +64,20 @@ jobs:
 
           if [ -n "$LANGUAGES" ]; then
             echo "languages=$LANGUAGES" | tee -a $GITHUB_OUTPUT
+          fi
+
+      - name: Run intentfest validate
+        env:
+          LANGUAGES: ${{ steps.extract-languages.outputs.languages }}
+          CHANGED_FILES_JSON: ${{ steps.changed-files.outputs.all_changed_files }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [ "$IS_PR" = "true" ] && [ -n "${LANGUAGES}" ] && [ -n "${CHANGED_FILES_JSON}" ]; then
+            echo "Running intentfest validate for languages=${{ steps.extract-languages.outputs.languages }} with error-on-warn-pr"
+            python3 -m script.intentfest validate --language "${LANGUAGES}" --changed-files-json "${CHANGED_FILES_JSON}" --error-on-warn-pr
+          else
+            echo "Running full intentfest validate"
+            python3 -m script.intentfest validate
           fi
 
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,8 @@ jobs:
           IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
           if [ "$IS_PR" = "true" ] && [ -n "${LANGUAGES}" ] && [ -n "${CHANGED_FILES_JSON}" ]; then
-            echo "Running intentfest validate for languages=${{ steps.extract-languages.outputs.languages }} with error-on-warn-pr"
-            python3 -m script.intentfest validate --language "${LANGUAGES}" --changed-files-json "${CHANGED_FILES_JSON}" --error-on-warn-pr
+            echo "Running intentfest validate for languages=${{ steps.extract-languages.outputs.languages }}"
+            python3 -m script.intentfest validate --language "${LANGUAGES}" --changed-files-json "${CHANGED_FILES_JSON}"
           else
             echo "Running full intentfest validate"
             python3 -m script.intentfest validate

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import json
+import re
 from collections import Counter, defaultdict
 from collections.abc import Callable, Collection
 from datetime import datetime
@@ -532,11 +533,6 @@ def get_arguments() -> argparse.Namespace:
         help="The language(s) to validate. Comma-separated for multiple.",
     )
     parser.add_argument(
-        "--error-on-warn-pr",
-        action="store_true",
-        help="Treat warnings in PR-changed files as errors.",
-    )
-    parser.add_argument(
         "--changed-files-json",
         type=str,
         help="JSON array of changed file paths (used by CI to pass changed files)",
@@ -688,12 +684,7 @@ def run() -> int:
         if not warnings[language]:
             warnings.pop(language)
 
-    if args.error_on_warn_pr and warnings:
-        # Require changed files to be provided when running in PR error-on-warn mode
-        if not args.changed_files_json:
-            print("error: --error-on-warn-pr requires --changed-files-json in CI")
-            return 2
-
+    if args.changed_files_json and warnings:
         try:
             changed_files = json.loads(args.changed_files_json)
         except Exception as err:
@@ -704,9 +695,6 @@ def run() -> int:
         warn_files = set()
         for language, language_warnings in warnings.items():
             for warning in language_warnings:
-                # Try to extract file path from warning string
-                import re
-
                 m = re.match(r"([^:]+):", warning)
                 if m:
                     warn_files.add(m.group(1))

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import json
 from collections import Counter, defaultdict
 from collections.abc import Callable, Collection
 from datetime import datetime
@@ -530,6 +531,16 @@ def get_arguments() -> argparse.Namespace:
         type=str,
         help="The language(s) to validate. Comma-separated for multiple.",
     )
+    parser.add_argument(
+        "--error-on-warn-pr",
+        action="store_true",
+        help="Treat warnings in PR-changed files as errors.",
+    )
+    parser.add_argument(
+        "--changed-files-json",
+        type=str,
+        help="JSON array of changed file paths (used by CI to pass changed files)",
+    )
     return parser.parse_args()
 
 
@@ -674,9 +685,42 @@ def run() -> int:
         # Remove language if no errors
         if not errors[language]:
             errors.pop(language)
-
         if not warnings[language]:
             warnings.pop(language)
+
+    if args.error_on_warn_pr and warnings:
+        # Require changed files to be provided when running in PR error-on-warn mode
+        if not args.changed_files_json:
+            print("error: --error-on-warn-pr requires --changed-files-json in CI")
+            return 2
+
+        try:
+            changed_files = json.loads(args.changed_files_json)
+        except Exception as err:
+            print(f"Failed to parse changed files JSON: {err}")
+            return 2
+
+        # Check if any warning is for a changed file
+        warn_files = set()
+        for language, language_warnings in warnings.items():
+            for warning in language_warnings:
+                # Try to extract file path from warning string
+                import re
+
+                m = re.match(r"([^:]+):", warning)
+                if m:
+                    warn_files.add(m.group(1))
+        matched_files = [
+            f for f in changed_files if any(f.endswith(wf) for wf in warn_files)
+        ]
+        if matched_files:
+            print("Validation warnings in changed PR files:")
+            for language, language_warnings in warnings.items():
+                for warning in language_warnings:
+                    for f in matched_files:
+                        if f in warning:
+                            print(f"[ERROR] {warning}")
+            return 1
 
     if errors:
         print("Validation failed")


### PR DESCRIPTION
Summary:
- Adds a new argument `--error-on-warn-pr` to `script/intentfest/validate.py` that converts warns into errors for newly changed files with validation errors.
- Adds a separate job on the ci workflow to do complete validation with warnings if no language has been changed, or with errors for files in language changed (PR only).
- Removes the `script/intentfest/validate.py` to remove redundant execution.

This PR was tested with an extra commit on top [here](https://github.com/staticdev/intents/pull/1) to force it to fail with the correct errors.