### PR TITLE
Add Danish language support for vacuum clean area intent

### DIFF
--- a/responses/da/HassVacuumCleanArea.yaml
+++ b/responses/da/HassVacuumCleanArea.yaml
@@ -1,0 +1,6 @@
+---
+language: da
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Rengør {{ slots.area }}"

--- a/sentences/da/vacuum_HassVacuumCleanArea.yaml
+++ b/sentences/da/vacuum_HassVacuumCleanArea.yaml
@@ -1,0 +1,22 @@
+---
+language: da
+intents:
+  HassVacuumCleanArea:
+    data:
+      # by area
+      - sentences:
+          - "<rengør> [<i_på>] <område>"
+
+      # by satellite area
+      - sentences:
+          - "<rengør> <her>"
+        requires_context:
+          area:
+            slot: true
+
+      # by area and name
+      - sentences:
+          - "<rengør> <område> med <navn>"
+          - "start <navn> [<i_på>] <område>"
+        requires_context:
+          domain: vacuum

--- a/tests/da/vacuum_HassVacuumCleanArea.yaml
+++ b/tests/da/vacuum_HassVacuumCleanArea.yaml
@@ -1,0 +1,39 @@
+---
+language: da
+tests:
+  # by area
+  - sentences:
+      - "støvsug stue"
+      - "støvsug i stuen"
+      - "rengør stuen"
+      - "rens stuen"
+    intent:
+      name: HassVacuumCleanArea
+      slots:
+        area: "Stue"
+    response: "Rengør stue"
+
+  # by satellite area
+  - sentences:
+      - "støvsug her"
+      - "rengør herinde"
+      - "rens i dette rum"
+    intent:
+      name: HassVacuumCleanArea
+      context:
+        area: "Stue"
+      slots:
+        area: "Stue"
+    response: "Rengør Stue"
+
+  # by area and name
+  - sentences:
+      - "støvsug stue med støver"
+      - "rengør stuen med støver"
+      - "start støver i stuen"
+    intent:
+      name: HassVacuumCleanArea
+      slots:
+        name: "Støver"
+        area: "Stue"
+    response: "Rengør stue"


### PR DESCRIPTION
## Summary
This PR adds Danish language support for the `HassVacuumCleanArea` intent, enabling users to control vacuum cleaners using Danish voice commands.

## Key Changes
- **Sentence patterns** (`sentences/da/vacuum_HassVacuumCleanArea.yaml`): Added Danish sentence templates for three vacuum control scenarios:
  - Cleaning by area (e.g., "støvsug stue")
  - Cleaning in the current area using satellite context (e.g., "støvsug her")
  - Cleaning by area with a specific vacuum device (e.g., "start støver i stuen")

- **Response template** (`responses/da/HassVacuumCleanArea.yaml`): Added Danish response message that confirms the area being cleaned

- **Test cases** (`tests/da/vacuum_HassVacuumCleanArea.yaml`): Added comprehensive test coverage including:
  - Direct area references with multiple sentence variations
  - Satellite area context handling
  - Combined area and device name specifications

## Implementation Details
- Supports multiple Danish phrasings for the same action (e.g., "støvsug", "rengør", "rens")
- Includes optional prepositions ("i", "på") for natural language flexibility
- Properly handles context-aware commands for satellite areas
- Validates domain context for device-specific commands

https://claude.ai/code/session_01KxnNsYb53ym5zJ9o2dzkFa