### PR TITLE
[DE] fix "und" in HassStartTimer

### DIFF
--- a/responses/de/HassStartTimer.yaml
+++ b/responses/de/HassStartTimer.yaml
@@ -4,23 +4,25 @@ responses:
   intents:
     HassStartTimer:
       default: >
+        {% set singular = ['1', 'eine', 'einer'] %}
         {% set h = slots.hours if slots.hours is defined else none %}
         {% set m = slots.minutes if slots.minutes is defined else none %}
         {% set s = slots.seconds if slots.seconds is defined else none %}
-        {% set h_text = h ~ (' Stunde' if h in [ "1", 'eine'] else ' Stunden') if h else '' %}
-        {% set m_text = m ~ (' Minute' if m in [ "1", 'eine'] else ' Minuten') if m else '' %}
-        {% set s_text = s ~ (' Sekunde' if s in [ "1", 'eine'] else ' Sekunden') if s else '' %}
+        {% set h_text = h ~ (' Stunde' if h in singular else ' Stunden') if h else '' %}
+        {% set m_text = m ~ (' Minute' if m in singular else ' Minuten') if m else '' %}
+        {% set s_text = s ~ (' Sekunde' if s in singular else ' Sekunden') if s else '' %}
         {% set text_list = [ h_text, m_text, s_text] | select() | list %}
         {% set text = text_list[:-1] | join(', ') ~ ' und ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' und ') %}
         {% set name = (' namens ' ~ slots.name | trim) if slots.name is defined else '' %}
         Timer{{ name }} für {{ text }} gestartet
       command: >
+        {% set singular = ['1', 'eine', 'einer'] %}
         {% set h = slots.hours if slots.hours is defined else none %}
         {% set m = slots.minutes if slots.minutes is defined else none %}
         {% set s = slots.seconds if slots.seconds is defined else none %}
-        {% set h_text = h ~ (' Stunde' if h in [ "1", 'eine'] else ' Stunden') if h else '' %}
-        {% set m_text = m ~ (' Minute' if m in [ "1", 'eine'] else ' Minuten') if m else '' %}
-        {% set s_text = s ~ (' Sekunde' if s in [ "1", 'eine'] else ' Sekunden') if s else '' %}
+        {% set h_text = h ~ (' Stunde' if h in singular else ' Stunden') if h else '' %}
+        {% set m_text = m ~ (' Minute' if m in singular else ' Minuten') if m else '' %}
+        {% set s_text = s ~ (' Sekunde' if s in singular else ' Sekunden') if s else '' %}
         {% set text_list = [ h_text, m_text, s_text] | select() | list %}
-        {% set text = text_list[:-1] | join(', ') ~ ' and ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' and ') %}
+        {% set text = text_list[:-1] | join(', ') ~ ' und ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' und ') %}
         Anweisung wird in {{ text }} ausgeführt

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -679,15 +679,15 @@ expansion_rules:
   timer_cancel: "(beende|stopp[e]|lösch[e])"
   timer_cancel_end_of_sentence: "(ausschalten|deaktivieren|abbrechen|stoppen|aus)"
   timer_duration_seconds: "{timer_seconds:seconds} Sekunde[n]"
-  timer_duration_minutes: "{timer_minutes:minutes} Minute[n][ [und]{timer_seconds:seconds} Sekunde[n]]"
-  timer_duration_hours: "{timer_hours:hours} Stunde[n][ [und]{timer_minutes:minutes} Minute[n]][ [und]{timer_seconds:seconds} Sekunde[n]]"
+  timer_duration_minutes: "{timer_minutes:minutes} Minute[n][ [und ]{timer_seconds:seconds} Sekunde[n]]"
+  timer_duration_hours: "{timer_hours:hours} Stunde[n][ [und ]{timer_minutes:minutes} Minute[n]][ [und ]{timer_seconds:seconds} Sekunde[n]]"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
   timer_decrease: "(verringere|verkürze|reduziere)"
   timer_decrease_end_of_sentence: "(verringern|verkürzen|reduzieren)"
 
   timer_start_seconds: "{timer_seconds:start_seconds} Sekunde[n]"
-  timer_start_minutes: "{timer_minutes:start_minutes} Minute[n][ [und]{timer_seconds:start_seconds} Sekunde[n]]"
-  timer_start_hours: "{timer_hours:start_hours} Stunde[n][ [und]{timer_minutes:start_minutes} Minute[n]][ [und]{timer_seconds:start_seconds} Sekunde[n]]"
+  timer_start_minutes: "{timer_minutes:start_minutes} Minute[n][ [und ]{timer_seconds:start_seconds} Sekunde[n]]"
+  timer_start_hours: "{timer_hours:start_hours} Stunde[n][ [und ]{timer_minutes:start_minutes} Minute[n]][ [und ]{timer_seconds:start_seconds} Sekunde[n]]"
   timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
 
   # Media Players

--- a/tests/de/homeassistant_HassStartTimer.yaml
+++ b/tests/de/homeassistant_HassStartTimer.yaml
@@ -199,6 +199,19 @@ tests:
     response: Anweisung wird in 5 Minuten ausgeführt
 
   - sentences:
+      - "Öffne die Garagentür in einer Stunde und drei Minuten"
+      - "in einer Stunde und drei Minuten öffne die Garagentür"
+    intent:
+      name: HassStartTimer
+      slots:
+        hours: 1
+        minutes: 3
+        conversation_command:
+          - "Öffne die Garagentür"
+          - "öffne die Garagentür"
+    response: Anweisung wird in einer Stunde und drei Minuten ausgeführt
+
+  - sentences:
       - "schalte in 5 Minuten das Licht im Wohnzimmer aus"
     intent:
       name: HassStartTimer


### PR DESCRIPTION
Fixes multiple minor issues with `und` in HassStartTimer. `In einer Stunde und vier Minuten schalte das Küchenlicht an` wasn't recognized correctly previously. Also responses were a mix of english and german.

- expansion rules `timer_duration_hours`, `timer_duration_minutes`, `timer_start_hours` and `timer_start_minutes` missed a `space` in between e.g. `und vier Minuten` (expected `undvier Minuten`)
- response did not use singular for Stunden/Minuten/Sekunden for `einer Stunde|Minute|Sekunde`
- response for **delayed commands** concatenated hours, minutes and seconds with "and" instead of "und" (`Anweisung wird in 3 Stunden and 2 Minuten ausgeführt`)

Added a dedicated test for timer requests with word-numbers (?) like `einer Stunde und drei Minuten` as that would've presented the issue earlier already.

Should fix https://github.com/OHF-Voice/intents/issues/3298. This was partially fixed with [this commit ](https://github.com/OHF-Voice/hassil/commit/37d25c29f2c280dbf3525f18bfa643d6247db039) (could not find the corresponding PR 🤷🏽) but as @hecktech27 mentioned on Discord, the problem was still existing for DE when multiple numbers were in the sentence.