### PR TITLE
[DE] add "welche" sentences to binary_sensor window

### DIFF
--- a/sentences/de/binary_sensor_HassGetState.yaml
+++ b/sentences/de/binary_sensor_HassGetState.yaml
@@ -311,6 +311,15 @@ intents:
           domain: binary_sensor
           device_class: window
 
+      - sentences:
+          - "<welche> fenster (ist|sind) {bs_window_states:state}[ <area_floor>]"
+          - "<welche> fenster (ist|sind) <area_floor> {bs_window_states:state}"
+          - "<welche> fenster <area_floor> (ist|sind) {bs_window_states:state}"
+        response: welches
+        slots:
+          domain: binary_sensor
+          device_class: window
+
       # Gas
       - sentences:
           - "(ist|wurde) <name>[ <area>] {bs_gas_states:state}"

--- a/sentences/de/binary_sensor_HassGetState.yaml
+++ b/sentences/de/binary_sensor_HassGetState.yaml
@@ -312,9 +312,9 @@ intents:
           device_class: window
 
       - sentences:
-          - "<welche> fenster (ist|sind) {bs_window_states:state}[ <area_floor>]"
-          - "<welche> fenster (ist|sind) <area_floor> {bs_window_states:state}"
-          - "<welche> fenster <area_floor> (ist|sind) {bs_window_states:state}"
+          - "<welche> fenster (ist|sind)[ noch] {bs_window_states:state}[ <area_floor>]"
+          - "<welche> fenster (ist|sind) <area_floor>[ noch] {bs_window_states:state}"
+          - "<welche> fenster <area_floor> (ist|sind)[ noch] {bs_window_states:state}"
         response: welches
         slots:
           domain: binary_sensor

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -249,6 +249,15 @@ entities:
     attributes:
       device_class: window
 
+  - name: "Bürofenster"
+    id: "binary_sensor.office_room_window"
+    area: office
+    state:
+      in: "offen"
+      out: "on"
+    attributes:
+      device_class: window
+
   - name: "Gas"
     id: "binary_sensor.gas"
     area: kitchen

--- a/tests/de/binary_sensor_HassGetState.yaml
+++ b/tests/de/binary_sensor_HassGetState.yaml
@@ -734,7 +734,7 @@ tests:
         domain: "binary_sensor"
         device_class: "window"
         state: "off"
-    response: "Nein, Wohnzimmerfenster ist es nicht"
+    response: "Nein, Bürofenster und Wohnzimmerfenster sind es nicht"
 
   - sentences:
       - "sind alle fenster geöffnet?"
@@ -794,7 +794,7 @@ tests:
         domain: "binary_sensor"
         device_class: "window"
         state: "on"
-    response: "1"
+    response: "2"
 
   - sentences:
       - "wie viele fenster sind in der küche geschlossen?"
@@ -883,7 +883,7 @@ tests:
         domain: "binary_sensor"
         device_class: "window"
         state: "on"
-    response: "Wohnzimmerfenster und Officefenster"
+    response: "Bürofenster und Wohnzimmerfenster"
 
   # Gas
   - sentences:

--- a/tests/de/binary_sensor_HassGetState.yaml
+++ b/tests/de/binary_sensor_HassGetState.yaml
@@ -828,10 +828,13 @@ tests:
 
   - sentences:
       - "welche Fenster sind offen im Wohnzimmer?"
+      - "welche Fenster sind noch offen im Wohnzimmer?"
       - "welches Fenster ist geöffnet im Wohnzimmer?"
       - "welche Fenster sind im Wohnzimmer offen?"
+      - "welche Fenster sind im Wohnzimmer noch offen?"
       - "welches Fenster ist im Wohnzimmer offen?"
       - "welche Fenster im Wohnzimmer sind offen?"
+      - "welche Fenster im Wohnzimmer sind noch offen?"
       - "welche Fenster im Wohnzimmer sind geöffnet?"
       - "welches Fenster im Wohnzimmer ist offen?"
     intent:
@@ -874,7 +877,9 @@ tests:
 
   - sentences:
       - "welche Fenster sind offen?"
+      - "welche Fenster sind noch offen?"
       - "welches Fenster ist auf?"
+      - "welche Fenster sind noch auf?"
       - "welche Fenster sind auf?"
       - "welche Fenster sind geöffnet?"
     intent:

--- a/tests/de/binary_sensor_HassGetState.yaml
+++ b/tests/de/binary_sensor_HassGetState.yaml
@@ -826,6 +826,65 @@ tests:
         state: "on"
     response: "0"
 
+  - sentences:
+      - "welche Fenster sind offen im Wohnzimmer?"
+      - "welches Fenster ist geöffnet im Wohnzimmer?"
+      - "welche Fenster sind im Wohnzimmer offen?"
+      - "welches Fenster ist im Wohnzimmer offen?"
+      - "welche Fenster im Wohnzimmer sind offen?"
+      - "welche Fenster im Wohnzimmer sind geöffnet?"
+      - "welches Fenster im Wohnzimmer ist offen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        area: "Wohnzimmer"
+        device_class: "window"
+        state: "on"
+    response: "Wohnzimmerfenster"
+
+  - sentences:
+      - "welche Fenster sind geschlossen in der Küche?"
+      - "welches Fenster ist geschlossen in der Küche?"
+      - "welche Fenster sind in der Küche zu?"
+      - "welches Fenster ist in der Küche geschlossen?"
+      - "welche Fenster in der Küche sind zu?"
+      - "welche Fenster in der Küche sind geschlossen?"
+      - "welches Fenster in der Küche ist zu?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        area: "Küche"
+        device_class: "window"
+        state: "off"
+    response: "Küchenfenster"
+
+  - sentences:
+      - "welche Fenster sind geschlossen?"
+      - "welches Fenster ist geschlossen?"
+      - "welche Fenster sind zu?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "window"
+        state: "off"
+    response: "Küchenfenster"
+
+  - sentences:
+      - "welche Fenster sind offen?"
+      - "welches Fenster ist auf?"
+      - "welche Fenster sind auf?"
+      - "welche Fenster sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "window"
+        state: "on"
+    response: "Wohnzimmerfenster und Officefenster"
+
   # Gas
   - sentences:
       - "wurde Gas entdeckt?"


### PR DESCRIPTION
I added "welche" sentences to the binary_sensor window. I reused the sentences from cover window cause they fit very well.

So now you can ask for:

Welche Fenster sind im Wohnzimmer auf?
Welche Fenster sind geschlossen?
Welche Fenster in der Küche sind geöffnet?
.....and so on.

I was "struggeling" with the word "noch". I added it to the "welches" sentences as well, because you would maybe want to ask:

Welche Fenster sind noch auf?
Welche Fenster sind oben noch auf?

For me the word "noch" could be added to the list of skip_words. The only sentences where the word "noch" is currently used, is in the timerStatus: https://github.com/OHF-Voice/intents/blob/main/sentences/de/homeassistant_HassTimerStatus.yaml 
But this sentences needs this word "noch".

Are there specific rules how and when skip_words should be added or not? 

Regards,
Tobias

