### PR TITLE
Fix trailing whitespace in en HassStartTimer test

### DIFF
--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -176,7 +176,7 @@ tests:
           - "open the garage door"
           - "open the garage door "
           - "open the front gate"
-          - "open the front gate"          
+          - "open the front gate"
     response: Command will be executed in 5 minutes
 
   - sentences:


### PR DESCRIPTION
Trailing whitespace on line 179 of `tests/en/homeassistant_HassStartTimer.yaml` (introduced in #3555) makes the prettier check — run via `pre-commit run prettier --all-files` in `script/lint` — fail on `main`. Because that check scans all files, it blocks the `build` status check on **every open PR**, not just ones touching this file.

This strips the stray trailing whitespace so prettier passes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)