### PR TITLE
[DE] reduce sentences count and ajust starTimer sentences

### DIFF
--- a/sentences/de/homeassistant_HassStartTimer.yaml
+++ b/sentences/de/homeassistant_HassStartTimer.yaml
@@ -12,7 +12,8 @@ intents:
           - "<timer_set>[ einen] Timer (auf|für) <timer_duration>"
           - "<timer_set>[ einen] Timer (auf|für) <timer_duration> (namens|für[ (<possessivpronom_mein>|<possessivpronom_unser>|<artikel_bestimmt>)]) {timer_name:name}"
           - "<timer_set>[ einen] <timer_duration> Timer (namens|für[ (<possessivpronom_mein>|<possessivpronom_unser>|<artikel_bestimmt>)]) {timer_name:name}"
-          - "<timer_set>[ einen][ Timer namens] {timer_name:name}[ Timer] (auf|für) <timer_duration>"
+          - "<timer_set>[ einen] {timer_name:name} Timer (auf|für) <timer_duration>"
+          - "<timer_set>[ einen] Timer (namens|für[ (<possessivpronom_mein>|<possessivpronom_unser>|<artikel_bestimmt>)]) {timer_name:name} (auf|für) <timer_duration>"
       - sentences:
           - "{timer_command:conversation_command} in <timer_duration>"
           - "[(mach[e]|fahr[e]|schalt[e]) ]in <timer_duration> {timer_command:conversation_command}"

--- a/sentences/de/homeassistant_HassStartTimer.yaml
+++ b/sentences/de/homeassistant_HassStartTimer.yaml
@@ -10,7 +10,8 @@ intents:
           - "{timer_name:name} Timer[ (auf|für)] <timer_duration>"
           - "<timer_set>[ einen] <timer_duration> Timer"
           - "<timer_set>[ einen] Timer (auf|für) <timer_duration>"
-          - "<timer_set>[ einen][ Timer (auf|für)] <timer_duration>[ Timer] (namens|für[ (<possessivpronom_mein>|<possessivpronom_unser>|<artikel_bestimmt>)]) {timer_name:name}"
+          - "<timer_set>[ einen] Timer (auf|für) <timer_duration> (namens|für[ (<possessivpronom_mein>|<possessivpronom_unser>|<artikel_bestimmt>)]) {timer_name:name}"
+          - "<timer_set>[ einen] <timer_duration> Timer (namens|für[ (<possessivpronom_mein>|<possessivpronom_unser>|<artikel_bestimmt>)]) {timer_name:name}"
           - "<timer_set>[ einen][ Timer namens] {timer_name:name}[ Timer] (auf|für) <timer_duration>"
       - sentences:
           - "{timer_command:conversation_command} in <timer_duration>"

--- a/tests/de/homeassistant_HassStartTimer.yaml
+++ b/tests/de/homeassistant_HassStartTimer.yaml
@@ -99,6 +99,8 @@ tests:
       - "5 Minuten Timer für Pizza"
       - "Stelle Timer namens Pizza auf 5 Minuten"
       - "Stelle Timer namens Pizza für 5 Minuten"
+      - "Stelle einen Timer für meine Pizza auf 5 Minuten"
+      - "Erstelle einen Timer für die Pizza für 5 Minuten"
       - "Timer auf 5 Minuten namens Pizza"
       - "Timer für 5 Minuten namens Pizza"
       - "Timer für 5 Minuten für die Pizza"
@@ -169,6 +171,18 @@ tests:
       slots:
         seconds: 45
     response: Timer für 45 Sekunden gestartet
+
+  - sentences:
+      - "Stelle einen Pizza Timer für 5 Minuten"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Wohnzimmer
+      slots:
+        minutes: 5
+        name:
+          - "Pizza"
+    response: Timer namens Pizza für 5 Minuten gestartet
 
   - sentences:
       - "Öffne die Garagentür in 5 Minuten"


### PR DESCRIPTION
Its me and the StartTimer again. 😄 

I was facing a small "issue" with the startTimer sentences. There are to may optional parameter in two of the sentences so the following sentence is processed:

"Stelle einen Wecker für 11 Minuten"
This results in:
"Timer names Wecker für 11 Minuten gestartet"

The startTimer intent will be used for all sentences which starts with: "<Stelle|Starte> [einen] ... für 5 Minuten", cause both "Timer" words are optional. I think this is not intended isn't it?

By splitting the sentence in two, this problem is fixed and the amount of sentences reduces by 50.000 (I added the possesivpromo so in summary the sentences count is reduced by 20.000 only).

So for now, if you would say:
"Stelle einen Eieruhrwecker für 5 Minuten" it will be not processed. 

Regards