### PR TITLE
[DE] MediaPlayer: "weiter" triggers MediaNext instead of MediaUnpause

### DIFF
--- a/sentences/de/media_player_HassMediaNext.yaml
+++ b/sentences/de/media_player_HassMediaNext.yaml
@@ -13,6 +13,7 @@ intents:
           - "[((an|auf)[ dem]|am) ]<name> <zu_dem> <naechster> <song>[ (vor[wärts]|weiter)][ ](springen|spulen)"
           - "überspring[e] ((das|dieses)[ eine]|ein) <song> [((an|auf)[ dem]|am) ]<name>"
           - "[((an|auf)[ dem]|am) ]<name> ((das|dieses)[ eine]|ein) <song> überspringen"
+          - "<name> weiter"
         requires_context:
           domain: media_player
       - sentences:
@@ -23,6 +24,7 @@ intents:
           - "[(spring[e]|spul[e]) ]<zu_dem> <naechster> <song>[ (vor[wärts]|weiter)]"
           - "<zu_dem> <naechster> <song>[ (vor[wärts]|weiter)][ ](springen|spulen)"
           - "überspring[e] ((das|dieses)[ eine]|ein) <song>"
+          - "weiter"
         requires_context:
           area:
             slot: true
@@ -41,3 +43,4 @@ intents:
           - "<area> <zu_dem> <naechster> <song>[ (vor[wärts]|weiter)][ ](springen|spulen)"
           - "überspring[e] ((das|dieses)[ eine]|ein) <song> <area>"
           - "<area> ((das|dieses)[ eine]|ein) <song> überspringen"
+          - "<area> weiter"

--- a/sentences/de/media_player_HassMediaUnpause.yaml
+++ b/sentences/de/media_player_HassMediaUnpause.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       # by name
       - sentences:
-          - "[(am|auf) ]<name> weiter[ (machen|<local_play>)]"
+          - "[(am|auf) ]<name> weiter (machen|<local_play>)"
           - "[(am|auf) ]<name> weiter(machen|schauen|hören|spielen|laufen lassen)"
           - "<name> fortsetzen"
           - "<name> wieder (starten|[ab]spielen|laufen lassen)"
@@ -15,7 +15,7 @@ intents:
 
       # media_type
       - sentences:
-          - "[[(die|das|mein|meine) ]<media_type> ](fortsetzen|weiter[ (machen|<local_play>)]|wieder <local_play>)"
+          - "[[(die|das|mein|meine) ]<media_type> ](fortsetzen|weiter (machen|<local_play>)|wieder <local_play>)"
           - "[[(die|das|mein|meine) ]<media_type> ]weiter(machen|schauen|hören|spielen|laufen lassen)"
           - "lass [(die|das|mein|meine) ]<media_type> wieder (starten|[ab]spielen|laufen)"
           - "lass [(die|das|mein|meine) ]<media_type> weiter ([ab]spielen|laufen)"
@@ -30,7 +30,7 @@ intents:
 
       # area_media_type
       - sentences:
-          - "[(die|das|mein|meine) ]<media_type> <area> (fortsetzen|weiter[ (machen|<local_play>)])"
+          - "[(die|das|mein|meine) ]<media_type> <area> (fortsetzen|weiter (machen|<local_play>))"
           - "[(die|das|mein|meine) ]<media_type> <area> weiter(machen|schauen|hören|spielen|laufen lassen)"
           - "setz[e] [(die|das|mein|meine) ]<media_type> <area> fort"
           - "spiel[e] [(die|das|mein|meine) ]<media_type> <area> (wieder ab|weiter[ ab])"
@@ -44,7 +44,7 @@ intents:
 
       # area
       - sentences:
-          - "<area> weiter[ (machen|<local_play>)]"
+          - "<area> weiter (machen|<local_play>)"
           - "<area> weiter(machen|schauen|hören|spielen|laufen lassen)"
           - "<area> fortsetzen"
           - "<area> wieder (starten|[ab]spielen|laufen lassen)"

--- a/tests/de/media_player_HassMediaNext.yaml
+++ b/tests/de/media_player_HassMediaNext.yaml
@@ -31,6 +31,7 @@ tests:
       - "am TV das lied überspringen"
       - "am TV dieses eine Lied überspringen"
       - "am TV ein Lied überspringen"
+      - "TV weiter"
     intent:
       name: HassMediaNext
       slots:
@@ -67,6 +68,7 @@ tests:
       - "im WOhnzimmer das lied überspringen"
       - "Im Wohnzimmer dieses eine Lied überspringen"
       - "Im Wohnzimmer ein Lied überspringen"
+      - "Wohnzimmer weiter"
     intent:
       name: HassMediaNext
       slots:
@@ -105,6 +107,7 @@ tests:
       - "überspring das lied"
       - "überspringe dieses eine Lied"
       - "überspring ein Lied"
+      - "weiter"
     intent:
       name: HassMediaNext
       slots:

--- a/tests/de/media_player_HassMediaUnpause.yaml
+++ b/tests/de/media_player_HassMediaUnpause.yaml
@@ -1,7 +1,6 @@
 language: de
 tests:
   - sentences:
-      - "TV weiter"
       - "TV weiter machen"
       - "TV weiter laufen lassen"
       - "TV weiterlaufen lassen"
@@ -22,7 +21,6 @@ tests:
       - "weiter laufen lassen"
       - "weiter machen"
       - "fortsetzen"
-      - "weiter"
       - "weiterschauen"
       - "weiter anschauen"
       - "weiter hören"
@@ -79,7 +77,6 @@ tests:
       - "Meine Fernsehsendung im Wohnzimmer fortsetzen"
       - "Die Fernsehsendung im Wohnzimmer weiter machen"
       - "Das Gerät im Wohnzimmer fortsetzen"
-      - "Das Gerät im Wohnzimmer weiter"
     intent:
       name: HassMediaUnpause
       slots:
@@ -88,7 +85,6 @@ tests:
         area: Wohnzimmer
     response: "Fortgesetzt"
   - sentences:
-      - "Wohnzimmer weiter"
       - "Wohnzimmer weiter machen"
       - "Wohnzimmer weiter laufen lassen"
       - "Wohnzimmer weiterlaufen lassen"


### PR DESCRIPTION
This PR moves `weiter` as a command from HassMediaUnpause to HassMediaNext.
In my opinion sentences like
- Weiter
- TV weiter
- Wohnzimmer weiter

should trigger MediaNext(changed in this PR) while sentences like `Musik weiter laufen lassen` should trigger MediaUnpause(as they already do)