### PR TITLE
[NL] Change `name_type` expansion rule for HassTurnOn and HassTurnOff

### DIFF
--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -23,7 +23,7 @@ intents:
       # light
       - sentences: *sentences
         expansion_rules:
-          name_type: (<name>[ ]<light>,<light> <name>)
+          name_type: (<name>[ ]<light>|<light> <name>)
           name_area: &name_area >
             (
               <name_type> <in> <area>
@@ -37,7 +37,7 @@ intents:
       # switch
       - sentences: *sentences
         expansion_rules:
-          name_type: (<name>[ ]<switch>, <switch> <name>)
+          name_type: (<name>[ ]<switch>|<switch> <name>)
           name_area: *name_area
         requires_context:
           domain:
@@ -46,7 +46,7 @@ intents:
       # fan
       - sentences: *sentences
         expansion_rules:
-          name_type: (<name>[ ]<fan>,<fan> <name>)
+          name_type: (<name>[ ]<fan>|<fan> <name>)
           name_area: *name_area
         requires_context:
           domain:

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -23,7 +23,7 @@ intents:
       # light
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<light>
+          name_type: (<name>[ ]<light>,<light> <name>)
           name_area: &name_area >
             (
               <name_type> <in> <area>
@@ -37,7 +37,7 @@ intents:
       # switch
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<switch>
+          name_type: (<name>[ ]<switch>, <switch> <name>)
           name_area: *name_area
         requires_context:
           domain:
@@ -46,7 +46,7 @@ intents:
       # fan
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<fan>
+          name_type: (<name>[ ]<fan>,<fan> <name>)
           name_area: *name_area
         requires_context:
           domain:

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -25,7 +25,7 @@ intents:
       # light
       - sentences: *sentences
         expansion_rules:
-          name_type: (<name>[ ]<light>,<light> <name>)
+          name_type: (<name>[ ]<light>|<light> <name>)
           name_area: &name_area >
             (
               <name_type> <in> <area>
@@ -39,7 +39,7 @@ intents:
       # switch
       - sentences: *sentences
         expansion_rules:
-          name_type: (<name>[ ]<switch>, <switch> <name>)
+          name_type: (<name>[ ]<switch>|<switch> <name>)
           name_area: *name_area
         requires_context:
           domain:
@@ -48,7 +48,7 @@ intents:
       # fan
       - sentences: *sentences
         expansion_rules:
-          name_type: (<name>[ ]<fan>,<fan> <name>)
+          name_type: (<name>[ ]<fan>|<fan> <name>)
           name_area: *name_area
         requires_context:
           domain:

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -25,7 +25,7 @@ intents:
       # light
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<light>
+          name_type: (<name>[ ]<light>,<light> <name>)
           name_area: &name_area >
             (
               <name_type> <in> <area>
@@ -39,7 +39,7 @@ intents:
       # switch
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<switch>
+          name_type: (<name>[ ]<switch>, <switch> <name>)
           name_area: *name_area
         requires_context:
           domain:
@@ -48,7 +48,7 @@ intents:
       # fan
       - sentences: *sentences
         expansion_rules:
-          name_type: <name>[ ]<fan>
+          name_type: (<name>[ ]<fan>,<fan> <name>)
           name_area: *name_area
         requires_context:
           domain:

--- a/tests/nl/homeassistant_HassTurnOff.yaml
+++ b/tests/nl/homeassistant_HassTurnOff.yaml
@@ -20,6 +20,8 @@ tests:
       - Werkbank licht uit
       - werkbank licht uit zetten
       - werkbank lamp uit
+      - lamp werkbank uit
+      - zet verlichting werkbank uit
     intent:
       name: HassTurnOff
       slots:
@@ -35,6 +37,8 @@ tests:
       - de waterkokerschakelaar uitzetten
       - waterkoker switch uitschakelen
       - de waterkoker uitdoen
+      - schakelaar waterkoker uit
+      - zet switch waterkoker uit
     intent:
       name: HassTurnOff
       slots:
@@ -66,6 +70,8 @@ tests:
       - Zet speelhoek ventilator naar uit
       - Speelhoek ventilator uit
       - Speelhoekventilator uitdoen
+      - ventilator speelhoek uit
+      - zet de ventilator speelhoek uit
     intent:
       name: HassTurnOff
       slots:

--- a/tests/nl/homeassistant_HassTurnOn.yaml
+++ b/tests/nl/homeassistant_HassTurnOn.yaml
@@ -32,7 +32,9 @@ tests:
       - Zet de werkbanklamp naar aan
       - Werkbankverlichting aan
       - werkbank licht aan zetten
-      - werkbank lamp aan?
+      - werkbank lamp aan
+      - zet de lamp werkbank aan
+      - verlichting werkbank aan
     intent:
       name: HassTurnOn
       slots:
@@ -47,6 +49,8 @@ tests:
       - waterkoker switch aan
       - waterkokerschakelaar aanzetten
       - waterkoker switch inschakelen
+      - zet de schakelaar waterkoker aan
+      - switch waterkoker aan
     intent:
       name: HassTurnOn
       slots:
@@ -61,6 +65,8 @@ tests:
       - Schakel de speelhoekventilator in
       - Zet speelhoek ventilator naar aan
       - Speelhoek fan aan
+      - zet fan speelhoek aan
+      - ventilator speelhoek aan
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
If you e.g. have a light called `kledingkast` you could turn that on by using
`zet kledingkastverlichting aan` or `kledingkast lampen aan`. 
However, something like `verlichting kledingkast aan` or `zet lampen kledingkast aan` did not work.

This PR addresses that by adjusting the `name_type` expansion rules for the specific sentences for the light, fan and switch domains.