### PR TITLE
[FR] Enable permutations of "reste-t-il" and "de temps"

### DIFF
--- a/sentences/fr/homeassistant_HassTimerStatus.yaml
+++ b/sentences/fr/homeassistant_HassTimerStatus.yaml
@@ -6,11 +6,11 @@ intents:
       # No name
       - sentences:
           # Combien de temps reste-t-il
-          - "[Encore] Combien de temps <reste_t_il>"
+          - "[Encore] Combien (de temps;<reste_t_il>)"
           # Combien de temps reste-t-il au minuteur
-          - "[Encore] Combien de temps <reste_t_il> <au> <minuteur>"
+          - "[Encore] Combien ([de temps];<reste_t_il>) <au> <minuteur>"
           # Combien de temps reste-t-il sur le minuteur
-          - "[Encore] Combien de temps <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur>"
+          - "[Encore] Combien ([de temps];<reste_t_il>) (sur|dans) [<le>|<mon>] <minuteur>"
           # Il reste combien de temps
           - "[Il reste] [encore] combien de temps"
           # Il reste combien de temps au minuteur
@@ -23,9 +23,9 @@ intents:
       # area
       - sentences:
           # Combien de temps reste-t-il au minuteur de la cuisine
-          - "[Encore] Combien [de temps] <reste_t_il> <au> <minuteur> [<de>] [<le>]{area}"
+          - "[Encore] Combien ([de temps];<reste_t_il>) <au> <minuteur> [<de>] [<le>]{area}"
           # Combien de temps reste-t-il sur le minuteur de la cuisine
-          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
+          - "[Encore] Combien ([de temps];<reste_t_il>) (sur|dans) [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
           # Il reste combien de temps au minuteur de la cuisine
           - "[Il reste] [encore] combien [de temps] <au> <minuteur> [<de>] [<le>]{area}"
           # Il reste combien de temps sur le minuteur de la cuisine
@@ -36,9 +36,9 @@ intents:
       # duration
       - sentences:
           # Combien de temps reste-t-il au minuteur de 2 minutes
-          - "[Encore] Combien [de temps] <reste_t_il> <au> <minuteur> [de] <timer_start>"
+          - "[Encore] Combien ([de temps];<reste_t_il>) <au> <minuteur> [de] <timer_start>"
           # Combien de temps reste-t-il sur le minuteur de 2 minutes
-          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur> [de] <timer_start>"
+          - "[Encore] Combien ([de temps];<reste_t_il>) (sur|dans) [<le>|<mon>] <minuteur> [de] <timer_start>"
           # Il reste combien de temps au minuteur de 2 minutes
           - "[Il reste] [encore] combien [de temps] <au> <minuteur> [de] <timer_start>"
           # Il reste combien de temps sur le minuteur de 2 minutes
@@ -49,11 +49,11 @@ intents:
       # name
       - sentences:
           # Combien de temps reste-t-il au minuteur appelé Pizza
-          - "[Encore] Combien [de temps] <reste_t_il> <au> <minuteur> [<appele>] {timer_name:name}"
+          - "[Encore] Combien ([de temps];<reste_t_il>) <au> <minuteur> [<appele>] {timer_name:name}"
           # Combien de temps reste-t-il sur le minuteur appelé Pizza
-          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
+          - "[Encore] Combien ([de temps];<reste_t_il>) (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
           # Combien de temps reste-t-il pour la pizza
-          - "[Encore] Combien [de temps] <reste_t_il> [<appele>] {timer_name:name}"
+          - "[Encore] Combien ([de temps];<reste_t_il>) [<appele>] {timer_name:name}"
           # Il reste combien de temps au minuteur appelé Pizza
           - "[Il reste] [encore] combien [de temps] <au> <minuteur> [<appele>] {timer_name:name}"
           # Il reste combien de temps sur le minuteur appelé Pizza

--- a/tests/fr/homeassistant_HassTimerStatus.yaml
+++ b/tests/fr/homeassistant_HassTimerStatus.yaml
@@ -4,9 +4,13 @@ tests:
   # No name
   - sentences:
       - "Combien de temps reste-t-il"
+      - "Combien reste-t-il de temps"
       - "Combien de temps reste-t-il au minuteur"
+      - "Combien reste-t-il au minuteur"
       - "Combien de temps reste-t-il sur mon minuteur"
       - "Combien de temps reste-t-il dans le minuteur"
+      - "Combien reste-t-il dans le minuteur"
+      - "Combien reste-t-il de temps à la minuterie"
       - "Il reste combien de temps"
       - "Il reste combien de temps au minuteur"
       - "Il reste combien sur mon minuteur"
@@ -21,6 +25,7 @@ tests:
       - "Combien de temps reste-t-il au minuteur de la cuisine"
       - "Combien de temps reste-t-il sur le minuteur de la cuisine"
       - "Combien de temps reste-t-il dans le minuteur de la cuisine"
+      - "Combien reste-t-il de temps à la minuterie de la cuisine"
       - "Il reste combien de temps au minuteur de la cuisine"
       - "Il reste combien sur mon minuteur de la cuisine"
       - "Il reste combien de temps dans le minuteur de la cuisine"
@@ -35,6 +40,7 @@ tests:
   - sentences:
       - "Combien de temps reste-t-il au minuteur de 5 minutes"
       - "Combien de temps reste-t-il sur le minuteur de 5 min"
+      - "Combien reste-t-il de temps sur le minuteur de 5 min"
       - "Combien de temps reste-t-il dans le minuteur de 5 minutes"
       - "Il reste combien de temps au minuteur de 5 minutes"
       - "Il reste combien sur mon minuteur de 5 min"
@@ -51,6 +57,7 @@ tests:
       - "Combien de temps reste-t-il au minuteur appelé chocolatine"
       - "Combien de temps reste-t-il à la minuterie surnommée chocolatine"
       - "Combien de temps reste-t-il sur le minuteur appelé chocolatine"
+      - "Combien reste-t-il de temps sur le minuteur appelé chocolatine"
       - "Combien de temps reste-t-il dans le minuteur appelé chocolatine"
       - "Il reste combien de temps au minuteur appelé chocolatine"
       - "Il reste combien sur mon minuteur appelé chocolatine"


### PR DESCRIPTION
This one has been driving my partner mad for a few months. She couldn't find out what the difference was between what we were saying, and I had to really listen to detect the difference. I was saying "Combien de temps reste-t-il [...]", and she was saying "Combien reste-t-il de temps [...]". I'm unclear if this is a specificity of Québécois or universal. I also made [de temps] optional for the no name options where it made sense to align with the named ones.