### PR TITLE
[ES] Move vacuum return verbs to _common.yaml

### DIFF
--- a/sentences/es/_common.yaml
+++ b/sentences/es/_common.yaml
@@ -582,6 +582,7 @@ expansion_rules:
   dime_si: "<dime> si"
   donde_se_encuentra: "dónde <se_encuentra>"
   enciende: "(enc[i]end(a|e|er|é)|conect(a|e|ar|á)|activ(a|e|ar|á)|prend(a|e|er|é))"
+  devuelve: "(dev(uelve|uelva|olver|olvé)|retorn(a|ar|e|á)|regres(a|ar|e|á))"
   ejecuta: "(<enciende>|ejecut(a|e|ar|á)|inici(a|e|ar|á))"
   elimina: "(elimin(a|e|ar|á)|borr(a|e|ar|á))"
   establece: "(pon[ga|er|é]|estable[z]c(a|e|er|é)|ajust(a|e|ar|á)|configur(a|e|ar|á)|cambi(a[r]|á|e))"

--- a/sentences/es/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/es/vacuum_HassVacuumReturnToBase.yaml
@@ -3,7 +3,8 @@ intents:
   HassVacuumReturnToBase:
     data:
       - sentences:
-          - "(dev(uelve|uelva|olver|olvé)|retorn(a|ar|e|á)|regres(a|ar|e|á)|mand(a|e|ar|á)|env(ía|íe|iar|iá)) <name> [a [la] base]"
+          - "<devuelve> <name> [a [la] base]"
+          - "(mand(a|e|ar|á)|env(ía|íe|iar|iá)) <name> [a [la] base]"
           - "que <name> (vuelva|regrese|retorne) [a [la] base]"
         requires_context:
           domain: vacuum


### PR DESCRIPTION
Refactors the Spanish HassVacuumReturnToBase sentences to use a new shared _devuelve_ expansion rule in _common.yaml, following the same pattern already used by _ejecuta_.