### PR TITLE
Website: group slot-combination intents, fix summary, highlight examples

### DIFF
--- a/script/intentfest/example_highlight.py
+++ b/script/intentfest/example_highlight.py
@@ -1,0 +1,288 @@
+"""Highlight slot values inside example sentences.
+
+Uses hassil to parse an example sentence against the language's intents and the
+slot lists built from the matching test fixtures. Each matched entity exposes a
+``text_span`` (start/end offsets into the original sentence), which we wrap in a
+``<span class="slot slot-<category>">`` so the website can colour-code names,
+areas, floors, numbers, wildcards, etc.
+
+Everything here is best-effort: if a language's intents fail to build or a
+sentence does not recognise, we fall back to the plain (HTML-escaped) text.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Any, Dict, Optional
+
+import yaml
+
+from .const import INTENTS_FILE, LIST_DIR, RULE_DIR, SENTENCE_DIR, TESTS_DIR
+
+# Map each slot name to a colour category. Slots not listed fall back to
+# "number" (numeric/range slots) or "other".
+_SLOT_CATEGORY: Dict[str, str] = {
+    "name": "name",
+    "area": "area",
+    "floor": "floor",
+    "domain": "class",
+    "device_class": "class",
+    "media_class": "class",
+    "color": "color",
+    "state": "state",
+    "message": "text",
+    "search_query": "text",
+    "conversation_command": "text",
+    "item": "text",
+}
+# Placeholder current-area name passed as intent context so templates that
+# reference the current area (e.g. "turn on the lights in here") recognize.
+_CONTEXT_AREA_NAME = "__context_area__"
+
+_NUMBER_SLOTS = {
+    "brightness",
+    "percentage",
+    "position",
+    "temperature",
+    "volume_level",
+    "volume_step",
+    "hours",
+    "minutes",
+    "seconds",
+    "start_hours",
+    "start_minutes",
+    "start_seconds",
+}
+
+
+def _slot_category(slot_name: str, is_wildcard: bool) -> str:
+    if is_wildcard:
+        return "text"
+    if slot_name in _SLOT_CATEGORY:
+        return _SLOT_CATEGORY[slot_name]
+    if slot_name in _NUMBER_SLOTS:
+        return "number"
+    return "other"
+
+
+# Lazily-built hassil Intents per language (None if the language fails to build).
+_LANG_INTENTS_CACHE: Dict[str, Any] = {}
+# hassil symbols are imported lazily so the summary still runs if hassil changes.
+_HASSIL: Dict[str, Any] = {}
+
+
+def _load_hassil() -> bool:
+    if _HASSIL:
+        return _HASSIL.get("ok", False)
+    try:
+        from hassil import Intents, TextSlotList, recognize_best
+
+        _HASSIL.update(
+            ok=True,
+            Intents=Intents,
+            TextSlotList=TextSlotList,
+            recognize_best=recognize_best,
+        )
+    except Exception:  # pylint: disable=broad-except
+        _HASSIL["ok"] = False
+    return _HASSIL["ok"]
+
+
+def _build_language_intents(language: str, intent_info: dict) -> Optional[Any]:
+    """Build a hassil Intents for the language from its sentences/lists/rules.
+
+    Mirrors the slot-combination test harness, but only loads what recognition
+    needs. Returns None if anything is missing or fails to parse.
+    """
+    if not _load_hassil():
+        return None
+
+    lang_dict: Dict[str, Any] = {
+        "language": language,
+        "intents": {},
+        "lists": {},
+        "expansion_rules": {},
+        "skip_words": [],
+    }
+
+    try:
+        common_path = SENTENCE_DIR / language / "_common.yaml"
+        if common_path.exists():
+            common_dict = yaml.safe_load(common_path.read_text()) or {}
+            lang_dict["skip_words"] = common_dict.get("skip_words", [])
+
+        for rule_path in (RULE_DIR / language).glob("*.yaml"):
+            rule_dict = yaml.safe_load(rule_path.read_text()) or {}
+            lang_dict["expansion_rules"].update(rule_dict.get("expansion_rules", {}))
+
+        # Shared (cross-language) lists first, then language-specific lists.
+        for list_path in LIST_DIR.glob("*.yaml"):
+            list_dict = yaml.safe_load(list_path.read_text()) or {}
+            lang_dict["lists"].update(list_dict.get("lists", {}))
+        for list_path in (LIST_DIR / language).glob("*.yaml"):
+            list_dict = yaml.safe_load(list_path.read_text()) or {}
+            lang_dict["lists"].update(list_dict.get("lists", {}))
+
+        for intent_name, info in intent_info.items():
+            data: list = []
+            for combo_name, combo_info in (info.get("slot_combinations") or {}).items():
+                sentences_path = (
+                    SENTENCE_DIR / language / intent_name / f"{combo_name}.yaml"
+                )
+                if not sentences_path.exists():
+                    continue
+                combo_data = yaml.safe_load(sentences_path.read_text()) or {}
+                for group in combo_data.get("data", []):
+                    slots = dict(group.get("slots", {}))
+                    requires_context = dict(group.get("requires_context", {}))
+                    if name_domains := group.get("name_domains"):
+                        requires_context["domain"] = name_domains
+                    elif inferred_domain := group.get("inferred_domain"):
+                        slots["domain"] = inferred_domain
+                    if combo_info.get("context_area"):
+                        requires_context["area"] = {"slot": True}
+                    data.append(
+                        {
+                            "sentences": group["sentences"],
+                            "slots": slots,
+                            "requires_context": requires_context,
+                            "response": group.get("response", "default"),
+                            "metadata": {"slot_combination": combo_name},
+                        }
+                    )
+            if data:
+                lang_dict["intents"][intent_name] = {"data": data}
+
+        if not lang_dict["intents"]:
+            return None
+
+        return _HASSIL["Intents"].from_dict(lang_dict)
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+
+def get_language_intents(language: str, intent_info: dict) -> Optional[Any]:
+    if language not in _LANG_INTENTS_CACHE:
+        _LANG_INTENTS_CACHE[language] = _build_language_intents(language, intent_info)
+    return _LANG_INTENTS_CACHE[language]
+
+
+def _slug(name: str) -> str:
+    return name.strip().lower().replace(" ", "_")
+
+
+def combo_slot_lists(language: str, intent_name: str, combo_name: str) -> dict:
+    """Build name/area/floor slot lists from a slot combination's test fixtures."""
+    if not _load_hassil():
+        return {}
+
+    test_path = TESTS_DIR / language / intent_name / f"{combo_name}.yaml"
+    if not test_path.exists():
+        return {}
+
+    try:
+        test_dict = yaml.safe_load(test_path.read_text()) or {}
+    except Exception:  # pylint: disable=broad-except
+        return {}
+
+    text_slot_list = _HASSIL["TextSlotList"]
+    return {
+        "name": text_slot_list.from_tuples(
+            [
+                (e["name"], e["name"], {"domain": e.get("domain")})
+                for e in test_dict.get("entities", [])
+                if e.get("name")
+            ],
+            name="name",
+        ),
+        "area": text_slot_list.from_strings(
+            [a["name"] for a in test_dict.get("areas", []) if a.get("name")],
+            name="area",
+        ),
+        "floor": text_slot_list.from_strings(
+            [f["name"] for f in test_dict.get("floors", []) if f.get("name")],
+            name="floor",
+        ),
+    }
+
+
+def recognize_example(
+    example: str, intents: Optional[Any], slot_lists: dict
+) -> Optional[Any]:
+    """Recognize an example sentence, returning the hassil result (or None).
+
+    Supplies a current-area context so "in here" / context-area templates
+    recognize, mirroring the slot-combination test harness.
+    """
+    if intents is None or not _load_hassil():
+        return None
+    try:
+        return _HASSIL["recognize_best"](
+            example,
+            intents,
+            slot_lists=slot_lists,
+            intent_context={"area": _CONTEXT_AREA_NAME},
+            best_slot_name="name",
+        )
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+
+def highlight_example(example: str, intents: Optional[Any], slot_lists: dict) -> str:
+    """Return the example as HTML with recognised slot values wrapped in spans.
+
+    Falls back to the plain HTML-escaped sentence when recognition is
+    unavailable or fails.
+    """
+    plain = html.escape(example)
+    result = recognize_example(example, intents, slot_lists)
+    if result is None:
+        return plain
+
+    # Collect valid, in-range spans.
+    spans = []
+    length = len(example)
+    for entity in result.entities.values():
+        text_span = getattr(entity, "text_span", None)
+        if not text_span:
+            continue
+        start, end = text_span
+        if start is None or end is None:
+            continue
+        if not (0 <= start < end <= length):
+            continue
+        # Trim surrounding whitespace so the highlight hugs the value
+        # (wildcards in particular can capture a trailing space).
+        while start < end and example[start].isspace():
+            start += 1
+        while end > start and example[end - 1].isspace():
+            end -= 1
+        if start >= end:
+            continue
+        spans.append((start, end, entity.name, bool(entity.is_wildcard)))
+
+    if not spans:
+        return plain
+
+    spans.sort(key=lambda s: s[0])
+
+    parts = []
+    pos = 0
+    for start, end, slot_name, is_wildcard in spans:
+        if start < pos:
+            # Overlapping match; skip to keep output well-formed.
+            continue
+        parts.append(html.escape(example[pos:start]))
+        category = _slot_category(slot_name, is_wildcard)
+        parts.append(
+            f'<span class="slot slot-{category}" title="{html.escape(slot_name)}">'
+            f"{html.escape(example[start:end])}</span>"
+        )
+        pos = end
+    parts.append(html.escape(example[pos:]))
+    return "".join(parts)
+
+
+# Re-export for callers that want the schemas without re-reading the file.
+def load_intent_info() -> dict:
+    return yaml.safe_load(INTENTS_FILE.read_text())

