### PR TITLE
Update language labeller regex to include country or region segment

### DIFF
--- a/.github/workflows/backfill_labels.yaml
+++ b/.github/workflows/backfill_labels.yaml
@@ -20,7 +20,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            const LanguageFileRegex = /(?<section>sentences|responses|tests)\/(?<language_code>[a-z]{2})\/(?<intent>.+)\.yaml/;
+            const LanguageFileRegex = /(?<section>sentences|responses|tests)\/(?<language_code>[a-z]{2}(-[a-zA-Z]{2,4})?)\/(?<intent>.+)\.yaml/;
 
             async function ensureLabelExists(label) {
               try {
@@ -66,7 +66,7 @@ jobs:
               const langs = new Set();
               for (const path of files) {
                 const m = LanguageFileRegex.exec(path);
-                if (m?.groups?.language_code) langs.add(m.groups.language_code);
+                if (m?.groups?.language_code) langs.add(m.groups.language_code.toLowerCase());
               }
               const desired = new Set([...langs].map(code => `lang: ${code}`));
 

--- a/.github/workflows/ci_lang_labels.yaml
+++ b/.github/workflows/ci_lang_labels.yaml
@@ -33,7 +33,7 @@ jobs:
             }
 
             // Your regex
-            const LanguageFileRegex = /(?<section>sentences|responses|tests)\/(?<language_code>[a-z]{2})\/(?<intent>.+)\.yaml/;
+            const LanguageFileRegex = /(?<section>sentences|responses|tests)\/(?<language_code>[a-z]{2}(-[a-zA-Z]{2,4})?)\/(?<intent>.+)\.yaml/;
 
             // Collect changed files (no checkout required)
             const files = [];
@@ -48,7 +48,7 @@ jobs:
             const langs = new Set();
             for (const path of files) {
               const m = LanguageFileRegex.exec(path);
-              if (m?.groups?.language_code) langs.add(m.groups.language_code);
+              if (m?.groups?.language_code) langs.add(m.groups.language_code.toLowerCase());
             }
             if (langs.size === 0) {
               core.info(`No language-specific files detected for PR #${prNumber}`);


### PR DESCRIPTION
Account for the optional country, region, or script segment on the language codes to support:
- de-CH
- pt-BR
- sr-Latn
- zh-CN
- zh-HK
- zh-TW

Without this some changes don't get labelled, e.g.: https://github.com/OHF-Voice/intents/pull/3496