### PR TITLE
Add three Claude Code skills for OHF-Voice/intents workflows

### DIFF
--- a/.claude/skills/ha-intents-author/SKILL.md
+++ b/.claude/skills/ha-intents-author/SKILL.md
@@ -149,18 +149,17 @@ If the intent requires a new list (e.g. `media_class`, `search_query`), add it t
 
 ### 6. Validate before finishing
 
-Always run the full test suite — not just validate:
+**Do not run `script/test`** — the full suite takes 4+ minutes and tests every language. Use the targeted commands instead:
 
 ```bash
-script/test
+# Test only the file you changed (fast, use while iterating)
+script/test_file tests/<lang>/<domain>_<intent>.yaml
+
+# Test the entire language (run this before pushing)
+script/test_file tests/<lang>/<domain>_<intent>.yaml --select-language
 ```
 
-This runs both `intentfest validate` and `pytest`. Do not push until `script/test` exits with 0 failures. If `script/test` is unavailable:
-
-```bash
-python3 -m script.intentfest validate --language <lang>
-pytest tests/test_language_sentences.py -k "<Intent> and <lang>" -q --no-header --tb=short
-```
+`--select-language` extracts the language from the file path and runs all tests for that language. Do not push until the language-scoped run exits with 0 failures.
 
 For spot checks while drafting:
 ```bash
@@ -184,7 +183,7 @@ Report:
 - Inlining words that already exist as expansion rules — check `_common.yaml` first.
 - Translating English word-by-word instead of writing what users actually say.
 - Putting sentences with different slot expectations in the same `data:` group — split them.
-- Pushing without running `script/test` — a passing `validate` alone is not enough.
+- Pushing without running `script/test_file <file> --select-language` — a passing `validate` alone is not enough.
 - Writing a `requires_context: area: slot: true` test without the `context:` block.
 - Using an entity name in a test that is not in `_fixtures.yaml`.
 - Using regex alternation `(a|b)` inside a list `in:` value — use separate entries.

--- a/.claude/skills/ha-intents-author/SKILL.md
+++ b/.claude/skills/ha-intents-author/SKILL.md
@@ -14,119 +14,178 @@ Before writing anything, confirm with the user (use AskUserQuestion if any are m
 1. **Repo path** — absolute path to the cloned `intents` repo. If unknown, ask. Default to the workspace folder if a folder named `intents/` is present.
 2. **Language code** — e.g. `fr`, `de`, `pt-BR`. Cross-check against `languages.yaml`.
 3. **Intent + slot combination** — e.g. `HassTurnOn / name_only`, or just `HassClimateSetTemperature`. If only an intent is given, list its slot combinations from `intents.yaml` and ask which one(s).
-4. **Format mode** — auto-detect:
-   - If `sentences/<lang>/<Intent>/` exists → **slot-combination format** (new, English-leading).
-   - Else → **legacy format** (`sentences/<lang>/<domain>_<intent>.yaml`).
-   The user can override.
+
+## Format: always use legacy
+
+**Always use the legacy format** (`sentences/<lang>/<domain>_<intent>.yaml`) for all non-English languages. The slot-combination format (`sentences/<lang>/<Intent>/<combo>.yaml`) is the new English-leading format and is **not ready** for other languages — do not use it, even if the user asks.
+
+Legacy file structure:
+```yaml
+language: <lang>
+intents:
+  <IntentName>:
+    data:
+      # <slot combination comment>
+      - sentences:
+          - "<template 1>"
+          - "<template 2>"
+        requires_context:        # optional
+          area:
+            slot: true           # copies active area into `area` slot
+        response: default        # or a specific response key
+```
+
+Cluster sentences by slot combination within the file, one `data:` group per combination, with a short comment. Look at `sentences/fr/cover_HassTurnOn.yaml` for the canonical example of this style.
 
 ## Syntax cheatsheet (HassIL)
 
-Templates use the [HassIL](https://github.com/home-assistant/hassil) syntax:
-
 - **Alternatives**: `(red|green|blue)` — one of. Can apply mid-word: `turn(s|ed|ing)`.
 - **Optionals**: `[the]` — present or absent. Mid-word: `light[s]`.
-- **Lists**: `{name}` matches a list value and stores it in the slot of the same name. Use `{list:slot}` if names differ.
-- **Expansion rules**: `<rule_name>` — replaced with the rule body. Defined in `rules/<lang>/*.yaml` (new) or `_common.yaml` (legacy).
+- **Lists**: `{name}` matches a list value and stores it in the slot. The stored value is the `out:` value, not the `in:` value. Use `{list:slot}` if names differ.
+- **Expansion rules**: `<rule_name>` — replaced with the rule body. Always prefer these over inlining.
 - **Permutations**: `(a;b)` — both must appear, any order.
+- **Inline expansion rules**: can be defined inside a `data:` group under `expansion_rules:` for local reuse within that group.
 
-**Slot-combination format restrictions** (enforced by validator for English, recommended elsewhere):
-- A list reference cannot appear inside an alternative: `(text|{list})` is forbidden.
-- A list reference cannot be optional: `[{list}]` is forbidden.
-- Rules should not contain `{lists}` or other `<rules>`.
+## Expansion rules: always prefer them over inlining
+
+**This is the most important authoring rule.** Before writing any word or phrase into a template, check `sentences/<lang>/_common.yaml` for an existing expansion rule. If one exists, use it — never inline the equivalent text.
+
+Common rules to look for (check your language's `_common.yaml` for the actual expansions):
+- Verb groups: `<active>`, `<mets>`, `<eteins>`, `<nettoie>`, `<envoie>`, `<demarre>` — domain-specific verb lists
+- Article rules: `<le>`, `<de>` — definite/partitive articles (know their exact content before using them)
+- Locative rules: `<dans>`, `<ici>` — prepositions and "here" equivalents
+- Domain nouns: `<media>`, `<volume>`, `<minuteur>`, `<serrure>` — object nouns
+
+If a phrase you need does not exist as a rule but appears 3+ times in the file, define it as an inline `expansion_rules:` in the `data:` group (for local reuse) or propose adding it to `_common.yaml`.
+
+**Never** hardcode verb lists when an expansion rule already covers them. **Never** hardcode article+noun combos when a rule already exists.
 
 ## Procedure
 
 ### 1. Survey context
 
-Read these in order — quote the exact paths back to the user as you go:
+Read these in order:
 
-- `intents.yaml` → find the target intent. Note: `slot_combinations`, `slots`, `name_domains` / `inferred_domains` and their importance (`required`/`usable`/`complete`/`optional`), the English `example`. The example is your seed.
-- `sentences/en/<Intent>/<combo>.yaml` (or `sentences/en/<domain>_<intent>.yaml`) → reference implementation.
-- `sentences/<lang>/_common.yaml` (legacy) and `rules/<lang>/*.yaml` + `lists/<lang>/*.yaml` (new) → existing rules and lists you should reuse instead of inlining.
-- `tests/<lang>/...` for the same intent → existing tests; new sentences need parallel test entries.
-- `responses/<lang>/<Intent>.yaml` → response keys you can reference via `response: "..."` in the sentence file.
+- `intents.yaml` → find the target intent. Note: `slot_combinations`, `slots`, `name_domains` / `inferred_domains` and their importance (`required`/`usable`/`complete`/`optional`), the English `example`.
+- `sentences/en/<domain>_<intent>.yaml` → reference implementation in English.
+- `sentences/<lang>/_common.yaml` → **read this carefully** for all available expansion rules and lists before writing a single template. Know the exact expansion of every rule you plan to use.
+- `tests/<lang>/<domain>_<intent>.yaml` → existing tests; new sentences need parallel test entries.
+- `tests/<lang>/_fixtures.yaml` → available entity names for `{name}` slot tests. Any `{name}` value used in tests **must** appear here.
+- `responses/<lang>/<Intent>.yaml` → response keys to reference via `response: default` or a specific key.
 
 ### 2. Draft sentences
 
-Write 3-10 templates per `data:` group. Group sentences that share the same `slots`, `name_domains` / `inferred_domain`, and `response`. Aim for:
+Write 2-5 templates per `data:` group. Group sentences that share the same slots and `requires_context`. Aim for:
 
-- **Natural phrasings a native speaker actually uses** — not literal translations of English. Ask the user for regional variants if unsure.
-- **Reuse rules**: prefer `<turn>` over re-listing `(turn|switch)`. If a phrase repeats 3+ times across the file, propose a new rule in `rules/<lang>/`.
-- **Cover the `required` domains/combinations** in `intents.yaml`. Split into multiple `data:` groups when domains diverge (e.g. lights vs covers).
-- **Keep template explosion in check** — every optional doubles permutations; every alternative multiplies. Flag any single template producing >10k permutations.
+- **Natural phrasings a native speaker actually uses** — not literal translations of English.
+- **Expansion rules first** — check `_common.yaml` before writing any word.
+- **Cover all slot combinations** from `intents.yaml`. Use separate `data:` groups for: context-area, explicit area, explicit floor, name-only, name+area.
+- **Keep template explosion in check** — every optional doubles permutations; every alternative multiplies.
 
-For each new template, mentally sample it and confirm it reads naturally in 2-3 expansions.
+### 3. `requires_context` rules
 
-### 3. Pair tests
+- `requires_context: area: slot: true` — fires only when an area is active in context; the active area value is automatically copied into the `area` slot. Use for sentences with no explicit area mention.
+- `requires_context: domain: <domain>` — fires only in the context of devices of that domain. Use for `{name}` slots targeting a specific device type (e.g. `media_player`, `fan`, `vacuum`).
+- Sentences with an explicit `{area}` or `{floor}` slot in the template do **not** need `requires_context`.
 
-For every `data:` group you add, add a matching `tests:` block in `tests/<lang>/...`. The shape differs by format — match whatever the existing file uses:
+### 4. Pair tests (mandatory)
 
-**Slot-combination format** (`tests/<lang>/<Intent>/<combo>.yaml`) — intent is implied by the path:
+Tests are not optional. Every `data:` group you add **must** have a matching test block in `tests/<lang>/<domain>_<intent>.yaml`.
+
+Legacy test format:
 ```yaml
-language: "<lang>"
-entities:
-  - { name: "Overhead Light", domain: "light" }
+language: <lang>
 tests:
-  - sentences: ["turn on Overhead Light"]
-    slots: { name: "Overhead Light" }
-    response: "Turned on the light"
-```
-
-**Legacy format** (`tests/<lang>/<domain>_<intent>.yaml`) — intent is named explicitly, fixtures live in `_fixtures.yaml`:
-```yaml
-language: "<lang>"
-tests:
-  - sentences: ["turn on the kitchen light"]
+  - sentences:
+      - "realised sentence 1"
+      - "realised sentence 2"
     intent:
-      name: HassTurnOn
-      slots: { area: "Kitchen", domain: "light" }
-    response: "Turned on the lights"
+      name: <IntentName>
+      slots:
+        area: "salon"
+    response: "Rendered response string"
 ```
 
-Either way, every new template needs at least one realised test sentence. Provide enough variety to catch under-specification (sentences that match too much) and missed permutations.
+**Critical test rules:**
 
-Provide enough variety to catch under-specification (sentences that match too much) and missed permutations.
+1. **Context-area tests** — if the sentence group uses `requires_context: area: slot: true`, the test block **must** include both `context:` and the `area` slot:
+   ```yaml
+   intent:
+     name: <IntentName>
+     context:
+       area: "salon"
+     slots:
+       area: "salon"
+   ```
+   Without `context:`, recognition returns `None` and the test fails.
 
-### 4. Validate before finishing
+2. **`{name}` slot values** must exist in `tests/<lang>/_fixtures.yaml`. Look up the exact entity name before writing the test sentence.
 
-Run from the repo root and report any failures verbatim:
+3. **List slot values** — use the `out:` value from the list definition, not the `in:` value (e.g. `media_class: "music"` not `media_class: "musique"`).
+
+4. **No duplicate sentences** — the same realised sentence cannot appear in two test blocks. The validator detects this.
+
+5. **One test block per slot-value combination** — sentences in the same block must all produce the same slot values. If two sentences produce different values (e.g. different `media_class`), split them into separate blocks.
+
+### 5. Lists in `_common.yaml`
+
+If the intent requires a new list (e.g. `media_class`, `search_query`), add it to `sentences/<lang>/_common.yaml`:
+
+- **Wildcard lists** (free-text slots): `search_query: wildcard: true`
+- **Value lists** — each value must be a **separate entry**. Do NOT use regex alternation inside `in:` values:
+  ```yaml
+  # WRONG
+  - in: "(morceau|chanson|piste)"
+    out: "track"
+
+  # RIGHT
+  - in: "morceau"
+    out: "track"
+  - in: "chanson"
+    out: "track"
+  - in: "piste"
+    out: "track"
+  ```
+
+### 6. Validate before finishing
+
+Always run the full test suite — not just validate:
+
+```bash
+script/test
+```
+
+This runs both `intentfest validate` and `pytest`. Do not push until `script/test` exits with 0 failures. If `script/test` is unavailable:
 
 ```bash
 python3 -m script.intentfest validate --language <lang>
-python3 -m script.intentfest count_sentences --language <lang> --summary
-pytest tests --language <lang> -k <Intent>
+pytest tests/test_language_sentences.py -k "<Intent> and <lang>" -q --no-header --tb=short
 ```
 
-For ad-hoc spot checks while drafting:
-
+For spot checks while drafting:
 ```bash
-# Expand a single template to see real sentences
-python3 -m script.intentfest sample_template '<your template>' \
-  --rule turn '(turn|switch)' --values name "kitchen light"
-
 # Confirm a sentence parses to the right intent and slots
 python3 -m script.intentfest parse --language <lang> --sentence 'allume la lumière'
 ```
 
-### 5. Hand back
+### 7. Hand back
 
 Report:
 
 1. Files changed (paths).
-2. New sentences (count) and test sentences (count).
-3. Validator output and pytest result.
-4. Any rules or lists you added (and why).
-5. Open questions for the language leader (e.g. regional spelling, formal vs informal forms).
+2. New sentence templates (count) and test sentences (count).
+3. `script/test` result (must be 0 failures).
+4. Any rules or lists added to `_common.yaml` (and why).
+5. Open questions for the language leader (regional spelling, formal vs informal, etc.).
 
 ## Anti-patterns to avoid
 
+- Using slot-combination format for non-English languages — always use legacy.
+- Inlining words that already exist as expansion rules — check `_common.yaml` first.
 - Translating English word-by-word instead of writing what users actually say.
-- Stuffing one `data:` group with sentences that have different slot expectations — split them.
-- Adding a sentence without a corresponding test (validator passes, real users break it).
-- Inlining a phrase that already exists as a rule (`<turn>`, `<the>`, `<here>`).
-- Putting `{name}` inside `[ ]` or `( | )` in slot-combination files — validator will reject it.
-- Wide-open templates like `[anything] {name} [please]` that explode into millions of permutations.
-
-## Output
-
-When you are done, present a short summary in chat plus a link to the changed files via `computer://` paths.
+- Putting sentences with different slot expectations in the same `data:` group — split them.
+- Pushing without running `script/test` — a passing `validate` alone is not enough.
+- Writing a `requires_context: area: slot: true` test without the `context:` block.
+- Using an entity name in a test that is not in `_fixtures.yaml`.
+- Using regex alternation `(a|b)` inside a list `in:` value — use separate entries.
+- Assuming `<le>` includes partitive articles — check the actual rule expansion in `_common.yaml`.

--- a/.claude/skills/ha-intents-author/SKILL.md
+++ b/.claude/skills/ha-intents-author/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ha-intents-author
+description: Author new sentence templates for a Home Assistant intent in a specific language. Use when adding sentences to a language file, expanding coverage of an intent, starting a new slot combination, or translating an intent into a new language. Assumes a local clone of OHF-Voice/intents.
+---
+
+# Author HA intent sentences
+
+You are helping a language leader write **sentence templates** for one intent in one language in the [OHF-Voice/intents](https://github.com/OHF-Voice/intents) repo. Your job is to produce natural, idiomatic templates plus matching tests, and verify them against the repo's tooling.
+
+## Inputs to confirm
+
+Before writing anything, confirm with the user (use AskUserQuestion if any are missing):
+
+1. **Repo path** — absolute path to the cloned `intents` repo. If unknown, ask. Default to the workspace folder if a folder named `intents/` is present.
+2. **Language code** — e.g. `fr`, `de`, `pt-BR`. Cross-check against `languages.yaml`.
+3. **Intent + slot combination** — e.g. `HassTurnOn / name_only`, or just `HassClimateSetTemperature`. If only an intent is given, list its slot combinations from `intents.yaml` and ask which one(s).
+4. **Format mode** — auto-detect:
+   - If `sentences/<lang>/<Intent>/` exists → **slot-combination format** (new, English-leading).
+   - Else → **legacy format** (`sentences/<lang>/<domain>_<intent>.yaml`).
+   The user can override.
+
+## Syntax cheatsheet (HassIL)
+
+Templates use the [HassIL](https://github.com/home-assistant/hassil) syntax:
+
+- **Alternatives**: `(red|green|blue)` — one of. Can apply mid-word: `turn(s|ed|ing)`.
+- **Optionals**: `[the]` — present or absent. Mid-word: `light[s]`.
+- **Lists**: `{name}` matches a list value and stores it in the slot of the same name. Use `{list:slot}` if names differ.
+- **Expansion rules**: `<rule_name>` — replaced with the rule body. Defined in `rules/<lang>/*.yaml` (new) or `_common.yaml` (legacy).
+- **Permutations**: `(a;b)` — both must appear, any order.
+
+**Slot-combination format restrictions** (enforced by validator for English, recommended elsewhere):
+- A list reference cannot appear inside an alternative: `(text|{list})` is forbidden.
+- A list reference cannot be optional: `[{list}]` is forbidden.
+- Rules should not contain `{lists}` or other `<rules>`.
+
+## Procedure
+
+### 1. Survey context
+
+Read these in order — quote the exact paths back to the user as you go:
+
+- `intents.yaml` → find the target intent. Note: `slot_combinations`, `slots`, `name_domains` / `inferred_domains` and their importance (`required`/`usable`/`complete`/`optional`), the English `example`. The example is your seed.
+- `sentences/en/<Intent>/<combo>.yaml` (or `sentences/en/<domain>_<intent>.yaml`) → reference implementation.
+- `sentences/<lang>/_common.yaml` (legacy) and `rules/<lang>/*.yaml` + `lists/<lang>/*.yaml` (new) → existing rules and lists you should reuse instead of inlining.
+- `tests/<lang>/...` for the same intent → existing tests; new sentences need parallel test entries.
+- `responses/<lang>/<Intent>.yaml` → response keys you can reference via `response: "..."` in the sentence file.
+
+### 2. Draft sentences
+
+Write 3-10 templates per `data:` group. Group sentences that share the same `slots`, `name_domains` / `inferred_domain`, and `response`. Aim for:
+
+- **Natural phrasings a native speaker actually uses** — not literal translations of English. Ask the user for regional variants if unsure.
+- **Reuse rules**: prefer `<turn>` over re-listing `(turn|switch)`. If a phrase repeats 3+ times across the file, propose a new rule in `rules/<lang>/`.
+- **Cover the `required` domains/combinations** in `intents.yaml`. Split into multiple `data:` groups when domains diverge (e.g. lights vs covers).
+- **Keep template explosion in check** — every optional doubles permutations; every alternative multiplies. Flag any single template producing >10k permutations.
+
+For each new template, mentally sample it and confirm it reads naturally in 2-3 expansions.
+
+### 3. Pair tests
+
+For every `data:` group you add, add a matching `tests:` block in `tests/<lang>/...`. The shape differs by format — match whatever the existing file uses:
+
+**Slot-combination format** (`tests/<lang>/<Intent>/<combo>.yaml`) — intent is implied by the path:
+```yaml
+language: "<lang>"
+entities:
+  - { name: "Overhead Light", domain: "light" }
+tests:
+  - sentences: ["turn on Overhead Light"]
+    slots: { name: "Overhead Light" }
+    response: "Turned on the light"
+```
+
+**Legacy format** (`tests/<lang>/<domain>_<intent>.yaml`) — intent is named explicitly, fixtures live in `_fixtures.yaml`:
+```yaml
+language: "<lang>"
+tests:
+  - sentences: ["turn on the kitchen light"]
+    intent:
+      name: HassTurnOn
+      slots: { area: "Kitchen", domain: "light" }
+    response: "Turned on the lights"
+```
+
+Either way, every new template needs at least one realised test sentence. Provide enough variety to catch under-specification (sentences that match too much) and missed permutations.
+
+Provide enough variety to catch under-specification (sentences that match too much) and missed permutations.
+
+### 4. Validate before finishing
+
+Run from the repo root and report any failures verbatim:
+
+```bash
+python3 -m script.intentfest validate --language <lang>
+python3 -m script.intentfest count_sentences --language <lang> --summary
+pytest tests --language <lang> -k <Intent>
+```
+
+For ad-hoc spot checks while drafting:
+
+```bash
+# Expand a single template to see real sentences
+python3 -m script.intentfest sample_template '<your template>' \
+  --rule turn '(turn|switch)' --values name "kitchen light"
+
+# Confirm a sentence parses to the right intent and slots
+python3 -m script.intentfest parse --language <lang> --sentence 'allume la lumière'
+```
+
+### 5. Hand back
+
+Report:
+
+1. Files changed (paths).
+2. New sentences (count) and test sentences (count).
+3. Validator output and pytest result.
+4. Any rules or lists you added (and why).
+5. Open questions for the language leader (e.g. regional spelling, formal vs informal forms).
+
+## Anti-patterns to avoid
+
+- Translating English word-by-word instead of writing what users actually say.
+- Stuffing one `data:` group with sentences that have different slot expectations — split them.
+- Adding a sentence without a corresponding test (validator passes, real users break it).
+- Inlining a phrase that already exists as a rule (`<turn>`, `<the>`, `<here>`).
+- Putting `{name}` inside `[ ]` or `( | )` in slot-combination files — validator will reject it.
+- Wide-open templates like `[anything] {name} [please]` that explode into millions of permutations.
+
+## Output
+
+When you are done, present a short summary in chat plus a link to the changed files via `computer://` paths.

--- a/.claude/skills/ha-intents-coverage/SKILL.md
+++ b/.claude/skills/ha-intents-coverage/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: ha-intents-coverage
+description: Analyze intent and slot-combination coverage for a Home Assistant language vs the canonical reference, and produce a prioritized gap report. Use when planning a sprint of contributions, onboarding a new contributor, comparing a language against English, hunting for missing required intents, or building a roadmap for a language's progress. Assumes a local clone of OHF-Voice/intents.
+---
+
+# HA intents coverage & gap analysis
+
+You are producing a coverage report for one language in [OHF-Voice/intents](https://github.com/OHF-Voice/intents). The output is a roadmap the language leader can use to plan work — what's missing, what's required vs optional, and where to start.
+
+## Inputs to confirm
+
+1. **Repo path** — absolute path to the cloned `intents` repo.
+2. **Target language** — e.g. `pt-BR`. Must exist in `languages.yaml`.
+3. **Reference language** — defaults to `en` (the canonical leader). The user can pick another for comparative purposes.
+4. **Output format** — markdown report (default), CSV, or interactive widget. Ask if not specified.
+
+## Procedure
+
+### 1. Build the canonical inventory
+
+Parse `intents.yaml` to enumerate every (intent, slot_combination) pair plus its importance metadata. For each combo capture:
+
+- `importance` (when no name/domain split): `required` / `usable` / `complete` / `optional`.
+- `name_domains` by importance level (when `{name}` slot present).
+- `inferred_domains` by importance level (when `{domain}` slot present).
+- The English `example` sentence — useful as a seed.
+
+Filter to `supported: true` intents only. This is the universe the language could cover.
+
+### 2. Inspect target language sentence coverage
+
+Detect format:
+
+- **Slot-combination format**: `sentences/<lang>/<Intent>/<combo>.yaml` files exist.
+- **Legacy format**: `sentences/<lang>/<domain>_<intent>.yaml` files only.
+
+For the new format, a combo is "covered" iff its file exists, parses, and includes templates whose `name_domains` / `inferred_domain` cover all `required` entries in `intents.yaml`.
+
+For legacy format, infer coverage by reading the file and matching `slots:` / `inferred_domain` / `requires_context.domain` in `data:` groups against the slot combinations defined in `intents.yaml`. This is approximate — flag intents where you cannot map cleanly.
+
+### 3. Compute the gap
+
+Categorise every combo as one of:
+
+- **Missing — required**: must exist; the language fails validation without it.
+- **Missing — usable**: expected by users; the leader should add it next.
+- **Missing — complete**: needed for a 100% score.
+- **Missing — optional**: nice to have.
+- **Partial**: file exists but doesn't cover all `required` domains in `name_domains` / `inferred_domains`. List which domains are missing.
+- **Covered**: present and complete.
+
+Pull the language's score and counts from the project's own tooling for cross-checks:
+
+```bash
+python3 -m script.intentfest count_sentences --language <lang> --summary
+python3 -m script.intentfest count_sentences --language <ref> --summary
+python3 -m script.intentfest validate --language <lang> 2>&1 | tail -50
+```
+
+### 4. Identify quick wins
+
+Flag combos where the language is close to coverage:
+
+- **Partial** combos missing only 1-2 domains.
+- **Missing — required** combos with very simple English templates (`HassNevermind`, `HassGetCurrentTime`).
+- Intents with a finished response file but no sentence file — content is half-built.
+- Intents the LLM template tool can bootstrap:
+  ```bash
+  python3 -m script.intentfest llm_template <lang> <Intent>
+  ```
+
+### 5. Produce the report
+
+Default markdown structure:
+
+```markdown
+# Coverage report: <lang> vs <ref>
+
+_Generated <date> against intents repo at commit <short-sha>._
+
+## Headline
+- **Score**: <X%> covered (<covered>/<total> combos)
+- **Required gaps**: <N> combos blocking 100% required coverage
+- **Format**: <legacy | slot-combination | mixed>
+
+## Required gaps (do these first)
+| Intent | Combo | English example | Notes |
+| --- | --- | --- | --- |
+| HassTurnOn | name_only | turn on the overhead light | covers `light` `switch`, missing `cover` |
+
+## Usable gaps
+…
+
+## Partial coverage
+…
+
+## Quick wins
+- `HassNevermind / default` — single short sentence in `en`, easy port.
+- `HassGetCurrentTime / default` — formulaic, LLM template recommended.
+
+## Suggested next sprint
+1. <Intent / combo> — <why>
+2. …
+
+## Appendix: full combo matrix
+<table or collapsed details>
+```
+
+For an interactive view, build an artifact (`mcp__cowork__create_artifact`) with a filterable table — useful when the leader will return to this weekly.
+
+### 6. Save outputs
+
+Write the markdown report to `<repo>/../<lang>-coverage-<YYYY-MM-DD>.md` (or wherever the user prefers — ask). Surface a `computer://` link in chat so they can open it.
+
+## Tips
+
+- Don't double-count the same combo appearing under multiple `data:` groups in legacy files.
+- A combo with `context_area: true` only counts as covered if the templates use a `<here>` rule or equivalent — note when you can't tell.
+- `name_domains.required` is the bar for "covers `required`". `complete` and `optional` lift the score but aren't strictly needed.
+- Cross-reference `languages.yaml` for the language's leader handles — useful if the report is being passed back to them.
+- If the target language is on legacy format, suggest migration to slot-combination format as a separate, larger effort — don't bury that recommendation.
+
+## Output
+
+Return: the path to the report, headline numbers in chat, and the top 3 recommended next actions.

--- a/.claude/skills/ha-intents-coverage/SKILL.md
+++ b/.claude/skills/ha-intents-coverage/SKILL.md
@@ -115,10 +115,11 @@ Write the markdown report to `<repo>/../<lang>-coverage-<YYYY-MM-DD>.md` (or whe
 ## Tips
 
 - Don't double-count the same combo appearing under multiple `data:` groups in legacy files.
-- A combo with `context_area: true` only counts as covered if the templates use a `<here>` rule or equivalent — note when you can't tell.
+- A combo with `context_area: true` only counts as covered if the templates use a `requires_context: area: slot: true` group — note when you can't tell.
 - `name_domains.required` is the bar for "covers `required`". `complete` and `optional` lift the score but aren't strictly needed.
 - Cross-reference `languages.yaml` for the language's leader handles — useful if the report is being passed back to them.
-- If the target language is on legacy format, suggest migration to slot-combination format as a separate, larger effort — don't bury that recommendation.
+- If the target language is on legacy format, **do not recommend migrating to slot-combination format**. The slot-combination format is English-only and not ready for other languages. Legacy is the correct and current standard for all non-English languages.
+- When presenting gaps, always include a reminder that every new intent must be accompanied by tests in `tests/<lang>/` — a sentence file without tests is incomplete.
 
 ## Output
 

--- a/.claude/skills/ha-intents-review/SKILL.md
+++ b/.claude/skills/ha-intents-review/SKILL.md
@@ -29,18 +29,16 @@ git diff main...HEAD -- <paths>
 
 Group changes by `(language, intent, slot_combination)`. For each group, run the rest of the procedure.
 
-### 2. Run the full test suite first
+### 2. Run the tests first
+
+**Do not run `script/test`** — the full suite takes 4+ minutes and tests every language. Run only the changed language:
 
 ```bash
-script/test
+# Any file in the changed language will do — --select-language scopes to the whole language
+script/test_file tests/<lang>/<domain>_<intent>.yaml --select-language
 ```
 
-This runs both `intentfest validate` and `pytest` in one shot. Report any failures before doing anything else — a failing test suite is an automatic blocking issue. If `script/test` is unavailable:
-
-```bash
-python3 -m script.intentfest validate --language <lang>
-pytest tests/test_language_sentences.py -k "<lang>" -q --no-header --tb=short
-```
+Report any failures before doing anything else — a failing language run is an automatic blocking issue.
 
 ### 3. Static checks (per changed file)
 

--- a/.claude/skills/ha-intents-review/SKILL.md
+++ b/.claude/skills/ha-intents-review/SKILL.md
@@ -5,7 +5,7 @@ description: Review a contributor's pull request or pasted YAML diff for a Home 
 
 # Review HA intents contributions
 
-You are reviewing a contribution to one or more sentence/test/response files in [OHF-Voice/intents](https://github.com/OHF-Voice/intents). The audience for your review is the language leader, who will paste it into a PR comment or use it to decide whether to merge.
+You are reviewing a contribution to one or more sentence/test/response files in [OHF-Voice/intents](https://github.com/OHF-Voice/intents). The audience is the language leader, who will paste your review into a PR comment or use it to decide whether to merge.
 
 ## Inputs to confirm
 
@@ -23,77 +23,83 @@ If anything is ambiguous, AskUserQuestion before reviewing.
 ### 1. Enumerate the diff
 
 ```bash
-git -C <repo> diff --name-status main...HEAD -- 'sentences/**' 'tests/**' 'responses/**' 'rules/**' 'lists/**'
-git -C <repo> diff main...HEAD -- <paths>
+git diff --name-status main...HEAD -- 'sentences/**' 'tests/**' 'responses/**' 'rules/**' 'lists/**'
+git diff main...HEAD -- <paths>
 ```
 
 Group changes by `(language, intent, slot_combination)`. For each group, run the rest of the procedure.
 
-### 2. Static checks (per changed file)
+### 2. Run the full test suite first
 
-Run the validator first — many issues come back already labeled:
+```bash
+script/test
+```
+
+This runs both `intentfest validate` and `pytest` in one shot. Report any failures before doing anything else — a failing test suite is an automatic blocking issue. If `script/test` is unavailable:
 
 ```bash
 python3 -m script.intentfest validate --language <lang>
+pytest tests/test_language_sentences.py -k "<lang>" -q --no-header --tb=short
 ```
 
-Then read the diff yourself and look for:
+### 3. Static checks (per changed file)
+
+**Format check**
+- Non-English languages must use the **legacy format** (`sentences/<lang>/<domain>_<intent>.yaml`). The slot-combination format (`sentences/<lang>/<Intent>/<combo>.yaml`) is English-only and not ready for other languages. Flag any non-English slot-combination file as a **blocking issue**.
 
 **Template syntax (HassIL)**
 - Unbalanced `(` `)`, `[` `]`, `<` `>`, `{` `}`.
 - A list inside an alternative: `(foo|{name})` — forbidden in slot-combination files.
 - A list inside an optional: `[{name}]` — forbidden in slot-combination files.
-- A rule that contains `{list}` or `<other_rule>` — discouraged (see `docs/slot_[combinations.md](http://combinations.md)`).
 - `{list:slot}` where `slot` is not declared in `intents.yaml` for this intent.
-- Template explosion: any template producing >10k permutations. Run:
-  ```bash
-  python3 -m script.intentfest count_sentences --language <lang>
-  ```
+- Template explosion: any template producing >10k permutations.
 
-**Slot-combination consistency**
-- Sentences with `{name}` must declare `name_domains:` covering at least the `required` set in `intents.yaml`.
-- Sentences with `{domain}` must declare `inferred_domain:` (single, not plural).
-- The combination's slots in the file must exactly match `slot_combinations.<combo>.slots` in `intents.yaml`.
+**Expansion rule usage**
+- Every word or phrase that already exists as an expansion rule in `sentences/<lang>/_common.yaml` must use the rule reference (`<rule>`) — not the inlined text. Flag any hardcoded verb lists, article groups, or locative phrases that duplicate an existing rule. This is the most common authoring oversight.
+- Check that the rule reference matches what the author intended: `<le>` does not include partitive articles ("de la", "du", "des"); `<dans>` typically includes "des". Know what the rule expands to before approving.
+- If a phrase repeats 3+ times in the file without a rule, suggest extracting it to `_common.yaml`.
+
+**`requires_context` correctness**
+- `requires_context: area: slot: true` — for sentences without an explicit area mention. The active area is injected into the `area` slot.
+- `requires_context: domain: <domain>` — for `{name}` slot sentences targeting a specific device type.
+- Sentences with an explicit `{area}` or `{floor}` slot do **not** need `requires_context`.
+
+**Slot-combination clustering (legacy format)**
+- Each `data:` group should be commented with the slot combination it covers.
+- All sentences within one group must produce the same set of slots. Sentences producing different slots must be in separate groups.
 
 **Test parity**
-- Every new sentence template needs at least one realised test sentence in `tests/<lang>/...` that exercises it.
-- Test fixtures (`entities`, `areas`, `floors`) referenced by `slots:` must be defined in the same file (new format) or in `_fixtures.yaml` (legacy).
-- `response:` in tests must match what the sentence file declares (or the rendered string).
+- Every new sentence template needs at least one realised test sentence in `tests/<lang>/<domain>_<intent>.yaml`.
+- `requires_context: area: slot: true` groups **must** have both `context: area: "X"` AND `slots: area: "X"` in the test block. Missing `context:` causes silent recognition failure.
+- `{name}` slot values used in tests must exist in `tests/<lang>/_fixtures.yaml`.
+- List slot values (e.g. `media_class`) must use the `out:` value, not the `in:` value (e.g. `music` not `musique`).
+- No duplicate realised sentences across test blocks — the validator rejects these.
+- Sentences producing different slot values must be in separate test blocks.
+
+**Lists in `_common.yaml`**
+- New wildcard slots (e.g. `search_query`) must be declared as `wildcard: true` in `_common.yaml`. A missing wildcard list causes `MissingListError` and breaks all tests for the language.
+- List `in:` values must be individual strings — regex alternation `(a|b|c)` inside an `in:` field is invalid and silently breaks `_common.yaml` loading, causing unrelated tests to fail.
 
 **Responses**
-- If a sentence references a `response:` key, that key must exist in `responses/<lang>/<Intent>.yaml`.
+- `response:` keys referenced in sentence files must exist in `responses/<lang>/<Intent>.yaml`.
 
-### 3. Naturalness pass (the part the validator can't do)
+### 4. Naturalness pass (the part the validator can't do)
 
-For each new template, ask out loud:
+For each new template, ask:
 - Would a native speaker really say this, or is it a literal translation of the English source?
 - Are formal/informal forms handled? Regional variants?
-- Are determiners (the/a/my) and conjugation correct across all expansions? Sample a few:
-  ```bash
-  python3 -m script.intentfest sample_template '<template>' --rule ... --values ...
-  ```
-- Does `parse` recover the right slots?
+- Do determiners and conjugation work across all expansions?
   ```bash
   python3 -m script.intentfest parse --language <lang> --sentence '<a realised sentence>'
   ```
 
-Call out specific lines (file + line number) when something reads off — don't generalise.
-
-### 4. Run the tests
-
-```bash
-pytest tests --language <lang> -k <Intent> -n auto
-```
-
-If the contribution touches multiple intents, run per-intent so failures are easier to attribute.
+Call out specific lines (file + line number) when something reads off.
 
 ### 5. Write the review
 
-Format the output as a PR-ready review with three sections:
-
 ```markdown
 ## Summary
-<2-3 sentence overview: what changed, what's the risk level (low / medium / high)>
+<2-3 sentence overview: what changed, risk level (low / medium / high)>
 
 ## Blocking issues
 - `<file>:<line>` — <issue>. Suggested fix: `<replacement>`.
@@ -102,21 +108,25 @@ Format the output as a PR-ready review with three sections:
 - `<file>:<line>` — <suggestion>.
 
 ## Verification
-- Validator: <pass/fail + summary>
-- Tests: <pass/fail + N tests>
-- Permutation counts: <any concerning numbers>
+- `script/test`: <pass / fail + summary>
+- Validator: <pass / fail>
+- Tests: <N passed / N failed>
 ```
 
-Keep blocking vs non-blocking strict: blocking = validator failure, test failure, syntax that violates slot-combination rules, or templates that match wrong intents. Everything else is a suggestion.
+Blocking = `script/test` failure, syntax violation, missing `context:` on a context-area test, wrong list value format (`in:` regex alternation), slot-combination format on a non-English language, or templates matching the wrong intent. Everything else is a suggestion.
 
 ## Common issues to watch for
 
-- **Copy-paste from English** that left English determiners (`the`, `a`) in the target language.
-- **Missing `name_domains`** when a `{name}` slot was added.
-- **A new rule that duplicates an existing rule** in `rules/<lang>/`.
-- **Tests that pass but only cover one expansion** of a template with many.
-- **Response references that don't exist** because someone added a sentence with `response: "lights_floor"` but didn't add that key.
-- **Whitespace/encoding** issues in non-Latin scripts (zero-width spaces, Arabic shaping).
+- **Inlined words that should be expansion rules** — always cross-check `_common.yaml`.
+- **Missing `context:` block** on tests for `requires_context: area: slot: true` groups — silent failure, hard to spot.
+- **List `in:` values using regex alternation** `(a|b)` — breaks the entire `_common.yaml`, causing unrelated tests to fail across all intents.
+- **Missing wildcard list** for free-text slots (e.g. `search_query`) — causes `MissingListError` across all tests for the language.
+- **Wrong slot value in tests** — using the `in:` value instead of the `out:` value (e.g. `musique` instead of `music`).
+- **Entity name in test not in `_fixtures.yaml`** — `{name}` slot silently returns `None`.
+- **Copy-paste from English** leaving English determiners in the target language.
+- **Sentences with different slot values in the same test block** — must be split.
+- **Slot-combination format on a non-English language** — blocking; use legacy format.
+- **Response references that don't exist** in `responses/<lang>/<Intent>.yaml`.
 
 ## Output
 

--- a/.claude/skills/ha-intents-review/SKILL.md
+++ b/.claude/skills/ha-intents-review/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ha-intents-review
+description: Review a contributor's pull request or pasted YAML diff for a Home Assistant intents language. Use when reviewing contributions to OHF-Voice/intents, checking sentence templates before merge, validating new test sentences, or auditing a branch for syntax and naturalness issues. Assumes a local clone of OHF-Voice/intents.
+---
+
+# Review HA intents contributions
+
+You are reviewing a contribution to one or more sentence/test/response files in [OHF-Voice/intents](https://github.com/OHF-Voice/intents). The audience for your review is the language leader, who will paste it into a PR comment or use it to decide whether to merge.
+
+## Inputs to confirm
+
+1. **Repo path** — absolute path to the cloned `intents` repo. The branch should already be checked out, OR the user gives a base ref to diff against (default `main`).
+2. **Scope** — one of:
+   - A branch / PR (compare `HEAD` against `main`).
+   - A specific commit range or file list.
+   - A pasted YAML snippet (no repo diff; review syntax only).
+3. **Language** — inferred from changed paths or asked.
+
+If anything is ambiguous, AskUserQuestion before reviewing.
+
+## Procedure
+
+### 1. Enumerate the diff
+
+```bash
+git -C <repo> diff --name-status main...HEAD -- 'sentences/**' 'tests/**' 'responses/**' 'rules/**' 'lists/**'
+git -C <repo> diff main...HEAD -- <paths>
+```
+
+Group changes by `(language, intent, slot_combination)`. For each group, run the rest of the procedure.
+
+### 2. Static checks (per changed file)
+
+Run the validator first — many issues come back already labeled:
+
+```bash
+python3 -m script.intentfest validate --language <lang>
+```
+
+Then read the diff yourself and look for:
+
+**Template syntax (HassIL)**
+- Unbalanced `(` `)`, `[` `]`, `<` `>`, `{` `}`.
+- A list inside an alternative: `(foo|{name})` — forbidden in slot-combination files.
+- A list inside an optional: `[{name}]` — forbidden in slot-combination files.
+- A rule that contains `{list}` or `<other_rule>` — discouraged (see `docs/slot_[combinations.md](http://combinations.md)`).
+- `{list:slot}` where `slot` is not declared in `intents.yaml` for this intent.
+- Template explosion: any template producing >10k permutations. Run:
+  ```bash
+  python3 -m script.intentfest count_sentences --language <lang>
+  ```
+
+**Slot-combination consistency**
+- Sentences with `{name}` must declare `name_domains:` covering at least the `required` set in `intents.yaml`.
+- Sentences with `{domain}` must declare `inferred_domain:` (single, not plural).
+- The combination's slots in the file must exactly match `slot_combinations.<combo>.slots` in `intents.yaml`.
+
+**Test parity**
+- Every new sentence template needs at least one realised test sentence in `tests/<lang>/...` that exercises it.
+- Test fixtures (`entities`, `areas`, `floors`) referenced by `slots:` must be defined in the same file (new format) or in `_fixtures.yaml` (legacy).
+- `response:` in tests must match what the sentence file declares (or the rendered string).
+
+**Responses**
+- If a sentence references a `response:` key, that key must exist in `responses/<lang>/<Intent>.yaml`.
+
+### 3. Naturalness pass (the part the validator can't do)
+
+For each new template, ask out loud:
+- Would a native speaker really say this, or is it a literal translation of the English source?
+- Are formal/informal forms handled? Regional variants?
+- Are determiners (the/a/my) and conjugation correct across all expansions? Sample a few:
+  ```bash
+  python3 -m script.intentfest sample_template '<template>' --rule ... --values ...
+  ```
+- Does `parse` recover the right slots?
+  ```bash
+  python3 -m script.intentfest parse --language <lang> --sentence '<a realised sentence>'
+  ```
+
+Call out specific lines (file + line number) when something reads off — don't generalise.
+
+### 4. Run the tests
+
+```bash
+pytest tests --language <lang> -k <Intent> -n auto
+```
+
+If the contribution touches multiple intents, run per-intent so failures are easier to attribute.
+
+### 5. Write the review
+
+Format the output as a PR-ready review with three sections:
+
+```markdown
+## Summary
+<2-3 sentence overview: what changed, what's the risk level (low / medium / high)>
+
+## Blocking issues
+- `<file>:<line>` — <issue>. Suggested fix: `<replacement>`.
+
+## Suggestions (non-blocking)
+- `<file>:<line>` — <suggestion>.
+
+## Verification
+- Validator: <pass/fail + summary>
+- Tests: <pass/fail + N tests>
+- Permutation counts: <any concerning numbers>
+```
+
+Keep blocking vs non-blocking strict: blocking = validator failure, test failure, syntax that violates slot-combination rules, or templates that match wrong intents. Everything else is a suggestion.
+
+## Common issues to watch for
+
+- **Copy-paste from English** that left English determiners (`the`, `a`) in the target language.
+- **Missing `name_domains`** when a `{name}` slot was added.
+- **A new rule that duplicates an existing rule** in `rules/<lang>/`.
+- **Tests that pass but only cover one expansion** of a template with many.
+- **Response references that don't exist** because someone added a sentence with `response: "lights_floor"` but didn't add that key.
+- **Whitespace/encoding** issues in non-Latin scripts (zero-width spaces, Arabic shaping).
+
+## Output
+
+End with a clear verdict: `Approve` / `Approve with suggestions` / `Request changes`, plus the markdown review block ready to paste.


### PR DESCRIPTION
I propose to add Claude Code skills to this repo to help language leaders
- Author new sentences
- Assess coverage
- Review contributor's PR


Adds project-level skills under .claude/skills/ to help language leaders:
- ha-intents-author: author new sentence templates for an intent/language
- ha-intents-coverage: produce a prioritized gap report vs the canonical reference
- ha-intents-review: review a contributor's PR or YAML diff
