### PR TITLE
[NL] Add `waarde`  as word to retreive the state of an entity

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -719,7 +719,7 @@ expansion_rules:
   to: "(naar|op)"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"
   all: "(alle|elke|iedere|overal)"
-  state: "(status|staat|stand)"
+  state: "(status|staat|stand|waarde)"
   # cover deivce classes
   awning: "(luifel[s]|[zonne]scherm[en])"
   blind: "(jaloezie[ën]|luxaflex)"


### PR DESCRIPTION
Small change in the `_common.yaml` which adds `waarde`  to the `state` expansion rule.