### PR TITLE
[fr] Add HassLawnMowerStartMowing

### DIFF
--- a/responses/fr/HassLawnMowerStartMowing.yaml
+++ b/responses/fr/HassLawnMowerStartMowing.yaml
@@ -1,0 +1,5 @@
+language: "fr"
+responses:
+  intents:
+    HassLawnMowerStartMowing:
+      default: "Tonte démarrée"

--- a/sentences/fr/HassLawnMowerStartMowing/default.yaml
+++ b/sentences/fr/HassLawnMowerStartMowing/default.yaml
@@ -1,0 +1,7 @@
+language: "fr"
+data:
+  - sentences:
+      - "(tonds|tondre|démarre|démarrer) [la] (pelouse|tondeuse|gazon)"
+      - "démarre [la] tonte"
+      - "commence [à] (tondre|tondre la pelouse|tondre le gazon)"
+    response: "default"

--- a/sentences/fr/HassLawnMowerStartMowing/default.yaml
+++ b/sentences/fr/HassLawnMowerStartMowing/default.yaml
@@ -1,7 +1,7 @@
 language: "fr"
 data:
   - sentences:
-      - "(tonds|tondre|démarre|démarrer) [la] (pelouse|tondeuse|gazon)"
-      - "démarre [la] tonte"
-      - "commence [à] (tondre|tondre la pelouse|tondre le gazon)"
+      - "<tond> [la] (pelouse|gazon)"
+      - "<tond> [la] tondeuse"
+      - "<demarre> [la] (tonte|tondeuse)"
     response: "default"

--- a/sentences/fr/HassLawnMowerStartMowing/name_only.yaml
+++ b/sentences/fr/HassLawnMowerStartMowing/name_only.yaml
@@ -1,0 +1,8 @@
+language: "fr"
+data:
+  - sentences:
+      - "<demarre> [<le>]{name}"
+      - "envoie [<le>]{name} (tondre|sur la pelouse|sur le gazon)"
+    name_domains:
+      - "lawn_mower"
+    response: "default"

--- a/sentences/fr/HassLawnMowerStartMowing/name_only.yaml
+++ b/sentences/fr/HassLawnMowerStartMowing/name_only.yaml
@@ -2,7 +2,7 @@ language: "fr"
 data:
   - sentences:
       - "<demarre> [<le>]{name}"
-      - "envoie [<le>]{name} (tondre|sur la pelouse|sur le gazon)"
+      - "<envoie> [<le>]{name} <tond>"
     name_domains:
       - "lawn_mower"
     response: "default"

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -516,6 +516,8 @@ expansion_rules:
   baisse: (baisse|baisser|descendre|descends)
   nettoie: (aspire|aspirer|nettoie|nettoyer)
   annonce: "(annonce|annoncer)"
+  tond: "(tonds|tondre)"
+  envoie: "(envoie|envoyer)"
 
   # Dirty Verbs. We have some heavy STT limitations today. We're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
   # Éteins


### PR DESCRIPTION
## Summary

- Adds French sentences for `HassLawnMowerStartMowing` in slot-combination format
- Covers `default` and `name_only` combos
- Adds French response: "Tonte démarrée"

## Combos covered

| Combo | Example |
|---|---|
| `default` | "tonds la pelouse", "démarre la tondeuse" |
| `name_only` | "démarre Clippy", "envoie Clippy tondre" |

## Test plan

- [ ] `python3 -m script.intentfest validate --language fr` passes
- [ ] Spot-check: "tonds la pelouse" → `HassLawnMowerStartMowing`
- [ ] Spot-check: "démarre Clippy" → `HassLawnMowerStartMowing` with name=Clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)