--- a/script/intentfest/report_unparsed_examples.py
+++ b/script/intentfest/report_unparsed_examples.py
@@ -1,0 +1,135 @@
+"""Report example sentences that hassil cannot recognize.
+
+Each slot combination sentence file may declare an ``example:`` per data block
+(a human-readable hint, also used to highlight slot values on the website).
+For the highlighting to work — and for the example to be trustworthy — it must
+be a sentence the templates can actually produce, using values from the
+combination's test fixtures.
+
+This report parses every example with hassil and lists the ones that:
+
+- do not recognize at all ("no match"), usually because the example uses a
+  {name}/value not present in the test fixtures, or is not a sentence the
+  templates can produce; or
+- recognize as a *different* intent than the file they live in ("wrong intent").
+
+Examples that recognize correctly but expose no highlightable slot (e.g.
+"nevermind", or an inferred-domain "turn on the fans") are counted but not
+listed, since there is nothing to fix.
+
+Usage:
+    python3 -m script.intentfest report_unparsed_examples [--language en]
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import yaml
+
+from .const import INTENTS_FILE, LANGUAGES, SENTENCE_DIR
+from .example_highlight import combo_slot_lists, get_language_intents, recognize_example
+from .util import get_base_arg_parser
+
+
+def get_arguments() -> argparse.Namespace:
+    """Get parsed passed in arguments."""
+    parser = get_base_arg_parser()
+    parser.add_argument(
+        "--language",
+        type=str,
+        choices=LANGUAGES,
+        help="Only report this language (default: all languages).",
+    )
+    return parser.parse_args()
+
+
+def _has_highlightable_span(result) -> bool:
+    return any(
+        getattr(entity, "text_span", None) for entity in result.entities.values()
+    )
+
+
+def run() -> int:
+    args = get_arguments()
+    languages = [args.language] if args.language else LANGUAGES
+
+    intent_info = yaml.safe_load(INTENTS_FILE.read_text())
+
+    total_examples = 0
+    total_no_match = 0
+    total_wrong_intent = 0
+    total_no_span = 0
+    languages_reported = 0
+
+    for language in languages:
+        intents = get_language_intents(language, intent_info)
+
+        problems: list[tuple[str, str, str, str]] = []
+        lang_examples = 0
+        lang_no_span = 0
+
+        for intent_name, info in sorted(intent_info.items()):
+            for combo_name in info.get("slot_combinations") or {}:
+                combo_path = (
+                    SENTENCE_DIR / language / intent_name / f"{combo_name}.yaml"
+                )
+                if not combo_path.exists():
+                    continue
+
+                combo_data = yaml.safe_load(combo_path.read_text()) or {}
+                slot_lists = combo_slot_lists(language, intent_name, combo_name)
+
+                for block in combo_data.get("data") or []:
+                    example = block.get("example")
+                    if not example:
+                        continue
+
+                    lang_examples += 1
+                    result = recognize_example(example, intents, slot_lists)
+
+                    if result is None:
+                        problems.append((intent_name, combo_name, example, "no match"))
+                    elif result.intent.name != intent_name:
+                        problems.append(
+                            (
+                                intent_name,
+                                combo_name,
+                                example,
+                                f"matched {result.intent.name}",
+                            )
+                        )
+                    elif not _has_highlightable_span(result):
+                        lang_no_span += 1
+
+        total_examples += lang_examples
+        total_no_span += lang_no_span
+        total_no_match += sum(1 for p in problems if p[3] == "no match")
+        total_wrong_intent += sum(1 for p in problems if p[3] != "no match")
+
+        if not lang_examples:
+            # Language has no slot-combination examples yet (not migrated).
+            continue
+
+        languages_reported += 1
+        print(f"\n=== {language} ===")
+        print(
+            f"{lang_examples} examples: "
+            f"{lang_examples - len(problems) - lang_no_span} highlighted, "
+            f"{lang_no_span} no slot to highlight, "
+            f"{len(problems)} problem(s)"
+        )
+        if problems:
+            width = max(len(f"{p[0]}/{p[1]}") for p in problems)
+            for intent_name, combo_name, example, reason in problems:
+                location = f"{intent_name}/{combo_name}"
+                print(f"  {location:<{width}}  [{reason}]  {example!r}")
+
+    print(
+        f"\nTotal: {total_examples} examples across {languages_reported} language(s) "
+        f"with examples — {total_no_match} no match, "
+        f"{total_wrong_intent} wrong intent, "
+        f"{total_no_span} with no highlightable slot."
+    )
+
+    return 0

--- a/script/intentfest/slot_combination_summary.py
+++ b/script/intentfest/slot_combination_summary.py
@@ -7,6 +7,129 @@ import json
 import yaml
 
 from .const import INTENTS_FILE, LANGUAGES, LANGUAGES_FILE, SENTENCE_DIR
+from .example_highlight import combo_slot_lists, get_language_intents, highlight_example
+
+# Ordered grouping of intents for the per-language breakdown. Each group has a
+# display name, a URL-friendly slug (used for the table-of-contents anchors),
+# and the intents that belong to it. Intents not listed here fall into "Other".
+INTENT_GROUPS: list[tuple[str, str, list[str]]] = [
+    (
+        "Lights, Switches & Devices",
+        "devices",
+        [
+            "HassTurnOn",
+            "HassTurnOff",
+            "HassLightSet",
+            "HassFanSetSpeed",
+            "HassSetPosition",
+        ],
+    ),
+    (
+        "Climate & Weather",
+        "climate",
+        [
+            "HassClimateGetTemperature",
+            "HassClimateSetTemperature",
+            "HassGetWeather",
+        ],
+    ),
+    (
+        "Media & Volume",
+        "media",
+        [
+            "HassMediaSearchAndPlay",
+            "HassMediaPause",
+            "HassMediaUnpause",
+            "HassMediaNext",
+            "HassMediaPrevious",
+            "HassSetVolume",
+            "HassSetVolumeRelative",
+            "HassMediaPlayerMute",
+            "HassMediaPlayerUnmute",
+        ],
+    ),
+    (
+        "Timers",
+        "timers",
+        [
+            "HassStartTimer",
+            "HassPauseTimer",
+            "HassUnpauseTimer",
+            "HassIncreaseTimer",
+            "HassDecreaseTimer",
+            "HassCancelTimer",
+            "HassCancelAllTimers",
+            "HassTimerStatus",
+        ],
+    ),
+    (
+        "Lists & To-do",
+        "lists",
+        [
+            "HassListAddItem",
+            "HassListCompleteItem",
+            "HassListRemoveItem",
+            "HassShoppingListAddItem",
+            "HassShoppingListCompleteItem",
+        ],
+    ),
+    (
+        "Vacuum & Lawn Mower",
+        "cleaning",
+        [
+            "HassVacuumStart",
+            "HassVacuumCleanArea",
+            "HassVacuumReturnToBase",
+            "HassLawnMowerStartMowing",
+            "HassLawnMowerDock",
+        ],
+    ),
+    (
+        "Date & Time",
+        "datetime",
+        [
+            "HassGetCurrentTime",
+            "HassGetCurrentDate",
+        ],
+    ),
+    (
+        "State & Information",
+        "state",
+        [
+            "HassGetState",
+        ],
+    ),
+    (
+        "Miscellaneous",
+        "assist",
+        [
+            "HassBroadcast",
+            "HassRespond",
+            "HassNevermind",
+        ],
+    ),
+]
+
+# Fallback group for any intent not explicitly placed above.
+_OTHER_GROUP = ("Other", "other")
+
+
+def _group_for_intent(intent_name: str) -> tuple[str, str]:
+    """Return the (name, slug) of the group an intent belongs to."""
+    for name, slug, members in INTENT_GROUPS:
+        if intent_name in members:
+            return name, slug
+    return _OTHER_GROUP
+
+
+def _intent_sort_key(intent_name: str) -> tuple[int, int, str]:
+    """Sort intents by group order, then by the within-group order declared in
+    INTENT_GROUPS (roughly how likely/early each intent is encountered).
+    Ungrouped intents fall after all groups, ordered alphabetically."""
+    for group_index, (_name, _slug, members) in enumerate(INTENT_GROUPS):
+        if intent_name in members:
+            return (group_index, members.index(intent_name), intent_name)
+    return (len(INTENT_GROUPS), 0, intent_name)
 
 
 def _first_example(example) -> str | None:
@@ -61,20 +184,58 @@ def run() -> int:
                     data_blocks = combo_data.get("data") or []
                     if data_blocks:
                         entry["supported"] = True
-                        entry["examples"] = [
+                        raw_examples = [
                             block["example"]
                             for block in data_blocks
                             if block.get("example")
                         ]
+                        if raw_examples:
+                            # Highlight slot values (name/area/floor/numbers/...)
+                            # by parsing each example with hassil.
+                            lang_intents = get_language_intents(language, intent_info)
+                            slot_lists = combo_slot_lists(
+                                language, intent_name, combo["name"]
+                            )
+                            entry["examples"] = [
+                                highlight_example(example, lang_intents, slot_lists)
+                                for example in raw_examples
+                            ]
                 lang_support[combo["name"]] = entry
             support[language] = lang_support
 
+        group_name, group_slug = _group_for_intent(intent_name)
         intents_out.append(
             {
                 "intent": intent_name,
                 "domain": info.get("domain"),
+                "group": group_name,
+                "group_slug": group_slug,
                 "combos": combos,
                 "support": support,
+            }
+        )
+
+    # Order intents by group, then by likely encounter order within the group,
+    # so the per-language sections read top-down rather than alphabetically.
+    intents_out.sort(key=lambda intent: _intent_sort_key(intent["intent"]))
+
+    # Ordered list of groups present in the output, used to render the
+    # per-language table of contents and grouped sections.
+    present_intents = {intent["intent"] for intent in intents_out}
+    groups_out = []
+    for name, slug, members in INTENT_GROUPS:
+        group_members = [m for m in members if m in present_intents]
+        if group_members:
+            groups_out.append({"name": name, "slug": slug, "intents": group_members})
+    other_members = [
+        intent["intent"] for intent in intents_out if intent["group"] == _OTHER_GROUP[0]
+    ]
+    if other_members:
+        groups_out.append(
+            {
+                "name": _OTHER_GROUP[0],
+                "slug": _OTHER_GROUP[1],
+                "intents": other_members,
             }
         )
 
@@ -123,7 +284,11 @@ def run() -> int:
 
     print(
         json.dumps(
-            {"languages": languages_out, "intents": intents_out},
+            {
+                "languages": languages_out,
+                "groups": groups_out,
+                "intents": intents_out,
+            },
             indent=2,
             ensure_ascii=False,
         )

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -31,6 +31,7 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
             "llm_template",
             "merged_output",
             "parse",
+            "report_unparsed_examples",
             "sample_template",
             "sample",
             "slot_combination_summary",
@@ -44,8 +45,27 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
 
 def load_merged_sentences(language: str) -> dict:
     merged_sentences: dict = {}
-    for sentence_file in sorted((SENTENCE_DIR / language).glob("*.yaml")):
+    language_dir = SENTENCE_DIR / language
+
+    # Language-level config (errors, skip words, ...) lives in top-level files
+    # such as _common.yaml.
+    for sentence_file in sorted(language_dir.glob("*.yaml")):
         merge_dict(merged_sentences, yaml.safe_load(sentence_file.read_text()))
+
+    # Since the slot-combination migration, each intent's sentences live in
+    # sentences/<lang>/<intent>/<slot_combination>.yaml, with the file rooted at
+    # `data:` (the intent comes from the directory name). Reconstruct the
+    # `intents: <Intent>: data:` shape that downstream code expects.
+    intents: dict = merged_sentences.setdefault("intents", {})
+    for intent_dir in sorted(p for p in language_dir.iterdir() if p.is_dir()):
+        intent_name = intent_dir.name
+        for combo_file in sorted(intent_dir.glob("*.yaml")):
+            combo_data = yaml.safe_load(combo_file.read_text()) or {}
+            for sentence_set in combo_data.get("data", []):
+                intents.setdefault(intent_name, {}).setdefault("data", []).append(
+                    sentence_set
+                )
+
     return merged_sentences
 
 

--- a/script/intentfest/website_summary.py
+++ b/script/intentfest/website_summary.py
@@ -111,8 +111,10 @@ def run() -> int:
 
     intents = {}
     for intent, info in intent_info.items():
+        # Since the slot-combination migration, an intent's sentences live in a
+        # directory (sentences/<lang>/<intent>/) rather than a single file.
         intents[intent] = {
-            "file_name": f"{info['domain']}_{intent}.yaml",
+            "file_name": intent,
             "important": intent in IMPORTANT_INTENTS,
         }
 

--- a/website/src-11ty/language.html
+++ b/website/src-11ty/language.html
@@ -29,6 +29,61 @@ permalink: "/language_{{ lang.code }}.html"
   .lang-detail td.example {
     font-style: italic;
   }
+  /* Highlighted slot values inside example sentences. */
+  .slot {
+    font-style: normal;
+    padding: 0 3px;
+    border-radius: 3px;
+    border-bottom: 2px solid transparent;
+  }
+  .slot-name {
+    background: #d8f3df;
+    border-color: #1b9e3e;
+  }
+  .slot-area {
+    background: #d7e9fb;
+    border-color: #2f7fd1;
+  }
+  .slot-floor {
+    background: #dfdcf7;
+    border-color: #5b4fc4;
+  }
+  .slot-number {
+    background: #fbeccb;
+    border-color: #d99e1a;
+  }
+  .slot-color {
+    background: #fbd7e6;
+    border-color: #d14a86;
+  }
+  .slot-class {
+    background: #ece1f7;
+    border-color: #8c4fc4;
+  }
+  .slot-text {
+    background: #fbe2cf;
+    border-color: #d97a2a;
+  }
+  .slot-state {
+    background: #d4f1ee;
+    border-color: #1aa39a;
+  }
+  .slot-other {
+    background: #e8e8e8;
+    border-color: #888;
+  }
+  .slot-legend {
+    margin: 0 0 1.5em;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    font-size: 0.8em;
+  }
+  .slot-legend li {
+    margin: 0;
+  }
   .badge {
     display: inline-block;
     font-size: 0.75em;
@@ -40,6 +95,44 @@ permalink: "/language_{{ lang.code }}.html"
   }
   .missing-required {
     background: #c0392b;
+  }
+  .group-toc {
+    margin: 1em 0 2em;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 10px;
+  }
+  .group-toc li {
+    margin: 0;
+  }
+  .group-toc a {
+    display: inline-block;
+    padding: 3px 10px;
+    border: 1px solid #d0d0d0;
+    border-radius: 14px;
+    text-decoration: none;
+    background: #f5f5f5;
+    color: #333;
+  }
+  .group-toc a:hover {
+    background: #e3e3e3;
+  }
+  .group-toc .count {
+    color: #888;
+  }
+  .lang-detail h2.group {
+    margin-top: 1.5em;
+    padding-bottom: 0.25em;
+    border-bottom: 2px solid #1b9e3e;
+  }
+  .lang-detail h3 {
+    margin-bottom: 0.4em;
+  }
+  .toplink {
+    font-size: 0.7em;
+    font-weight: normal;
   }
 </style>
 
@@ -61,14 +154,49 @@ permalink: "/language_{{ lang.code }}.html"
     <a href="https://github.com/OHF-Voice/intents/tree/main/sentences/{{ lang.code }}" target="_blank">sentences/{{ lang.code }}/</a>
   </p>
 
+  <p>
+    Example sentences highlight the
+    <a href="https://github.com/OHF-Voice/intents/blob/main/docs/slot_combinations.md" target="_blank">slot</a>
+    values, parsed with
+    <a href="https://github.com/OHF-Voice/hassil" target="_blank">hassil</a>:
+  </p>
+  <ul class="slot-legend">
+    <li><span class="slot slot-name">name</span></li>
+    <li><span class="slot slot-area">area</span></li>
+    <li><span class="slot slot-floor">floor</span></li>
+    <li><span class="slot slot-class">domain / device class</span></li>
+    <li><span class="slot slot-number">number</span></li>
+    <li><span class="slot slot-color">color</span></li>
+    <li><span class="slot slot-state">state</span></li>
+    <li><span class="slot slot-text">free text / wildcard</span></li>
+  </ul>
+
+  <h2 id="top">Intent groups</h2>
+  <ul class="group-toc">
+    {% for group in slotCombinationSummary.groups %}
+    <li>
+      <a href="#group-{{ group.slug }}">
+        {{ group.name }} <span class="count">({{ group.intents.size }})</span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+
+  {% for group in slotCombinationSummary.groups %}
+  <h2 class="group" id="group-{{ group.slug }}">
+    {{ group.name }}
+    <a class="toplink" href="#top">&uarr; top</a>
+  </h2>
+
   {% for intent in slotCombinationSummary.intents %}
+  {% if intent.group_slug == group.slug %}
   {% assign support = intent.support[lang.code] %}
-  <h2>
+  <h3>
     <a href="https://github.com/OHF-Voice/intents/tree/main/sentences/{{ lang.code }}/{{ intent.intent }}" target="_blank">
       {{ intent.intent | remove_first: "Hass" }}
     </a>
     <small>({{ intent.domain }})</small>
-  </h2>
+  </h3>
   <table>
     <thead>
       <tr>
@@ -97,5 +225,7 @@ permalink: "/language_{{ lang.code }}.html"
       {% endfor %}
     </tbody>
   </table>
+  {% endif %}
+  {% endfor %}
   {% endfor %}
 </div>

--- a/website/src-11ty/slot_combinations.html
+++ b/website/src-11ty/slot_combinations.html
@@ -42,7 +42,8 @@ permalink: /slot_combinations.html
   format each language provides, ranked by coverage of the
   <strong>required</strong> combinations (the must-haves). The secondary bar
   shows coverage of <em>all</em> declared combinations. Click a language for a
-  per-intent breakdown of what is covered and what is missing.
+  per-intent breakdown of what is covered and what is missing, organized by
+  intent group (timers, media, to-do lists, and more).
 </p>
 
 <table class="leaderboard">


### PR DESCRIPTION
## Summary

Improvements to the slot-combination coverage website, plus a fix for breakage caused by the recent slot-combination syntax migration.

### Group intents by category (per-language page)
The per-language breakdown now groups intents into categories — **Timers**, **Media & Volume**, **Lists & To-do**, **Lights/Switches/Devices**, **Climate & Weather**, **Vacuum & Lawn Mower**, **Date & Time**, **State & Information**, **Miscellaneous** — with a table-of-contents at the top. Within each group, intents are ordered by likely usage/encounter order (e.g. `StartTimer` before `CancelTimer`) rather than alphabetically.

### Fix `website_summary` for the new layout
After the migration, sentences live in `sentences/<lang>/<intent>/<combo>.yaml` rooted directly at `data:` (no `intents:` nesting). `load_merged_sentences` only globbed top-level files, so the summary crashed with `KeyError: 'intents'`. It now reconstructs the intents map by walking the per-intent subdirectories, and the per-intent link points at the intent directory.

### Highlight slot values in example sentences
Example sentences now colour-code their slot values (name / area / floor / numbers / device-class / wildcards / …). Each example is parsed with **hassil**; the matched `MatchEntity.text_span` offsets are wrapped in `<span class="slot slot-<category>">`, with a legend on the page. Recognition is best-effort — examples that don't parse fall back to plain text. ~75% of English examples highlight.

### New `report_unparsed_examples` action
```
python3 -m script.intentfest report_unparsed_examples [--language en]
```
Lists `example:` strings hassil can't recognize (typically names not present in the test fixtures, or sentences the templates can't produce) so maintainers can clean up the `example:` fields. Read-only; prints to stdout.

## Test plan
- `python3 -m script.intentfest website_summary` and `slot_combination_summary` both run clean (previously the former crashed).
- Full eleventy build succeeds (68 pages); highlighted spans render as real HTML and the grouped TOC anchors resolve.
- `report_unparsed_examples` runs across all languages in ~3s.

Note: only English is migrated so far, so other languages short-circuit to plain examples until they migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)