### PR TITLE
[DE] HassGetTemperature: handle unavailable and unknown states

### DIFF
--- a/responses/de/HassClimateGetTemperature.yaml
+++ b/responses/de/HassClimateGetTemperature.yaml
@@ -5,9 +5,17 @@ responses:
       current_temperature: >
         {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
         {% set temperature = state.state if current_temperature is none else current_temperature %}
-        {{ temperature | float | round(1) | replace(".",",") | replace(",0","") }} Grad
+        {% if temperature not in ['unavailable', 'unknown'] %}
+          {{ temperature | float | round(1) | replace(".",",") | replace(",0","") }} Grad
+        {% else %}
+          Der Temperatursensor ist nicht verfügbar.
+        {% endif %}
 
       target_temperature: |
         {% set target_temperature = state_attr(state.entity_id, 'temperature') %}
         {% set temperature = state.state if target_temperature is none else target_temperature %}
-        {{ temperature | float | round(1) | replace(".",",") | replace(",0","") }} Grad
+        {% if temperature not in ['unavailable', 'unknown'] %}
+          {{ temperature | float | round(1) | replace(".",",") | replace(",0","") }} Grad
+        {% else %}
+          Thermostat ist nicht verfügbar.
+        {% endif %}

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -121,6 +121,16 @@ entities:
     attributes:
       current_temperature: 24.0
       temperature: 23.0
+  # test entity to test correct handling of unknown as a state in temperature requests
+  - name: Garagenthermostat
+    id: climate.garage
+    area: garage
+    state: "unknown"
+  # test entity to test correct handling of unavailable as a state in temperature requests
+  - name: Auffahrtthermostat
+    id: climate.driveway
+    area: driveway
+    state: "unavailable"
   - name: Bürotemperatur
     id: climate.office
     area: office

--- a/tests/de/climate_HassClimateGetTemperature.yaml
+++ b/tests/de/climate_HassClimateGetTemperature.yaml
@@ -401,6 +401,24 @@ tests:
         area: Wohnzimmer
     response: "22 Grad"
 
+  # check unknown
+  - sentences:
+      - Wie warm ist die Garage
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        area: Garage
+    response: "Der Temperatursensor ist nicht verfügbar."
+
+  # check unavailable
+  - sentences:
+      - Wie warm ist die Auffahrt
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        area: Auffahrt
+    response: "Der Temperatursensor ist nicht verfügbar."
+
   # check localization
   - sentences:
       - Wie warm ist das Büro


### PR DESCRIPTION
this PR adjusts response templates to not respond with a technical error message if an assigned room temperature sensor is unavailable or unknown.
this avoids `ValueError: Template error: float got invalid input.........` (e.g. if an assigned battery powered sensor goes offline) and instead responds with 'Der Temperatursensor ist nicht verfügbar.'