### PR TITLE
[fr] Add HassLawnMowerDock

### DIFF
--- a/responses/fr/HassLawnMowerDock.yaml
+++ b/responses/fr/HassLawnMowerDock.yaml
@@ -1,0 +1,5 @@
+language: "fr"
+responses:
+  intents:
+    HassLawnMowerDock:
+      default: "Tondeuse garée"

--- a/sentences/fr/HassLawnMowerDock/default.yaml
+++ b/sentences/fr/HassLawnMowerDock/default.yaml
@@ -1,7 +1,6 @@
 language: "fr"
 data:
   - sentences:
-      - "(arrête|stoppe|gare|renvoie) [la] (tondeuse|tonte)"
-      - "arrête de (tondre|tondre la pelouse|tondre le gazon)"
-      - "renvoie la tondeuse [(à|sur) (sa|la) base]"
+      - "(<eteins>|<renvoie>) [la] (tondeuse|tonte)"
+      - "<renvoie> la tondeuse [(à|sur) (sa|la) base]"
     response: "default"

--- a/sentences/fr/HassLawnMowerDock/default.yaml
+++ b/sentences/fr/HassLawnMowerDock/default.yaml
@@ -1,0 +1,7 @@
+language: "fr"
+data:
+  - sentences:
+      - "(arrête|stoppe|gare|renvoie) [la] (tondeuse|tonte)"
+      - "arrête de (tondre|tondre la pelouse|tondre le gazon)"
+      - "renvoie la tondeuse [(à|sur) (sa|la) base]"
+    response: "default"

--- a/sentences/fr/HassLawnMowerDock/name_only.yaml
+++ b/sentences/fr/HassLawnMowerDock/name_only.yaml
@@ -1,0 +1,8 @@
+language: "fr"
+data:
+  - sentences:
+      - "(arrête|stoppe|gare) [<le>]{name}"
+      - "<renvoie> [<le>]{name} [(à|sur) (sa|la) base]"
+    name_domains:
+      - "lawn_mower"
+    response: "default"

--- a/sentences/fr/HassLawnMowerDock/name_only.yaml
+++ b/sentences/fr/HassLawnMowerDock/name_only.yaml
@@ -1,7 +1,7 @@
 language: "fr"
 data:
   - sentences:
-      - "(arrête|stoppe|gare) [<le>]{name}"
+      - "<eteins> [<le>]{name}"
       - "<renvoie> [<le>]{name} [(à|sur) (sa|la) base]"
     name_domains:
       - "lawn_mower"


### PR DESCRIPTION
## Summary

- Adds French sentences for `HassLawnMowerDock` in slot-combination format
- Covers `default` and `name_only` combos
- Adds French response: "Tondeuse garée"

## Combos covered

| Combo | Example |
|---|---|
| `default` | "arrête la tondeuse", "renvoie la tondeuse à la base" |
| `name_only` | "gare Clippy", "renvoie Clippy à sa base" |

## Test plan

- [ ] `python3 -m script.intentfest validate --language fr` passes
- [ ] Spot-check: "arrête la tondeuse" → `HassLawnMowerDock`
- [ ] Spot-check: "renvoie Clippy à sa base" → `HassLawnMowerDock` with name=Clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)