### PR TITLE
Migration tooling: prune, check_overmatch, validate gates + guide notes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,5 +90,47 @@ jobs:
             script/test
           fi
 
+      # Cross-intent over-matching: the slot-combination suite only checks
+      # intent.name within one intent, so it can't catch one intent stealing
+      # another's utterance. This gate re-recognizes every test sentence against
+      # the language's whole merged Intents.
+      - name: Check cross-intent over-matching
+        env:
+          LANGUAGES: ${{ steps.extract-languages.outputs.languages }}
+          is_pr: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [ "$is_pr" = "true" ] && [ -n "${LANGUAGES}" ]; then
+            langs=$(echo "${LANGUAGES}" | tr ',' ' ')
+          else
+            langs=$(for d in sentences/*/; do l=${d#sentences/}; l=${l%/}; if find "$d" -mindepth 1 -maxdepth 1 -type d | grep -q .; then echo "$l"; fi; done)
+          fi
+          rc=0
+          for l in $langs; do
+            echo "::group::check_overmatch $l"
+            python3 -m script.intentfest check_overmatch --language "$l" || rc=1
+            echo "::endgroup::"
+          done
+          exit $rc
+
+      # Fully-migrated languages must carry no dead rules/lists (partial and
+      # unmigrated languages are skipped by the tool).
+      - name: Check for prunable dead rules/lists
+        env:
+          LANGUAGES: ${{ steps.extract-languages.outputs.languages }}
+          is_pr: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [ "$is_pr" = "true" ] && [ -n "${LANGUAGES}" ]; then
+            langs=$(echo "${LANGUAGES}" | tr ',' ' ')
+          else
+            langs=$(for d in sentences/*/; do l=${d#sentences/}; l=${l%/}; if find "$d" -mindepth 1 -maxdepth 1 -type d | grep -q .; then echo "$l"; fi; done)
+          fi
+          rc=0
+          for l in $langs; do
+            echo "::group::prune --check $l"
+            python3 -m script.intentfest prune --language "$l" --check || rc=1
+            echo "::endgroup::"
+          done
+          exit $rc
+
       - run: python3 -m script.intentfest parse --language en --sentence 'turn on the lights in the kitchen'
       - run: python3 -m script.intentfest codeowners --check

--- a/docs/syntax_migration_guide.md
+++ b/docs/syntax_migration_guide.md
@@ -5,7 +5,7 @@ This guide explains how to migrate sentences written in the original
 [`hassil`](../../hassil/docs/template_syntax.md)) to the new
 **slot combination** format described in [`slot_combinations.md`](slot_combinations.md).
 
-The *template syntax itself* (alternatives `(a|b)`, optionals `[x]`, lists
+The _template syntax itself_ (alternatives `(a|b)`, optionals `[x]`, lists
 `{list}`, rules `<rule>`, permutations `(a;b)`) is **unchanged**. What changes
 is **how files are organized**, **where lists and rules live**, **how target
 domains are declared**, and a few **new restrictions** on what a template may
@@ -23,19 +23,17 @@ contain.
 - [Migration checklist](#migration-checklist)
 - [Adversarial review (final step)](#adversarial-review-final-step)
 
-
 ## At a glance
 
-| Concern            | Old format                                              | New format                                                            |
-| ------------------ | ------------------------------------------------------- | --------------------------------------------------------------------- |
-| Sentence files     | `sentences/<lang>/<domain>_<intent>.yaml`               | `sentences/<lang>/<intent>/<slot_combination>.yaml`                   |
-| File root          | `intents: <Intent>: data:`                              | `data:` (intent & slot combination come from the path)               |
-| Grouping           | By intent (and ad‑hoc by domain in the filename)        | By **slot combination**, declared in `intents.yaml`                  |
-| Target domain      | `requires_context: { domain: ... }` / `slots: { domain }` | `name_domains:` / `inferred_domain:` in each sentence group        |
-| Lists              | `sentences/<lang>/_common.yaml` → `lists:`              | `lists/<lang>/<group>.yaml` (or shared `lists/<group>.yaml`)         |
-| Rules              | `sentences/<lang>/_common.yaml` → `expansion_rules:`    | `rules/<lang>/<group>.yaml`                                          |
-| Tests              | `tests/<lang>/<domain>_<intent>.yaml`                   | `tests/<lang>/<intent>/<slot_combination>.yaml` (self‑contained)     |
-
+| Concern        | Old format                                                | New format                                                       |
+| -------------- | --------------------------------------------------------- | ---------------------------------------------------------------- |
+| Sentence files | `sentences/<lang>/<domain>_<intent>.yaml`                 | `sentences/<lang>/<intent>/<slot_combination>.yaml`              |
+| File root      | `intents: <Intent>: data:`                                | `data:` (intent & slot combination come from the path)           |
+| Grouping       | By intent (and ad‑hoc by domain in the filename)          | By **slot combination**, declared in `intents.yaml`              |
+| Target domain  | `requires_context: { domain: ... }` / `slots: { domain }` | `name_domains:` / `inferred_domain:` in each sentence group      |
+| Lists          | `sentences/<lang>/_common.yaml` → `lists:`                | `lists/<lang>/<group>.yaml` (or shared `lists/<group>.yaml`)     |
+| Rules          | `sentences/<lang>/_common.yaml` → `expansion_rules:`      | `rules/<lang>/<group>.yaml`                                      |
+| Tests          | `tests/<lang>/<domain>_<intent>.yaml`                     | `tests/<lang>/<intent>/<slot_combination>.yaml` (self‑contained) |
 
 ## 1. Sentence files: group by slot combination
 
@@ -76,7 +74,7 @@ data:
       - "<turn> on [<the>] {name}"
     name_domains:
       - "light"
-    example: "turn on the overhead light"  # use names from tests
+    example: "turn on the overhead light" # use names from tests
     response: "default"
 ```
 
@@ -99,7 +97,6 @@ matching sentence file; `usable` combinations produce a warning when missing.
 > All templates in a slot combination file must match **exactly** the slots
 > listed for that combination in `intents.yaml`. Don't mix sentences that match
 > different slots into the same file.
-
 
 ## 2. Declaring target domains (`requires_context` is gone)
 
@@ -157,7 +154,6 @@ Every domain marked `required` in `intents.yaml` must be covered somewhere in th
 file, but not necessarily by the same group of sentences — split them in whatever
 way reads best for your language. Non-required levels (`usable`, `complete`,
 `optional`) only affect the language's coverage score.
-
 
 ## 3. Lists move out of `_common.yaml`
 
@@ -217,7 +213,6 @@ Two things to note:
 - The `range` (`from`/`to`/`step`/`type`) and `wildcard: true` forms are
   unchanged; only the file location changes.
 
-
 ## 4. Rules move out of `_common.yaml`
 
 Expansion rules used to share the `_common.yaml` file under `expansion_rules:`:
@@ -257,7 +252,6 @@ readable and keep the matched slots predictable):
   `<other_rule>`. Nesting forces readers to chase a chain of definitions and can
   make the set of possible sentences explode.
 
-
 ## 5. New template restrictions
 
 The template syntax is otherwise unchanged, but **list references are no longer
@@ -271,7 +265,6 @@ allowed inside alternatives or optionals**:
 This guarantees that a sentence template always matches the same set of slots. If
 you have a sentence where a list is optional, split it into two templates (one
 with the list, one without) so each has a well-defined slot signature.
-
 
 ## 6. Tests
 
@@ -296,13 +289,12 @@ tests:
       - "turn on the overhead light"
     slots:
       name: "Overhead Light"
-    response: "Turned on the light"  # rendered response text, not the key
+    response: "Turned on the light" # rendered response text, not the key
 ```
 
 > Note the two meanings of `response:` — in a **sentence** file it's the response
 > **key** (e.g. `default`); in a **test** file it's the expected rendered **text**
 > (e.g. `Turned on the light`). See §8.
-
 
 ## 7. Tooling
 
@@ -332,12 +324,12 @@ checklist's cleanup step.) The helper:
 
 Grouping is purely organizational (the test harness merges every file in
 `rules/<lang>/`), so re-group the output by hand if you like. **Once the language
-is fully migrated, prune `rules/<lang>/` *and* `lists/<lang>/` down to what your
+is fully migrated, prune `rules/<lang>/` _and_ `lists/<lang>/` down to what your
 combos actually reference** (like `rules/en/`) — `migrate_common` copies
 everything, so the inlined slot rules (`name`/`area`/`floor`), unused value lists,
 and any composite/dangling rules are left behind as dead weight to delete. Prune
 **orphaned response keys** too (see the final-cleanup step). Build the reference
-graph carefully: a rule/list is live only if a sentence — or another *live* rule —
+graph carefully: a rule/list is live only if a sentence — or another _live_ rule —
 references it (a rule used only by another dead rule is itself dead).
 
 ### Per intent — scaffold the sentences and tests
@@ -363,7 +355,7 @@ The tool reuses the same slot-resolution logic as `check_slot_combinations`
   (entity/area/floor fixtures by name; `timers:`/`media:` are carried verbatim for
   `*Timer*`/`*Media*` intents — trim them to what each file needs);
 - write a **flag report** to `migration_reports/<lang>/<Intent>.md` listing
-  everything it could *not* safely do.
+  everything it could _not_ safely do.
 
 The tool is deliberately conservative: it never edits or deletes the old
 `*_<Intent>.yaml` files and never touches `_common.yaml`, so a run is always safe
@@ -379,7 +371,6 @@ This per-intent split is intended to be done by a focused agent with limited
 context: feed it this guide, run the tool for its one intent, and have it clear
 the flag report.
 
-
 ## 8. Lessons from practice (gotchas)
 
 These are the things the scaffolder **flags for you** because they need judgement:
@@ -391,7 +382,7 @@ These are the things the scaffolder **flags for you** because they need judgemen
   through to pick the right file.
 
 - **Old templates pack several combos into one line.** Compact templates such as
-  `open (<name>;[<in>] (<area>|<floor>))` match `name_area` *and* `name_floor`
+  `open (<name>;[<in>] (<area>|<floor>))` match `name_area` _and_ `name_floor`
   (and the `(area|floor)` alternative alone yields two signatures). The new format
   requires each file to match exactly one signature, so these must be **split into
   one template per combo**. This is the largest manual chunk — in NL's `HassTurnOn`,
@@ -419,10 +410,10 @@ These are the things the scaffolder **flags for you** because they need judgemen
   - **Fallback — inline.** Inline the rule bodies into the templates. This always
     works but bloats templates badly (e.g. a long `<media_item>` alternation
     repeated on every line), so reserve it for small, one-off rules.
-  You must always inline **list-bearing** rules regardless (`<name>` →
-  `[<the>] {name}`), per §4. The scaffolder flags every rule/list reference that
-  isn't resolvable from `rules/<lang>/` / `lists/<lang>/` as `unresolved rule` /
-  `unresolved list`.
+    You must always inline **list-bearing** rules regardless (`<name>` →
+    `[<the>] {name}`), per §4. The scaffolder flags every rule/list reference that
+    isn't resolvable from `rules/<lang>/` / `lists/<lang>/` as `unresolved rule` /
+    `unresolved list`.
 
 - **Every sentence template must be exercised by a test.** The slot-combination
   harness fails if a template in a combo file is never matched by any test
@@ -431,10 +422,10 @@ These are the things the scaffolder **flags for you** because they need judgemen
   carries over the old tests).
 
 - **`skip_words` ARE applied by the slot-combination harness.** Unlike rules and
-  lists, `skip_words` from `_common.yaml` *are* loaded and applied when matching
+  lists, `skip_words` from `_common.yaml` _are_ loaded and applied when matching
   test sentences (the harness reads them into the compiled `Intents` — see
   `tests/test_slot_combinations.py`). So a test sentence that leans on a skip word
-  (e.g. German "*kannst du* ..." / "*bitte* ...") still matches, and you do **not**
+  (e.g. German "_kannst du_ ..." / "_bitte_ ...") still matches, and you do **not**
   need to strip skip words from carried-over tests. (This changed when `skip_words`
   loading was added to the harness; migrations that pre-date it may contain
   unnecessary rewrites.)
@@ -473,12 +464,12 @@ These are the things the scaffolder **flags for you** because they need judgemen
   enumeration is exponential, so the scaffolder bails out on templates with a huge
   number of signatures (rather than hanging). Build those by hand from the
   reference language. For big multi-domain intents (`HassTurnOn`/`HassTurnOff`)
-  the scaffolder's auto-placed *sentences* are unreliable anyway — treat the
+  the scaffolder's auto-placed _sentences_ are unreliable anyway — treat the
   **already-migrated `en` files as authoritative** and use the report mainly for
   its combo list, `unresolved`/`complex` flags, and old-files list.
 
 - **Don't write symmetric duplicate templates.** A permutation `(a;b)` already
-  matches both orders, so adding explicit `a b` *and* `b a` templates creates
+  matches both orders, so adding explicit `a b` _and_ `b a` templates creates
   duplicates that can't each be uniquely test-exercised. Prefer the permutation.
 
 - **Mind `recognize_best` collisions.** Phrasings shared across combos (e.g.
@@ -504,7 +495,7 @@ These are the things the scaffolder **flags for you** because they need judgemen
   (which adds one) will mismatch.
 
 - **Fixture counts couple to the response.** Some responses depend on how many
-  fixtures exist (e.g. `HassCancelAllTimers` counts *all* timer fixtures;
+  fixtures exist (e.g. `HassCancelAllTimers` counts _all_ timer fixtures;
   `HassTimerStatus` switches wording with more than one timer). Trim fixtures to
   exactly what makes the asserted response render.
 
@@ -516,6 +507,18 @@ These are the things the scaffolder **flags for you** because they need judgemen
   area tests their own `areas:` fixture so `{area}` resolves, keep the wildcard
   terminal in the template, and avoid solid compounds like "keukentimer" that
   don't match `{area}[ ]<timer>` (which needs a space).
+
+- **Slots that abut a prepositional phrase over-absorb (Romance languages).** In
+  languages where modifiers attach with a preposition (es/fr/it/pt "puerta **del
+  garaje**", "lumière **du salon**"), a wildcard (`{search_query}`) or even
+  `{area}`/`{name}` placed next to such a phrase tends to swallow it, capturing the
+  wrong slot. Two recurring traps from the es migration: `{search_query} [el|la]
+{media_class}` let the wildcard eat "Avatar **la película**" (no clean boundary —
+  drop the article-between ordering), and `{area}` named "garaje" stole "**del
+  garaje**" from a `{device_class: garage}` match (an inherent ambiguity with no
+  dedicated combo). Prefer a required preposition/literal as a boundary, keep
+  wildcards terminal, and accept that some "X de[l] <area>" phrasings are genuinely
+  ambiguous when an area shares the noun.
 
 ### Intent-shape gotchas
 
@@ -536,7 +539,6 @@ These are the things the scaffolder **flags for you** because they need judgemen
   they used (`get_brightness`, etc.) become orphaned — prune them (see final
   cleanup). (Earlier revisions of this guide called `HassGetState` a partial
   migration; that is no longer the case.)
-
 
 ## Migration checklist
 
@@ -564,7 +566,7 @@ and:
    generated `migration_reports/<lang>/<Intent>.md`.
 2. Resolve every flag: **split multi-combo templates** into one template per
    combo, fix **unmapped signatures**, resolve any `unresolved rule`/`unresolved
-   list` (they should be rare after Step 0), and confirm the `response` keys.
+list` (they should be rare after Step 0), and confirm the `response` keys.
 3. Confirm the scaffolded `sentences/<lang>/<Intent>/<combo>.yaml` files: each
    starts at `data:` (no `intents:` nesting), carries the right
    `name_domains:`/`inferred_domain:`, and **all `required` domains are covered**.
@@ -590,7 +592,7 @@ and:
     history reviewable intent-by-intent and easy to revert in isolation. Don't
     batch several intents into one commit.
 
-**Final cleanup — only once *no* old-format files remain.** When the language has
+**Final cleanup — only once _no_ old-format files remain.** When the language has
 no `<domain>_<intent>.yaml` files left, the copies left behind in Step 0 are dead
 weight. Delete the blocks that have moved to their new homes:
 
@@ -620,17 +622,16 @@ weight. Delete the blocks that have moved to their new homes:
 Then run `validate` + the tests one last time to confirm the language is green
 with `_common.yaml` slimmed down.
 
-> **Caveat:** if a language *intentionally* keeps any old-format
+> **Caveat:** if a language _intentionally_ keeps any old-format
 > `<domain>_<intent>.yaml` files, this cleanup does **not** apply to it: those
 > files still resolve their rules/lists from `_common.yaml` and their fixtures
 > from `_fixtures.yaml`, so both must stay. (As of this writing no upstream intent
 > is kept in the old format — `en` is fully migrated, `HassGetState` included.)
 
-
 ## Adversarial review (final step)
 
 A green `validate` and a passing test suite are **necessary but not sufficient**:
-they confirm each test sentence matches *some* template and that response keys
+they confirm each test sentence matches _some_ template and that response keys
 exist, but they do **not** catch dropped user phrasings, over-matching, wrong
 domain/response mappings, trivially-passing tests, or dead/dangling rules. So the
 last step of a language migration is an adversarial review loop.
@@ -657,12 +658,20 @@ converges to nothing. Angles that proved productive:
    while migrating on a branch, but once the migration is merged the old files are
    gone from `main`, so use the merge-base or the commit before Step 0
    (`git show <pre-migration-sha>:sentences/<lang>/<domain>_<intent>.yaml`).
+   **Filter every candidate through `en`/`intents.yaml` before calling it a
+   regression:** a phrasing is only a real loss if a slot combination exists to
+   hold it (i.e. `en` covers it, or `intents.yaml` declares a fitting combo). If
+   there is no combo for it — e.g. all-lights-on-a-floor (no `domain_floor`),
+   all-locks-in-an-area, whole-house fans on `HassTurnOn`, or attribute/measurement
+   queries on `HassGetState` — it is a by-design model limitation, not a migration
+   bug, and "restoring" it has nowhere to go. This filter avoids chasing the many
+   acceptable drops the raw old-vs-new diff surfaces.
 2. **Over-matching / wrong-slot (false positives).** Templates that now match
    utterances they shouldn't, capture the wrong slot, or whose file's templates
    don't actually match the combo's declared signature. The per-test harness
    asserts `intent.name == expected`, so it **cannot** catch cross-intent
    over-matching (e.g. a `HassTurnOn` template stealing a `HassTurnOff` utterance);
-   verify this with a probe that merges *all* intents into one `Intents` and calls
+   verify this with a probe that merges _all_ intents into one `Intents` and calls
    `recognize_best`, then checks which intent wins.
 3. **Mappings.** Wrong `name_domains`/`inferred_domain` or `response` keys vs the
    old `requires_context`/`slots` and `intents.yaml`; uncovered `required` domains.
@@ -675,7 +684,7 @@ converges to nothing. Angles that proved productive:
 6. **Symmetry + completeness.** Sibling intents (TurnOn vs TurnOff, the media
    group, Increase vs Decrease) that diverge for non-`intents.yaml` reasons;
    `usable`/`complete` combos the old language covered but the migration dropped;
-   response-file integrity. Watch asymmetric *structure*: e.g. `HassTurnOn` has no
+   response-file integrity. Watch asymmetric _structure_: e.g. `HassTurnOn` has no
    `domain_all` combo — its "all (the) lights" quantifier lives in `domain_only` —
    while `HassTurnOff` has a dedicated `domain_all`, so it's easy to drop the "all"
    phrasing from `HassTurnOn` when splitting.

--- a/rules/en/common.yaml
+++ b/rules/en/common.yaml
@@ -1,12 +1,9 @@
----
-language: "en"
-
+language: en
 expansion_rules:
-  all: "(all [[of] (the|my|our)]|every [single]|each [and every])"
-  everywhere: "(everywhere|all over|[(in|on|at|of|across|around|throughout)] (the|my|our) [(entire|whole)] (home|house|apartment|flat)|[(in|on|at|of|across|around|throughout)] (all [[of] (the|my|our)]|every [single]|each [and every]) (room|area|floor)[s])"
-  here: "([in] here|[in] (this|the|my|our) (room|area|space))"
-  home: "(home|house|apartment|flat)"
-  in: "(in|on|at|of|across|around|throughout)"
-  is: "(is|are) [(there|the|my|our)]"
-  percent: "(([ ]%)| percent)"
-  the: "(the|my|our)"
+  all: (all [[of] (the|my|our)]|every [single]|each [and every])
+  everywhere: (everywhere|all over|[(in|on|at|of|across|around|throughout)] (the|my|our) [(entire|whole)] (home|house|apartment|flat)|[(in|on|at|of|across|around|throughout)] (all [[of] (the|my|our)]|every [single]|each [and every]) (room|area|floor)[s])
+  here: ([in] here|[in] (this|the|my|our) (room|area|space))
+  home: (home|house|apartment|flat)
+  in: (in|on|at|of|across|around|throughout)
+  is: (is|are) [(there|the|my|our)]
+  the: (the|my|our)

--- a/rules/en/getstate.yaml
+++ b/rules/en/getstate.yaml
@@ -6,7 +6,7 @@ expansion_rules:
   which: (which|what) [of <the>]
   are: <is>
   any: (any|some) [of <the>]
-  are_any: '[<are>] <any>'
-  are_all: '[<are>] <all>'
+  are_any: "[<are>] <any>"
+  are_all: "[<are>] <all>"
   how_many: how many [of <the>]
-  lockable: '[<the>] (lock|door|window|gate|garage door|shutter)[s]'
+  lockable: "[<the>] (lock|door|window|gate|garage door|shutter)[s]"

--- a/rules/en/getstate.yaml
+++ b/rules/en/getstate.yaml
@@ -1,16 +1,12 @@
----
-language: "en"
-
+language: en
 expansion_rules:
-  what_is: "(what's|whats|what is|tell me)"
-  how_is: "(how is|how's|hows)"
-  where_is: "(where's|wheres|where is)"
-  which: "(which|what) [of <the>]"
-  are: "<is>"
-  any: "(any|some) [of <the>]"
-  are_any: "[<are>] <any>"
-  are_all: "[<are>] <all>"
-  how_many: "how many [of <the>]"
-  currently: "(currently|presently|right now|at the moment)"
-  state: "[(present|current)] (state|status)"
-  lockable: "[<the>] (lock|door|window|gate|garage door|shutter)[s]"
+  what_is: (what's|whats|what is|tell me)
+  how_is: (how is|how's|hows)
+  where_is: (where's|wheres|where is)
+  which: (which|what) [of <the>]
+  are: <is>
+  any: (any|some) [of <the>]
+  are_any: '[<are>] <any>'
+  are_all: '[<are>] <all>'
+  how_many: how many [of <the>]
+  lockable: '[<the>] (lock|door|window|gate|garage door|shutter)[s]'

--- a/rules/en/timers.yaml
+++ b/rules/en/timers.yaml
@@ -1,16 +1,5 @@
----
-language: "en"
-
+language: en
 expansion_rules:
-  timer_set: "(start|set|create)"
-  timer_cancel: "(cancel|stop)"
-  timer_remove: "(remove|take)"
-  timer_duration_seconds: "{timer_seconds:seconds}( |-)second[s]"
-  timer_duration_minutes: "({timer_minutes:minutes}( |-)minute[s] [[and] {timer_seconds:seconds}( |-)second[s]])|({timer_minutes:minutes} and [a] {timer_half:seconds} minute[s])|({timer_half:seconds} a minute[s])"
-  timer_duration_hours: "({timer_hours:hours}( |-)hour[s] [[and] {timer_minutes:minutes}( |-)minute[s]] [[and] {timer_seconds:seconds}( |-)second[s]])|({timer_hours:hours} and [a] {timer_half:minutes} hour[s])|({timer_half:minutes} an hour[s])"
-  timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
-
-  timer_start_seconds: "{timer_seconds:start_seconds}( |-)second[s]"
-  timer_start_minutes: "{timer_minutes:start_minutes}( |-)minute[s] [[and] {timer_seconds:start_seconds}( |-)second[s]]"
-  timer_start_hours: "{timer_hours:start_hours}( |-)hour[s] [[and] {timer_minutes:start_minutes}( |-)minute[s]] [[and] {timer_seconds:start_seconds}( |-)second[s]]"
-  timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
+  timer_set: (start|set|create)
+  timer_cancel: (cancel|stop)
+  timer_remove: (remove|take)

--- a/rules/fr/common.yaml
+++ b/rules/fr/common.yaml
@@ -1,4 +1,3 @@
----
 language: fr
 expansion_rules:
   pourcent: (%| %| pourcent| pour cent)
@@ -19,7 +18,6 @@ expansion_rules:
   en_route: (en route)|(en marche)
   yatil: (y a[-][ ]t[-][']il|il y a)
   estil: (est|sont)[-][ ][(il[s]|elle[s])]
-  atil: (ont|a)[-][ ][t][ ][-][(il[s]|elle[s])]
   quel: quel[le][s]
   quelest: <quel> (est|sont)
   donnemoi: (donne[s]|dis)[(-| )moi]

--- a/rules/fr/nouns.yaml
+++ b/rules/fr/nouns.yaml
@@ -1,12 +1,8 @@
----
 language: fr
 expansion_rules:
   lumiere: (lumière[s]|lampe[s]|ampoule[s]|éclairage[s])
   ventilateur: "[le ](ventilateur|ventilo|brasseur d'air)"
   ventilateurs: "[les ](ventilateurs|ventilos|brasseurs d'air)"
-  fenetre: (fenetre[s]|fenêtre[s]|baie[s]|velux|vélux|lucarne[s])
-  appareil: (appareil|machine|équipement)[s]
-  capteur: (capteur|sonde|détecteur)[s]
   media: (morceau|chanson|musique|élément|podcast|film|vidéo|épisode|radio|média)
   lecture: (lecture|visionnage)
   volume: (volume|son|watt[s])

--- a/rules/fr/timers.yaml
+++ b/rules/fr/timers.yaml
@@ -1,29 +1,5 @@
----
 language: fr
 expansion_rules:
-  nb_seconds_duration: "{timer_seconds:seconds}"
-  nb_minutes_duration: "{timer_minutes:minutes}"
-  nb_hours_duration: "{timer_hours:hours}"
-  nb_seconds_start: "{timer_seconds:start_seconds}"
-  nb_minutes_start: "{timer_minutes:start_minutes}"
-  nb_hours_start: "{timer_hours:start_hours}"
   second_unit: (seconde|secondes|sec|s)
   minute_unit: (minute|minutes|min|m)
   hour_unit: (heure|heures|h)
-  s_unit: (sec|s)
-  m_unit: (min|m)
-  h_unit: h
-  timer_duration_seconds: <nb_seconds_duration> <second_unit>
-  timer_duration_minutes: <nb_minutes_duration> <minute_unit>[( | et )<nb_seconds_duration> [<second_unit>]]
-  timer_duration_hours: <nb_hours_duration> <hour_unit>[( | et )<nb_minutes_duration> [<minute_unit>]][( | et )<nb_seconds_duration> [<second_unit>]]
-  timer_duration_s: <nb_seconds_duration><s_unit>
-  timer_duration_m: <nb_minutes_duration><m_unit>[<nb_seconds_duration>[<s_unit>]]
-  timer_duration_h: <nb_hours_duration><h_unit>[<nb_minutes_duration>[<m_unit>][<nb_seconds_duration>[<s_unit>]]]
-  timer_duration: <timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>|<timer_duration_s>|<timer_duration_m>|<timer_duration_h>
-  timer_start_seconds: <nb_seconds_start> <second_unit>
-  timer_start_minutes: <nb_minutes_start> <minute_unit>[( | et )<nb_seconds_start> [<second_unit>]]
-  timer_start_hours: <nb_hours_start> <hour_unit>[( | et )<nb_minutes_start> [<minute_unit>]][( | et )<nb_seconds_start> [<second_unit>]]
-  timer_start_s: <nb_seconds_start><s_unit>
-  timer_start_m: <nb_minutes_start><m_unit>[<nb_seconds_start>[<s_unit>]]
-  timer_start_h: <nb_hours_start><h_unit>[<nb_minutes_start>[<m_unit>][<nb_seconds_start>[<s_unit>]]]
-  timer_start: <timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>|<timer_start_s>|<timer_start_m>|<timer_start_h>

--- a/script/intentfest/check_overmatch.py
+++ b/script/intentfest/check_overmatch.py
@@ -1,0 +1,338 @@
+"""Check for cross-intent over-matching.
+
+The per-test slot-combination suite (tests/test_slot_combinations.py) compiles
+each language's intents into one `Intents` object but only asserts that a test
+sentence matches its *own* intent. It can never observe one intent stealing
+another intent's utterance, because every assertion is scoped to the directory
+the test lives under.
+
+This subcommand closes that gap. It compiles ALL of a language's migrated
+intents into a single `Intents` object (exactly like the suite's
+`lang_resources_fixture`), then for every test sentence in
+`tests/<lang>/<Intent>/<combo>.yaml` runs `recognize_best` against the merged
+set. If the winning intent is not the intent the test lives under, that is a
+cross-intent false positive (e.g. the es bug where
+"pon la luz al máximo" (HassLightSet) was stolen by HassMediaSearchAndPlay's
+greedy `{search_query}` wildcard).
+
+Exit code is 1 if any cross-intent mismatch is found, else 0, so it can be
+wired into CI as a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import yaml
+from hassil import Intents, SlotList, TextSlotList, recognize_best
+
+from .const import (
+    INTENTS_FILE,
+    LANGUAGES,
+    LIST_DIR,
+    RESPONSE_DIR,
+    RULE_DIR,
+    SENTENCE_DIR,
+    TESTS_DIR,
+)
+from .util import get_base_arg_parser
+
+# Sentinel area injected via intent_context, matching the slot-combination
+# harness (tests/test_slot_combinations.py:CONTEXT_AREA_NAME).
+CONTEXT_AREA_NAME = "__context_area__"
+
+
+@dataclass
+class OvermatchFinding:
+    """A cross-intent over-match (or a no-match) for one test sentence."""
+
+    language: str
+    expected_intent: str
+    expected_combo: str
+    sentence: str
+    # None kind == cross-intent mismatch; "no_match" == nothing recognized.
+    kind: str = "mismatch"
+    won_intent: Optional[str] = None
+    won_combo: Optional[str] = None
+    won_slots: dict[str, Any] = field(default_factory=dict)
+
+
+def check_sentence(
+    intents: Intents,
+    slot_lists: dict[str, SlotList],
+    language: str,
+    expected_intent: str,
+    expected_combo: str,
+    sentence: str,
+) -> Optional[OvermatchFinding]:
+    """Recognize one sentence against the merged intents.
+
+    Returns a finding if the winning intent is not the expected intent (a
+    cross-intent over-match), or if nothing was recognized at all; otherwise
+    returns None.
+    """
+    result = recognize_best(
+        sentence,
+        intents,
+        slot_lists=slot_lists,
+        intent_context={"area": CONTEXT_AREA_NAME},
+        best_slot_name="name",
+    )
+
+    if result is None:
+        return OvermatchFinding(
+            language=language,
+            expected_intent=expected_intent,
+            expected_combo=expected_combo,
+            sentence=sentence,
+            kind="no_match",
+        )
+
+    won_intent = result.intent.name
+    if won_intent == expected_intent:
+        return None
+
+    won_combo: Optional[str] = None
+    if result.intent_metadata is not None:
+        won_combo = result.intent_metadata.get("slot_combination")
+
+    return OvermatchFinding(
+        language=language,
+        expected_intent=expected_intent,
+        expected_combo=expected_combo,
+        sentence=sentence,
+        kind="mismatch",
+        won_intent=won_intent,
+        won_combo=won_combo,
+        won_slots={e_name: e.value for e_name, e in result.entities.items()},
+    )
+
+
+def _slug(name: str) -> str:
+    """Synthesize an id from a human name (mirrors the test harness)."""
+    return name.strip().casefold().replace(" ", "_")
+
+
+def get_arguments() -> argparse.Namespace:
+    """Get parsed passed in arguments."""
+    parser = get_base_arg_parser()
+    parser.add_argument(
+        "--language", type=str, choices=LANGUAGES, help="The language to check."
+    )
+    parser.add_argument(
+        "--intent",
+        help="Only check test sentences belonging to this intent.",
+    )
+    return parser.parse_args()
+
+
+def _load_merged_intents(language: str, intent_schemas: dict[str, Any]) -> Intents:
+    """Compile ALL of a language's migrated intents into one `Intents`.
+
+    This faithfully mirrors tests/test_slot_combinations.py's
+    `lang_resources_fixture` so the merged compiled set is identical to what the
+    per-test suite runs against.
+    """
+    lang_intents_dict: dict[str, Any] = {
+        "language": language,
+        "intents": {},
+        "lists": {},
+        "expansion_rules": {},
+        "skip_words": [],
+    }
+
+    # Load skip words (Home Assistant applies these at runtime, from _common.yaml)
+    common_path = SENTENCE_DIR / language / "_common.yaml"
+    if common_path.exists():
+        with open(common_path, "r", encoding="utf-8") as common_file:
+            common_dict = yaml.safe_load(common_file) or {}
+        lang_intents_dict["skip_words"] = common_dict.get("skip_words", [])
+
+    # Load expansion rules
+    rules_dict: dict[str, Any] = lang_intents_dict["expansion_rules"]
+    for rule_path in (RULE_DIR / language).glob("*.yaml"):
+        with open(rule_path, "r", encoding="utf-8") as rule_file:
+            rule_dict = yaml.safe_load(rule_file)
+            rules_dict.update(rule_dict["expansion_rules"])
+
+    # Load shared lists
+    lists_dict: dict[str, Any] = lang_intents_dict["lists"]
+    for list_path in LIST_DIR.glob("*.yaml"):
+        with open(list_path, "r", encoding="utf-8") as list_file:
+            list_dict = yaml.safe_load(list_file)
+            lists_dict.update(list_dict["lists"])
+
+    # Load language-specific lists
+    for list_path in (LIST_DIR / language).glob("*.yaml"):
+        with open(list_path, "r", encoding="utf-8") as list_file:
+            list_dict = yaml.safe_load(list_file)
+            lists_dict.update(list_dict["lists"])
+
+    for intent_name, intent_info in intent_schemas.items():
+        intent_dict = lang_intents_dict["intents"].get(intent_name, {"data": []})
+        intent_data = intent_dict["data"]
+
+        for combo_name, combo_info in intent_info["slot_combinations"].items():
+            sentences_path = (
+                SENTENCE_DIR / language / intent_name / f"{combo_name}.yaml"
+            )
+            if not sentences_path.exists():
+                continue
+
+            with open(sentences_path, "r", encoding="utf-8") as sentences_file:
+                test_data_dict = yaml.safe_load(sentences_file)
+
+                for test_sentences_dict in test_data_dict["data"]:
+                    test_slots = test_sentences_dict.get("slots", {})
+                    test_metadata = test_sentences_dict.get("metadata", {})
+                    test_requires_context = test_sentences_dict.get(
+                        "requires_context", {}
+                    )
+
+                    if name_domains := test_sentences_dict.get("name_domains"):
+                        test_requires_context["domain"] = name_domains
+                    elif inferred_domain := test_sentences_dict.get("inferred_domain"):
+                        test_slots["domain"] = inferred_domain
+
+                    # Add context area slot
+                    if combo_info.get("context_area"):
+                        test_requires_context["area"] = {"slot": True}
+
+                    # Attach metadata so we can identify the slot combination of
+                    # whichever intent ends up winning.
+                    test_metadata["slot_combination"] = combo_name
+
+                    # Convert to hassil format
+                    intent_data.append(
+                        {
+                            "sentences": test_sentences_dict["sentences"],
+                            "slots": test_slots,
+                            "metadata": test_metadata,
+                            "requires_context": test_requires_context,
+                            "response": test_sentences_dict["response"],
+                        }
+                    )
+
+        lang_intents_dict["intents"][intent_name] = intent_dict
+
+    return Intents.from_dict(lang_intents_dict)
+
+
+def _build_slot_lists(test_dict: dict[str, Any]) -> dict[str, SlotList]:
+    """Build name/area/floor TextSlotLists from a test file, as the harness does."""
+    return {
+        "name": TextSlotList.from_tuples(
+            [
+                (
+                    e["name"],
+                    e["name"],
+                    {"domain": e["domain"]},
+                    {  # metadata
+                        "domain": e["domain"],
+                        "state": e.get("state"),
+                        "state_with_unit": e.get("state_with_unit"),
+                        "entity_id": f"{e['domain']}.{_slug(e['name'])}",
+                        "attributes": e.get("attributes", {}),
+                        "name": e["name"],
+                    },
+                )
+                for e in test_dict.get("entities", [])
+            ],
+            name="name",
+        ),
+        "area": TextSlotList.from_strings(
+            [a["name"] for a in test_dict.get("areas", [])], name="area"
+        ),
+        "floor": TextSlotList.from_strings(
+            [f["name"] for f in test_dict.get("floors", [])], name="floor"
+        ),
+    }
+
+
+def run() -> int:
+    """Run function."""
+    args = get_arguments()
+
+    with open(INTENTS_FILE, "r", encoding="utf-8") as intents_file:
+        intent_schemas = yaml.safe_load(intents_file)
+
+    if args.language is None:
+        languages = LANGUAGES
+    else:
+        languages = [args.language]
+
+    total_mismatches = 0
+    total_no_match = 0
+    total_sentences = 0
+
+    for language in languages:
+        merged_intents = _load_merged_intents(language, intent_schemas)
+
+        lang_tests_dir = TESTS_DIR / language
+        if not lang_tests_dir.is_dir():
+            continue
+
+        for intent_name, intent_info in intent_schemas.items():
+            if args.intent and (intent_name != args.intent):
+                continue
+
+            for combo_name, combo_info in intent_info["slot_combinations"].items():
+                test_file_path = (
+                    TESTS_DIR / language / intent_name / f"{combo_name}.yaml"
+                )
+                if not test_file_path.exists():
+                    continue
+
+                with open(test_file_path, "r", encoding="utf-8") as test_file:
+                    test_dict = yaml.safe_load(test_file)
+
+                slot_lists = _build_slot_lists(test_dict)
+
+                for test_group in test_dict.get("tests", []):
+                    for test_sentence in test_group.get("sentences", []):
+                        total_sentences += 1
+                        finding = check_sentence(
+                            merged_intents,
+                            slot_lists,
+                            language,
+                            intent_name,
+                            combo_name,
+                            test_sentence,
+                        )
+                        if finding is None:
+                            continue
+
+                        if finding.kind == "no_match":
+                            total_no_match += 1
+                            print(
+                                f"[WARN] No match against merged intents: "
+                                f"language={finding.language}, "
+                                f"expected_intent={finding.expected_intent}, "
+                                f"combo={finding.expected_combo}, "
+                                f"sentence='{finding.sentence}'"
+                            )
+                            continue
+
+                        total_mismatches += 1
+                        print(
+                            f"[WARN] Cross-intent over-match: "
+                            f"language={finding.language}, "
+                            f"expected_intent={finding.expected_intent}, "
+                            f"expected_combo={finding.expected_combo}, "
+                            f"sentence='{finding.sentence}' "
+                            f"-> won_intent={finding.won_intent}, "
+                            f"won_combo={finding.won_combo}, "
+                            f"won_slots={finding.won_slots}"
+                        )
+
+    print()
+    print(
+        f"Checked {total_sentences} test sentence(s) across "
+        f"{len(languages)} language(s)."
+    )
+    print(f"Cross-intent over-matches: {total_mismatches}")
+    print(f"No-match sentences: {total_no_match}")
+
+    return 1 if total_mismatches else 0

--- a/script/intentfest/check_overmatch.py
+++ b/script/intentfest/check_overmatch.py
@@ -28,15 +28,7 @@ from typing import Any, Optional
 import yaml
 from hassil import Intents, SlotList, TextSlotList, recognize_best
 
-from .const import (
-    INTENTS_FILE,
-    LANGUAGES,
-    LIST_DIR,
-    RESPONSE_DIR,
-    RULE_DIR,
-    SENTENCE_DIR,
-    TESTS_DIR,
-)
+from .const import INTENTS_FILE, LANGUAGES, LIST_DIR, RULE_DIR, SENTENCE_DIR, TESTS_DIR
 from .util import get_base_arg_parser
 
 # Sentinel area injected via intent_context, matching the slot-combination
@@ -278,7 +270,7 @@ def run() -> int:
             if args.intent and (intent_name != args.intent):
                 continue
 
-            for combo_name, combo_info in intent_info["slot_combinations"].items():
+            for combo_name in intent_info["slot_combinations"]:
                 test_file_path = (
                     TESTS_DIR / language / intent_name / f"{combo_name}.yaml"
                 )

--- a/script/intentfest/migrate_common.py
+++ b/script/intentfest/migrate_common.py
@@ -128,14 +128,15 @@ def _copy_rules(
 
     en_groups = _name_to_stem(RULE_DIR / "en", "expansion_rules")
     grouped: Dict[str, Dict[str, str]] = defaultdict(dict)
+    # name -> body for rules skipped because they are fully optional. These are
+    # inlined into the copied rules that reference them (see below) so no copied
+    # rule is left with a dangling reference to a non-existent rule.
+    skipped_optional: Dict[str, str] = {}
     for name, body in rules.items():
         try:
             not_optional(str(body))
         except vol.Invalid:
-            flags.append(
-                f"rule `<{name}>` is fully optional — cannot be a standalone "
-                "rule in the new format; inline it in templates instead."
-            )
+            skipped_optional[name] = str(body)
             continue
 
         group = en_groups.get(name) or _keyword_group(name) or "common"
@@ -146,13 +147,30 @@ def _copy_rules(
         if re.search(r"<[^>]+>", str(body)):
             flags.append(f"rule `<{name}>` references another rule — flatten it (§4).")
 
-    # A rule that survived but references a rule that was skipped (e.g. the
-    # fully-optional `<in>`) is a dangling reference: it resolves fine in the old
-    # _common.yaml but breaks the moment a new-format sentence reaches it. Flag it.
+    # Inline each skipped fully-optional rule into every copied rule body that
+    # references it, so the latent break the migration guide warns about (a
+    # copied rule referencing a rule that was never copied) cannot happen.
+    inlined_into = _inline_optional_rules(grouped, skipped_optional)
+    for ref, targets in sorted(inlined_into.items()):
+        flags.append(
+            f"inlined fully-optional `<{ref}>` into "
+            + ", ".join(f"<{name}>" for name in sorted(targets))
+            + " (it cannot be a standalone rule in the new format)."
+        )
+    for name in sorted(set(skipped_optional) - set(inlined_into)):
+        flags.append(
+            f"rule `<{name}>` is fully optional — cannot be a standalone "
+            "rule in the new format; inline it in templates instead."
+        )
+
+    # A copied rule that still references a rule that was not copied (and was not
+    # an inlinable fully-optional rule, e.g. a nested non-optional rule that got
+    # skipped) is a dangling reference: it resolves fine in the old _common.yaml
+    # but breaks the moment a new-format sentence reaches it. Flag it.
     copied = {name for group in grouped.values() for name in group}
     for group_rules in grouped.values():
         for name, body in group_rules.items():
-            for ref in sorted(set(re.findall(r"<([a-z0-9_]+)>", str(body)))):
+            for ref in sorted(set(re.findall(r"<(\w+)>", str(body)))):
                 if ref not in copied:
                     flags.append(
                         f"rule `<{name}>` references `<{ref}>`, which was NOT copied "
@@ -227,6 +245,76 @@ def _copy_lists(
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
+
+
+def _wrap_optional_body(body: str) -> str:
+    """Return ``body`` safe to splice into another rule body.
+
+    A fully-optional body is already a single bracketed/parenthesised group, so
+    it can be spliced as-is. If it is not a single fully-enclosing ``[...]`` or
+    ``(...)`` group, wrap it in ``(...)`` so surrounding precedence (e.g. an
+    enclosing alternative) cannot change its meaning.
+    """
+    body = body.strip()
+    if _is_single_enclosing_group(body):
+        return body
+    return f"({body})"
+
+
+def _is_single_enclosing_group(body: str) -> bool:
+    """True if ``body`` is one ``[...]``/``(...)`` group wrapping the whole text."""
+    if len(body) < 2 or body[0] not in "[(":
+        return False
+    closer = "]" if body[0] == "[" else ")"
+    depth = 0
+    for index, char in enumerate(body):
+        if char in "[(":
+            depth += 1
+        elif char in "])":
+            depth -= 1
+            if depth == 0:
+                # The opening bracket only encloses everything if it closes at
+                # the very end of the string.
+                return index == len(body) - 1 and char == closer
+    return False
+
+
+def _inline_optional_rules(
+    grouped: Dict[str, Dict[str, str]], skipped_optional: Dict[str, str]
+) -> Dict[str, set]:
+    """Inline skipped fully-optional rules into copied rule bodies in place.
+
+    Substitutes ``<name>`` with the (wrapped) body of each skipped fully-optional
+    rule in every grouped rule body that references it. Runs to a fixpoint so a
+    chain of optional rules also resolves. Returns a map of
+    ``{inlined_rule_name: {target_rule_name, ...}}`` for reporting.
+    """
+    inlined_into: Dict[str, set] = defaultdict(set)
+    if not skipped_optional:
+        return {}
+
+    wrapped = {
+        name: _wrap_optional_body(body) for name, body in skipped_optional.items()
+    }
+
+    # Bounded fixpoint: each pass inlines one more level of optional references.
+    for _ in range(len(skipped_optional) + 1):
+        changed = False
+        for group_rules in grouped.values():
+            for name, body in group_rules.items():
+                new_body = body
+                for ref, replacement in wrapped.items():
+                    pattern = re.compile(rf"<{re.escape(ref)}>")
+                    if pattern.search(new_body):
+                        new_body = pattern.sub(replacement, new_body)
+                        inlined_into[ref].add(name)
+                if new_body != body:
+                    group_rules[name] = new_body
+                    changed = True
+        if not changed:
+            break
+
+    return dict(inlined_into)
 
 
 def _values_have_references(values: list) -> bool:

--- a/script/intentfest/migrate_language.py
+++ b/script/intentfest/migrate_language.py
@@ -121,6 +121,7 @@ def run() -> int:
 
     result = MigrationResult()
     _migrate_sentences(args, intent, lang_intents, combos, result)
+    _check_subset_templates(result)
     _migrate_tests(args, combos, result)
     _check_required_coverage(intent_info, result)
 
@@ -531,6 +532,87 @@ def _signature_comment(signature: Signature) -> str:
     if has_context_area:
         parts.append("context_area: true")
     return "; ".join(parts)
+
+
+# -----------------------------------------------------------------------------
+# Subset / duplicate templates
+# -----------------------------------------------------------------------------
+
+
+def _strip_optionals(text: str) -> str:
+    """Remove every ``[...]`` optional group from a template, collapse spaces.
+
+    Bracket-depth aware so nested optionals are dropped wholesale. Returns the
+    text that *must* always be present, with runs of whitespace collapsed.
+    """
+    out: List[str] = []
+    depth = 0
+    for char in text:
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            out.append(char)
+    return " ".join("".join(out).split())
+
+
+def _check_subset_templates(result: MigrationResult) -> None:
+    """Flag templates unreachable as a unique best match within one combo.
+
+    Two kinds, both conservative (high precision):
+
+    * exact duplicate templates, and
+    * optional-subset: template A always matches whatever template B matches
+      because A equals B with some of B's optional ``[...]`` groups removed.
+      Approximated safely by stripping ALL optionals from both: equal stripped
+      forms with differing originals means the one with fewer optionals is a
+      subset of the other.
+
+    Such a template later fails the slot-combination harness's "every template
+    must be exercised as a unique best match" check, with a confusing symptom.
+    """
+    for combo_name, entries in result.combos.items():
+        templates = [text for entry in entries for text in entry.get("sentences", [])]
+
+        # Exact duplicates.
+        seen: Set[str] = set()
+        for text in templates:
+            if text in seen:
+                result.flags.append(
+                    Flag(
+                        "subset/duplicate templates",
+                        f"`{combo_name}`: `{text}` is an exact duplicate of an "
+                        "earlier template (unreachable as a unique best match).",
+                    )
+                )
+            seen.add(text)
+
+        # Optional-subset: compare distinct templates pairwise.
+        unique = list(dict.fromkeys(templates))
+        for i, first in enumerate(unique):
+            for second in unique[i + 1 :]:
+                if first == second:
+                    continue
+                if _strip_optionals(first) != _strip_optionals(second):
+                    continue
+                # Same required core: the one with fewer optionals matches a
+                # superset of inputs, so the other is unreachable as unique.
+                opt_first = first.count("[")
+                opt_second = second.count("[")
+                if opt_first == opt_second:
+                    continue  # too close to call — stay conservative
+                subset, superset = (
+                    (second, first) if opt_second < opt_first else (first, second)
+                )
+                result.flags.append(
+                    Flag(
+                        "subset/duplicate templates",
+                        f"`{combo_name}`: `{subset}` is subsumed by `{superset}` "
+                        "(same template minus optional `[...]` groups) — "
+                        "unreachable as a unique best match.",
+                    )
+                )
 
 
 # -----------------------------------------------------------------------------

--- a/script/intentfest/prune.py
+++ b/script/intentfest/prune.py
@@ -6,15 +6,17 @@ slot rules. Once a language is fully migrated, a lot of that copied weight is
 dead: rules no live sentence (or live rule) references, value lists nothing
 references, and response keys no sentence group's ``response:`` points at.
 
-    python3 -m script.intentfest prune --language <lang> [--write]
+    python3 -m script.intentfest prune --language <lang> [--write] [--check]
 
-Default is a dry-run report. With ``--write`` the dead rules/lists and orphaned
-response keys are removed from their files (deleting a file that becomes empty),
-preserving formatting via ``YamlDumper`` like ``migrate_common._write_yaml``. The
-``default`` response key is never auto-removed (it is commonly retained for custom
-sentences). Builds the liveness graph carefully: a rule/list is live only if a
-sentence — or another *live* rule — references it (a rule used only by another
-dead rule is itself dead). Always exits 0: this is a cleanup tool, not a gate.
+Default is a dry-run report. With ``--write`` the dead rules/lists are removed from
+their files (deleting a file that becomes empty), preserving formatting via
+``YamlDumper`` like ``migrate_common._write_yaml``; add ``--prune-responses`` to
+also drop orphaned response keys (the ``default`` key is never auto-removed — it is
+commonly retained for custom sentences). With ``--check`` the tool exits **1** if
+any dead rule or dead list exists (a CI gate to keep migrations free of dead
+weight); orphaned response keys are reported but do not fail the gate. Builds the
+liveness graph carefully: a rule/list is live only if a sentence — or another
+*live* rule — references it (a rule used only by another dead rule is itself dead).
 """
 
 from __future__ import annotations
@@ -42,7 +44,17 @@ def get_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--write",
         action="store_true",
-        help="Remove the dead items from their files (default: dry-run report).",
+        help="Remove dead rules/lists from their files (default: dry-run report).",
+    )
+    parser.add_argument(
+        "--prune-responses",
+        action="store_true",
+        help="With --write, also remove orphaned response keys (except `default`).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if any dead rule/list exists (CI gate); implies a dry run.",
     )
     return parser.parse_known_args()[0]
 
@@ -51,6 +63,21 @@ def run() -> int:
     """Run function."""
     args = get_arguments()
     language = args.language
+
+    # Pruning is only valid once a language is FULLY migrated. While old-format
+    # `<domain>_<Intent>.yaml` files remain, their templates still reference rules/
+    # lists (resolved from _common.yaml) that this tool's new-format-only liveness
+    # graph can't see, and the copied rules/lists are still needed for the intents
+    # not yet migrated. So skip partial (and unmigrated) languages instead of
+    # reporting false "dead" items.
+    if not _is_fully_migrated(language):
+        print(
+            f"# prune: {language}\n\n"
+            f"{language} is not fully migrated yet (old-format sentence files "
+            "remain, or no slot-combination intents exist). Pruning is premature "
+            "until the migration is complete — skipping."
+        )
+        return 0
 
     rule_bodies = _load_named(RULE_DIR / language, "expansion_rules")
     list_names = set(_load_named(LIST_DIR / language, "lists"))
@@ -65,8 +92,20 @@ def run() -> int:
 
     _report(language, dead_rules, dead_lists, orphans)
 
-    if args.write:
-        _write_changes(language, dead_rules, dead_lists, orphans)
+    if args.write and not args.check:
+        _write_changes(
+            language, dead_rules, dead_lists, orphans, args.prune_responses
+        )
+
+    if args.check:
+        if dead_rules or dead_lists:
+            print(
+                f"\n[FAIL] {language}: {len(dead_rules)} dead rule(s) and "
+                f"{len(dead_lists)} dead list(s) can be pruned — run "
+                f"`python3 -m script.intentfest prune --language {language} --write`."
+            )
+            return 1
+        print(f"\n[OK] {language}: no dead rules/lists.")
 
     return 0
 
@@ -219,11 +258,13 @@ def _write_changes(
     dead_rules: List[str],
     dead_lists: List[str],
     orphans: Dict[str, List[str]],
+    prune_responses: bool,
 ) -> None:
     print("\n# Removing dead items (--write):\n")
     _prune_named(RULE_DIR / language, "expansion_rules", set(dead_rules), "<{}>")
     _prune_named(LIST_DIR / language, "lists", set(dead_lists), "{{{}}}")
-    _prune_responses(language, orphans)
+    if prune_responses:
+        _prune_responses(language, orphans)
 
 
 def _prune_named(directory: Path, key: str, dead: Set[str], fmt: str) -> None:
@@ -270,6 +311,24 @@ def _prune_responses(language: str, orphans: Dict[str, List[str]]) -> None:
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
+
+
+def _is_fully_migrated(language: str) -> bool:
+    """True if the language has slot-combination intents and no old-format files.
+
+    Old-format files are the flat ``sentences/<lang>/<domain>_<Intent>.yaml`` files
+    (everything except ``_common.yaml``); slot-combination intents live in
+    per-intent subdirectories.
+    """
+    language_dir = SENTENCE_DIR / language
+    if not language_dir.is_dir():
+        return False
+    has_combo_dir = any(p.is_dir() for p in language_dir.iterdir())
+    has_old_format = any(
+        p.is_file() and p.name != "_common.yaml"
+        for p in language_dir.glob("*.yaml")
+    )
+    return has_combo_dir and not has_old_format
 
 
 def _load_named(directory: Path, key: str) -> Dict[str, str]:

--- a/script/intentfest/prune.py
+++ b/script/intentfest/prune.py
@@ -93,9 +93,7 @@ def run() -> int:
     _report(language, dead_rules, dead_lists, orphans)
 
     if args.write and not args.check:
-        _write_changes(
-            language, dead_rules, dead_lists, orphans, args.prune_responses
-        )
+        _write_changes(language, dead_rules, dead_lists, orphans, args.prune_responses)
 
     if args.check:
         if dead_rules or dead_lists:
@@ -325,8 +323,7 @@ def _is_fully_migrated(language: str) -> bool:
         return False
     has_combo_dir = any(p.is_dir() for p in language_dir.iterdir())
     has_old_format = any(
-        p.is_file() and p.name != "_common.yaml"
-        for p in language_dir.glob("*.yaml")
+        p.is_file() and p.name != "_common.yaml" for p in language_dir.glob("*.yaml")
     )
     return has_combo_dir and not has_old_format
 

--- a/script/intentfest/prune.py
+++ b/script/intentfest/prune.py
@@ -1,0 +1,299 @@
+"""Final cleanup step of a language migration: prune dead rules/lists/responses.
+
+``migrate_common`` copies *everything* out of ``_common.yaml`` into
+``rules/<lang>/`` and ``lists/<lang>/``, and the per-intent migration inlines the
+slot rules. Once a language is fully migrated, a lot of that copied weight is
+dead: rules no live sentence (or live rule) references, value lists nothing
+references, and response keys no sentence group's ``response:`` points at.
+
+    python3 -m script.intentfest prune --language <lang> [--write]
+
+Default is a dry-run report. With ``--write`` the dead rules/lists and orphaned
+response keys are removed from their files (deleting a file that becomes empty),
+preserving formatting via ``YamlDumper`` like ``migrate_common._write_yaml``. The
+``default`` response key is never auto-removed (it is commonly retained for custom
+sentences). Builds the liveness graph carefully: a rule/list is live only if a
+sentence — or another *live* rule — references it (a rule used only by another
+dead rule is itself dead). Always exits 0: this is a cleanup tool, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+import yaml
+
+from .const import LIST_DIR, RESPONSE_DIR, RULE_DIR, SENTENCE_DIR
+from .util import YamlDumper, get_base_arg_parser
+
+# Unicode-aware reference patterns: \w matches accented letters in Python 3, so
+# names like `añadir`/`habitación` are caught. Do NOT narrow these to ASCII.
+RULE_REF_RE = re.compile(r"<(\w+)>")
+LIST_REF_RE = re.compile(r"\{(\w+)(?::\w+)?\}")
+
+
+def get_arguments() -> argparse.Namespace:
+    """Get parsed passed in arguments."""
+    parser = get_base_arg_parser()
+    parser.add_argument("--language", required=True, help="Language code, e.g. en")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Remove the dead items from their files (default: dry-run report).",
+    )
+    return parser.parse_known_args()[0]
+
+
+def run() -> int:
+    """Run function."""
+    args = get_arguments()
+    language = args.language
+
+    rule_bodies = _load_named(RULE_DIR / language, "expansion_rules")
+    list_names = set(_load_named(LIST_DIR / language, "lists"))
+
+    seed_rules, seed_lists = _collect_sentence_refs(language)
+
+    live_rules, live_lists = _liveness_graph(rule_bodies, seed_rules, seed_lists)
+
+    dead_rules = sorted(set(rule_bodies) - live_rules)
+    dead_lists = sorted(list_names - live_lists)
+    orphans = _orphaned_responses(language)
+
+    _report(language, dead_rules, dead_lists, orphans)
+
+    if args.write:
+        _write_changes(language, dead_rules, dead_lists, orphans)
+
+    return 0
+
+
+# -----------------------------------------------------------------------------
+# Liveness graph
+# -----------------------------------------------------------------------------
+
+
+def _liveness_graph(
+    rule_bodies: Dict[str, str],
+    seed_rules: Set[str],
+    seed_lists: Set[str],
+) -> Tuple[Set[str], Set[str]]:
+    """Resolve which rules/lists are live.
+
+    A rule is live if a sentence references it, or another *live* rule's body
+    references it. We start from the sentence-seeded rules and expand transitively
+    through live rule bodies only — a rule reached solely via a dead rule never
+    enters the worklist, so it stays dead.
+    """
+    live_rules: Set[str] = set()
+    live_lists: Set[str] = set(seed_lists)
+
+    # Only rules that actually exist can be "live" (and propagate). A sentence may
+    # reference a rule that no longer exists; that is a dangling ref, not our job.
+    queue = [name for name in seed_rules if name in rule_bodies]
+    while queue:
+        name = queue.pop()
+        if name in live_rules:
+            continue
+        live_rules.add(name)
+        body = str(rule_bodies[name])
+        # Lists referenced by a live rule body are themselves live.
+        live_lists.update(LIST_REF_RE.findall(body))
+        # Rules referenced by a live rule body become live (and propagate).
+        for ref in RULE_REF_RE.findall(body):
+            if ref in rule_bodies and ref not in live_rules:
+                queue.append(ref)
+
+    return live_rules, live_lists
+
+
+def _collect_sentence_refs(language: str) -> Tuple[Set[str], Set[str]]:
+    """Collect every <rule> and {list} ref appearing in this language's templates."""
+    rules: Set[str] = set()
+    lists: Set[str] = set()
+    language_dir = SENTENCE_DIR / language
+    if not language_dir.is_dir():
+        return rules, lists
+
+    for intent_dir in sorted(p for p in language_dir.iterdir() if p.is_dir()):
+        for combo_file in sorted(intent_dir.glob("*.yaml")):
+            doc = yaml.safe_load(combo_file.read_text(encoding="utf-8")) or {}
+            for sentence_set in doc.get("data") or []:
+                for sentence in sentence_set.get("sentences") or []:
+                    text = str(sentence)
+                    rules.update(RULE_REF_RE.findall(text))
+                    lists.update(LIST_REF_RE.findall(text))
+    return rules, lists
+
+
+# -----------------------------------------------------------------------------
+# Orphaned response keys
+# -----------------------------------------------------------------------------
+
+
+def _orphaned_responses(language: str) -> Dict[str, List[str]]:
+    """Map each migrated intent to its orphaned response keys (incl. `default`).
+
+    A response key is orphaned if no sentence group's ``response:`` references it.
+    ``default`` is reported but flagged as often-intentional by the caller.
+    """
+    orphans: Dict[str, List[str]] = {}
+    response_dir = RESPONSE_DIR / language
+    if not response_dir.is_dir():
+        return orphans
+
+    sentence_dir = SENTENCE_DIR / language
+    for response_file in sorted(response_dir.glob("*.yaml")):
+        intent = response_file.stem
+        doc = yaml.safe_load(response_file.read_text(encoding="utf-8")) or {}
+        defined = doc.get("responses", {}).get("intents", {}).get(intent, {})
+        if not isinstance(defined, dict) or not defined:
+            continue
+
+        # Only consider intents that are actually migrated (have a sentence dir).
+        intent_sentence_dir = sentence_dir / intent
+        if not intent_sentence_dir.is_dir():
+            continue
+
+        used = _collect_used_responses(intent_sentence_dir)
+        dead_keys = sorted(key for key in defined if key not in used)
+        if dead_keys:
+            orphans[intent] = dead_keys
+    return orphans
+
+
+def _collect_used_responses(intent_sentence_dir: Path) -> Set[str]:
+    """Collect every `response:` value referenced by an intent's sentence groups."""
+    used: Set[str] = set()
+    for combo_file in sorted(intent_sentence_dir.glob("*.yaml")):
+        doc = yaml.safe_load(combo_file.read_text(encoding="utf-8")) or {}
+        for sentence_set in doc.get("data") or []:
+            response = sentence_set.get("response")
+            if response is not None:
+                used.add(str(response))
+    return used
+
+
+# -----------------------------------------------------------------------------
+# Reporting
+# -----------------------------------------------------------------------------
+
+
+def _report(
+    language: str,
+    dead_rules: List[str],
+    dead_lists: List[str],
+    orphans: Dict[str, List[str]],
+) -> None:
+    print(f"# prune: {language}\n")
+
+    print(f"Dead rules ({len(dead_rules)}):")
+    for name in dead_rules:
+        print(f"  - <{name}>")
+
+    print(f"\nDead lists ({len(dead_lists)}):")
+    for name in dead_lists:
+        print(f"  - {{{name}}}")
+
+    orphan_count = sum(len(keys) for keys in orphans.values())
+    print(f"\nOrphaned response keys ({orphan_count}):")
+    for intent in sorted(orphans):
+        for key in orphans[intent]:
+            note = " (often intentional)" if key == "default" else ""
+            print(f"  - {intent}.{key}{note}")
+
+    total = len(dead_rules) + len(dead_lists) + orphan_count
+    print(f"\nTotal dead items: {total}")
+
+
+# -----------------------------------------------------------------------------
+# Writing
+# -----------------------------------------------------------------------------
+
+
+def _write_changes(
+    language: str,
+    dead_rules: List[str],
+    dead_lists: List[str],
+    orphans: Dict[str, List[str]],
+) -> None:
+    print("\n# Removing dead items (--write):\n")
+    _prune_named(RULE_DIR / language, "expansion_rules", set(dead_rules), "<{}>")
+    _prune_named(LIST_DIR / language, "lists", set(dead_lists), "{{{}}}")
+    _prune_responses(language, orphans)
+
+
+def _prune_named(directory: Path, key: str, dead: Set[str], fmt: str) -> None:
+    """Remove dead names from every file under ``directory``, deleting empties."""
+    if not dead or not directory.is_dir():
+        return
+    for path in sorted(directory.glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        section = doc.get(key)
+        if not isinstance(section, dict):
+            continue
+        removed = [name for name in list(section) if name in dead]
+        if not removed:
+            continue
+        for name in removed:
+            del section[name]
+            print(f"  - removed {fmt.format(name)} from {path}")
+        if section:
+            _write_yaml(path, doc)
+        else:
+            path.unlink()
+            print(f"  - deleted empty {path}")
+
+
+def _prune_responses(language: str, orphans: Dict[str, List[str]]) -> None:
+    response_dir = RESPONSE_DIR / language
+    for intent in sorted(orphans):
+        # Never auto-remove `default` — it is commonly retained intentionally.
+        to_remove = [key for key in orphans[intent] if key != "default"]
+        if not to_remove:
+            continue
+        path = response_dir / f"{intent}.yaml"
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        defined = doc.get("responses", {}).get("intents", {}).get(intent, {})
+        if not isinstance(defined, dict):
+            continue
+        for key in to_remove:
+            if key in defined:
+                del defined[key]
+                print(f"  - removed {intent}.{key} from {path}")
+        _write_yaml(path, doc)
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _load_named(directory: Path, key: str) -> Dict[str, str]:
+    """Map each rule/list name in a directory to its body (merging all files)."""
+    mapping: Dict[str, str] = {}
+    if not directory.is_dir():
+        return mapping
+    for path in sorted(directory.glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for name, body in (doc.get(key) or {}).items():
+            mapping[name] = body
+    return mapping
+
+
+def _write_yaml(path: Path, doc: dict) -> Path:
+    """Write YAML preserving formatting, mirroring migrate_common._write_yaml."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = yaml.dump(
+        doc,
+        Dumper=YamlDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=10_000,
+    )
+    path.write_text(text, encoding="utf-8")
+    return path

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -33,6 +33,7 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
             "migrate_common",
             "migrate_language",
             "parse",
+            "prune",
             "report_unparsed_examples",
             "sample_template",
             "sample",

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -24,6 +24,7 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
         type=str,
         choices=[
             "add_language",
+            "check_overmatch",
             "check_slot_combinations",
             "codeowners",
             "count_sentences",

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -46,6 +46,12 @@ HA_LIST_NAMES = {"name", "area", "floor"}
 SLOT_COMBO_VALIDATION_LANGUAGES = {"en"}
 IMPORTANCE_LEVELS = {"required", "usable", "complete", "optional"}
 
+# Unicode-aware reference patterns: \w matches accented letters in Python 3, so
+# rule/list names like <añadir> or {habitación} are captured (ASCII-only classes
+# would silently drop them and mis-flag live references as dangling).
+RULE_REF_RE = re.compile(r"<(\w+)>")
+LIST_REF_RE = re.compile(r"\{(\w+)(?::\w+)?\}")
+
 
 def match_anything(value):
     """Validator that matches everything"""
@@ -681,6 +687,12 @@ def run() -> int:
         )
         available_rule_names = validate_expansion_rules(language, errors[language])
 
+        # (A) Dangling rule/list references in rules/<lang>/ (ERROR)
+        validate_rule_references(language, available_list_names, errors[language])
+
+        # (B) Un-localized example: in non-English slot-combination groups (WARN)
+        validate_localized_examples(language, warnings[language])
+
         validate_slot_combinations(
             intent_schemas,
             language,
@@ -1176,6 +1188,115 @@ def validate_expansion_rules(language: str, errors: list[str]) -> set[str]:
             lang_rule_names.update(rule_info["expansion_rules"])
 
     return lang_rule_names
+
+
+def validate_rule_references(
+    language: str,
+    available_list_names: set[str],
+    errors: list[str],
+) -> None:
+    """Check rule bodies in rules/<lang>/ for dangling rule/list references.
+
+    A reference that resolves nowhere compiles fine but breaks the moment a
+    sentence reaches it. For the slot-combination format:
+      - <ref>  must be a rule defined in rules/<lang>/
+      - {list} must be a shared/lang list (available_list_names already includes
+        the builtin name/area/floor slot lists).
+    """
+    rules_dir: Path = RULE_DIR / language
+    if not rules_dir.is_dir():
+        return
+
+    # name -> body, collected across all rule files for the language.
+    rule_bodies: dict[str, str] = {}
+    for rule_path in sorted(rules_dir.glob("*.yaml")):
+        try:
+            rule_doc = yaml.safe_load(rule_path.read_text(encoding="utf8"))
+        except yaml.YAMLError:
+            # Malformed YAML is already reported by validate_expansion_rules.
+            continue
+        if not rule_doc:
+            continue
+        rule_bodies.update(rule_doc.get("expansion_rules", {}) or {})
+
+    defined_rule_names = set(rule_bodies)
+
+    for name in sorted(rule_bodies):
+        body = str(rule_bodies[name])
+
+        for ref in sorted(set(RULE_REF_RE.findall(body))):
+            if ref not in defined_rule_names:
+                errors.append(
+                    f"rules/{language}/: expansion rule <{name}> references "
+                    f"undefined rule <{ref}> (not defined in rules/{language}/)"
+                )
+
+        for list_name in sorted(set(LIST_REF_RE.findall(body))):
+            if list_name not in available_list_names:
+                errors.append(
+                    f"rules/{language}/: expansion rule <{name}> references "
+                    f"undefined list {{{list_name}}} (not in lists/, "
+                    f"lists/{language}/, or builtin slot lists)"
+                )
+
+
+def validate_localized_examples(language: str, warnings: list[str]) -> None:
+    """Warn when a non-English slot-combination group has an un-localized example.
+
+    A missing/empty example, or one byte-identical to the matching English
+    group's example, is a strong signal the English placeholder was copied and
+    never localized. This is a soft signal, so keep it a WARN.
+    """
+    if language == "en":
+        return
+
+    sentence_dir = SENTENCE_DIR / language
+    if not sentence_dir.is_dir():
+        return
+
+    en_sentence_dir = SENTENCE_DIR / "en"
+
+    for combo_path in sorted(sentence_dir.glob("*/*.yaml")):
+        intent_name = combo_path.parent.name
+        combo_name = combo_path.stem
+        rel_path = str(combo_path.relative_to(ROOT))
+
+        try:
+            combo_doc = yaml.safe_load(combo_path.read_text(encoding="utf8"))
+        except yaml.YAMLError:
+            # Malformed YAML is already reported elsewhere.
+            continue
+        if not combo_doc:
+            continue
+
+        en_path = en_sentence_dir / intent_name / f"{combo_name}.yaml"
+        en_examples: list[Any] = []
+        if en_path.exists():
+            try:
+                en_doc = yaml.safe_load(en_path.read_text(encoding="utf8"))
+            except yaml.YAMLError:
+                en_doc = None
+            if en_doc:
+                en_examples = [
+                    group.get("example") for group in en_doc.get("data", []) or []
+                ]
+
+        for index, group in enumerate(combo_doc.get("data", []) or []):
+            example = group.get("example")
+
+            if not example or (isinstance(example, str) and not example.strip()):
+                warnings.append(
+                    f"{rel_path}: group #{index + 1} has a missing/empty example "
+                    "(should be localized)"
+                )
+                continue
+
+            en_example = en_examples[index] if index < len(en_examples) else None
+            if en_example is not None and example == en_example:
+                warnings.append(
+                    f"{rel_path}: group #{index + 1} example is identical to the "
+                    f"English example ('{example}') - likely not localized"
+                )
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_check_overmatch.py
+++ b/tests/test_check_overmatch.py
@@ -1,0 +1,109 @@
+"""Tests for the intentfest ``check_overmatch`` cross-intent probe."""
+
+from hassil import Intents, TextSlotList
+
+from script.intentfest.check_overmatch import check_sentence
+
+
+def _build_intents() -> Intents:
+    """A tiny two-intent language where one intent greedily steals the other.
+
+    ``GreedyPlay`` has a wildcard ``{search_query}`` that swallows almost any
+    sentence, including the one that should belong to ``LightSet`` -- this is the
+    same shape as the real es bug ("pon la luz al máximo" stolen by
+    HassMediaSearchAndPlay's greedy wildcard).
+    """
+    return Intents.from_dict(
+        {
+            "language": "xx",
+            "lists": {
+                "search_query": {"wildcard": True},
+                "name": {"values": ["the lamp"]},
+            },
+            "intents": {
+                "LightSet": {
+                    "data": [
+                        {
+                            # Requires the {name} list to match; if that list is
+                            # absent at recognize time, this never fires.
+                            "sentences": ["set {name} to max"],
+                            "metadata": {"slot_combination": "name_only"},
+                        }
+                    ]
+                },
+                "GreedyPlay": {
+                    "data": [
+                        {
+                            "sentences": ["play {search_query}", "set {search_query}"],
+                            "metadata": {"slot_combination": "query_only"},
+                        }
+                    ]
+                },
+            },
+        }
+    )
+
+
+def test_check_sentence_flags_cross_intent_overmatch():
+    """The greedy intent stealing a LightSet utterance is reported.
+
+    The utterance is one LightSet has no template for (a template gap), so only
+    GreedyPlay's wildcard matches it -- a cross-intent false positive that the
+    per-intent suite, scoped to LightSet's own Intents, would never surface.
+    """
+    intents = _build_intents()
+    finding = check_sentence(
+        intents,
+        slot_lists={
+            "name": TextSlotList.from_strings(["the lamp"], name="name"),
+        },
+        language="xx",
+        expected_intent="LightSet",
+        expected_combo="name_only",
+        sentence="set the lamp to maximum brightness",
+    )
+
+    assert finding is not None
+    assert finding.kind == "mismatch"
+    assert finding.won_intent == "GreedyPlay"
+    assert finding.won_combo == "query_only"
+
+
+def test_check_sentence_passes_when_expected_intent_wins():
+    """A sentence only its own intent matches yields no finding."""
+    intents = _build_intents()
+    finding = check_sentence(
+        intents,
+        slot_lists={},
+        language="xx",
+        expected_intent="GreedyPlay",
+        expected_combo="query_only",
+        sentence="play some jazz",
+    )
+
+    assert finding is None
+
+
+def test_check_sentence_reports_no_match():
+    """A sentence nothing recognizes is reported as a no-match."""
+    intents = Intents.from_dict(
+        {
+            "language": "xx",
+            "intents": {
+                "LightSet": {
+                    "data": [{"sentences": ["turn on the light"]}],
+                },
+            },
+        }
+    )
+    finding = check_sentence(
+        intents,
+        slot_lists={},
+        language="xx",
+        expected_intent="LightSet",
+        expected_combo="name_only",
+        sentence="completely unrelated gibberish xyzzy",
+    )
+
+    assert finding is not None
+    assert finding.kind == "no_match"

--- a/tests/test_check_overmatch.py
+++ b/tests/test_check_overmatch.py
@@ -1,8 +1,15 @@
 """Tests for the intentfest ``check_overmatch`` cross-intent probe."""
 
+import importlib
+from typing import Any
+
 from hassil import Intents, TextSlotList
 
-from script.intentfest.check_overmatch import check_sentence
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+_check_overmatch: Any = importlib.import_module("script.intentfest.check_overmatch")
+check_sentence = _check_overmatch.check_sentence
 
 
 def _build_intents() -> Intents:

--- a/tests/test_migrate_common.py
+++ b/tests/test_migrate_common.py
@@ -1,0 +1,63 @@
+"""Tests for the intentfest ``migrate_common`` rule inlining."""
+
+import importlib
+from typing import Any
+
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+_migrate_common: Any = importlib.import_module("script.intentfest.migrate_common")
+# pylint: disable=protected-access
+_inline_optional_rules = _migrate_common._inline_optional_rules
+_is_single_enclosing_group = _migrate_common._is_single_enclosing_group
+_wrap_optional_body = _migrate_common._wrap_optional_body
+# pylint: enable=protected-access
+
+
+def test_is_single_enclosing_group():
+    """Only a single bracket/paren enclosing the whole string counts."""
+    assert _is_single_enclosing_group("[en|de]")
+    assert _is_single_enclosing_group("([en|de] el)")
+    assert not _is_single_enclosing_group("[en] [de]")  # two groups
+    assert not _is_single_enclosing_group("en [el]")  # leading text
+    assert not _is_single_enclosing_group("plain")
+
+
+def test_wrap_optional_body_keeps_single_group():
+    """An already-enclosing optional body is spliced as-is; others are wrapped."""
+    assert _wrap_optional_body("[[en|de] [el|la]|del]") == "[[en|de] [el|la]|del]"
+    assert _wrap_optional_body("[en] [el]") == "([en] [el])"
+
+
+def test_inline_optional_rules_substitutes_and_reports():
+    """A skipped optional rule is inlined into every referencing copied rule."""
+    grouped = {
+        "common": {
+            "area": "<en_el> {area}",
+            "planta": "<en_el> {floor}",
+            "unrelated": "{name}",
+        }
+    }
+    skipped_optional = {"en_el": "[[en|de] [el|la]|del]"}
+
+    inlined = _inline_optional_rules(grouped, skipped_optional)
+
+    assert grouped["common"]["area"] == "[[en|de] [el|la]|del] {area}"
+    assert grouped["common"]["planta"] == "[[en|de] [el|la]|del] {floor}"
+    assert grouped["common"]["unrelated"] == "{name}"  # untouched
+    assert inlined == {"en_el": {"area", "planta"}}
+
+
+def test_inline_optional_rules_resolves_chain():
+    """A chain of optional rules resolves to a fixpoint."""
+    grouped = {"common": {"area": "<en_el> {area}"}}
+    skipped_optional = {
+        "en_el": "[<de> [el|la]]",
+        "de": "[en|de]",
+    }
+
+    inlined = _inline_optional_rules(grouped, skipped_optional)
+
+    assert "<en_el>" not in grouped["common"]["area"]
+    assert "<de>" not in grouped["common"]["area"]
+    assert "area" in inlined["en_el"]

--- a/tests/test_migrate_language.py
+++ b/tests/test_migrate_language.py
@@ -1,0 +1,70 @@
+"""Tests for the intentfest ``migrate_language`` subset/duplicate detector."""
+
+import importlib
+from typing import Any
+
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+_migrate_language: Any = importlib.import_module("script.intentfest.migrate_language")
+# pylint: disable=protected-access
+_strip_optionals = _migrate_language._strip_optionals
+_check_subset_templates = _migrate_language._check_subset_templates
+# pylint: enable=protected-access
+_MigrationResult = _migrate_language.MigrationResult
+
+
+def test_strip_optionals():
+    """All optional groups (incl. nested) are removed and whitespace collapsed."""
+    assert _strip_optionals("enciende [la] luz") == "enciende luz"
+    assert _strip_optionals("enciende [la [gran]] luz") == "enciende luz"
+    assert _strip_optionals("enciende la luz") == "enciende la luz"
+
+
+def _subset_details(result):
+    return [
+        flag.detail
+        for flag in result.flags
+        if flag.category == "subset/duplicate templates"
+    ]
+
+
+def test_flags_exact_duplicate():
+    result = _MigrationResult()
+    result.combos = {
+        "name_only": [{"sentences": ["enciende {name}", "enciende {name}"]}]
+    }
+    _check_subset_templates(result)
+    details = _subset_details(result)
+    assert len(details) == 1
+    assert "exact duplicate" in details[0]
+
+
+def test_flags_optional_subset():
+    result = _MigrationResult()
+    result.combos = {
+        "name_only": [{"sentences": ["enciende {name}", "enciende [la] {name}"]}]
+    }
+    _check_subset_templates(result)
+    details = _subset_details(result)
+    assert len(details) == 1
+    # The one without the optional is the subset, subsumed by the one with it.
+    assert "`enciende {name}`" in details[0]
+    assert "subsumed by" in details[0]
+
+
+def test_no_false_positive_on_distinct_required_text():
+    result = _MigrationResult()
+    result.combos = {"name_only": [{"sentences": ["enciende {name}", "apaga {name}"]}]}
+    _check_subset_templates(result)
+    assert not _subset_details(result)
+
+
+def test_no_flag_when_optional_count_ties():
+    """Different optionals but equal count is too close to call — stay quiet."""
+    result = _MigrationResult()
+    result.combos = {
+        "name_only": [{"sentences": ["[por favor] {name}", "{name} [ahora]"]}]
+    }
+    _check_subset_templates(result)
+    assert not _subset_details(result)

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,6 +1,13 @@
 """Tests for the intentfest ``prune`` liveness graph."""
 
-from script.intentfest.prune import _liveness_graph
+import importlib
+from typing import Any
+
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+_prune: Any = importlib.import_module("script.intentfest.prune")
+_liveness_graph = _prune._liveness_graph  # pylint: disable=protected-access
 
 
 def test_liveness_graph_drops_dead_keeps_transitive():

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,0 +1,42 @@
+"""Tests for the intentfest ``prune`` liveness graph."""
+
+from script.intentfest.prune import _liveness_graph
+
+
+def test_liveness_graph_drops_dead_keeps_transitive():
+    """A rule reached only via a dead rule is dead; transitive live rules stay.
+
+    Graph:
+      sentence -> <a>
+      <a> -> <b>            (b is live: reached from a live rule)
+      <c> -> <d>            (c, d are dead: nothing live reaches them)
+    """
+    rule_bodies = {
+        "a": "hello <b>",
+        "b": "world",
+        "c": "<d> unused",
+        "d": "leaf",
+    }
+    live_rules, _ = _liveness_graph(rule_bodies, seed_rules={"a"}, seed_lists=set())
+
+    assert live_rules == {"a", "b"}
+    assert "c" not in live_rules  # unreferenced root is dead
+    assert "d" not in live_rules  # referenced only by the dead root is dead
+
+
+def test_liveness_graph_collects_lists_unicode():
+    """Lists in live rule bodies are live; accented names survive the regex."""
+    rule_bodies = {
+        # Unicode-aware: the accented rule/list names must be picked up.
+        "añadir": "pon {habitación} en {brightness:level}",
+        "muerto": "{nunca}",  # list reachable only via a dead rule
+    }
+    live_rules, live_lists = _liveness_graph(
+        rule_bodies, seed_rules={"añadir"}, seed_lists={"seed_list"}
+    )
+
+    assert live_rules == {"añadir"}
+    assert "habitación" in live_lists  # accented list name not dropped
+    assert "brightness" in live_lists  # slot-form {list:slot} captured
+    assert "seed_list" in live_lists
+    assert "nunca" not in live_lists  # only a dead rule references it

--- a/tests/test_validate_rule_references.py
+++ b/tests/test_validate_rule_references.py
@@ -1,8 +1,14 @@
 """Tests for validate.validate_rule_references (dangling rule/list refs)."""
 
+import importlib
+from typing import Any
+
 import yaml
 
-from script.intentfest import validate
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+validate: Any = importlib.import_module("script.intentfest.validate")
 
 
 def _write_rules(rules_dir, language, rules):
@@ -34,7 +40,7 @@ def test_clean_rules_no_errors(tmp_path, monkeypatch):
         errors=errors,
     )
 
-    assert errors == []
+    assert not errors
 
 
 def test_dangling_rule_reference_errors(tmp_path, monkeypatch):
@@ -90,7 +96,7 @@ def test_unicode_reference_names_resolve(tmp_path, monkeypatch):
         errors=errors,
     )
 
-    assert errors == []
+    assert not errors
 
 
 def test_slot_form_list_reference(tmp_path, monkeypatch):
@@ -105,4 +111,4 @@ def test_slot_form_list_reference(tmp_path, monkeypatch):
         errors=errors,
     )
 
-    assert errors == []
+    assert not errors

--- a/tests/test_validate_rule_references.py
+++ b/tests/test_validate_rule_references.py
@@ -1,0 +1,108 @@
+"""Tests for validate.validate_rule_references (dangling rule/list refs)."""
+
+import yaml
+
+from script.intentfest import validate
+
+
+def _write_rules(rules_dir, language, rules):
+    lang_dir = rules_dir / language
+    lang_dir.mkdir(parents=True, exist_ok=True)
+    (lang_dir / "common.yaml").write_text(
+        yaml.safe_dump({"language": language, "expansion_rules": rules}),
+        encoding="utf-8",
+    )
+
+
+def test_clean_rules_no_errors(tmp_path, monkeypatch):
+    """A rule body whose refs all resolve produces no errors."""
+    monkeypatch.setattr(validate, "RULE_DIR", tmp_path)
+    _write_rules(
+        tmp_path,
+        "xx",
+        {
+            "turn": "(turn|switch)",
+            "act": "<turn> [<the>] {name}",
+            "the": "[the]",
+        },
+    )
+
+    errors: list[str] = []
+    validate.validate_rule_references(
+        "xx",
+        available_list_names={"name", "area", "floor"},
+        errors=errors,
+    )
+
+    assert errors == []
+
+
+def test_dangling_rule_reference_errors(tmp_path, monkeypatch):
+    """A <ref> not defined in rules/<lang>/ is reported as an error."""
+    monkeypatch.setattr(validate, "RULE_DIR", tmp_path)
+    _write_rules(tmp_path, "xx", {"act": "<turn> the light"})
+
+    errors: list[str] = []
+    validate.validate_rule_references(
+        "xx",
+        available_list_names={"name", "area", "floor"},
+        errors=errors,
+    )
+
+    assert len(errors) == 1
+    assert "<act>" in errors[0]
+    assert "<turn>" in errors[0]
+
+
+def test_dangling_list_reference_errors(tmp_path, monkeypatch):
+    """A {list} not in available lists is reported as an error."""
+    monkeypatch.setattr(validate, "RULE_DIR", tmp_path)
+    _write_rules(tmp_path, "xx", {"act": "set to {missing_list}"})
+
+    errors: list[str] = []
+    validate.validate_rule_references(
+        "xx",
+        available_list_names={"name", "area", "floor"},
+        errors=errors,
+    )
+
+    assert len(errors) == 1
+    assert "<act>" in errors[0]
+    assert "{missing_list}" in errors[0]
+
+
+def test_unicode_reference_names_resolve(tmp_path, monkeypatch):
+    """Accented rule/list names are captured and resolve (no false positives)."""
+    monkeypatch.setattr(validate, "RULE_DIR", tmp_path)
+    _write_rules(
+        tmp_path,
+        "es",
+        {
+            "añadir": "pon <continúa> {habitación}",
+            "continúa": "[continúa]",
+        },
+    )
+
+    errors: list[str] = []
+    validate.validate_rule_references(
+        "es",
+        available_list_names={"habitación", "name"},
+        errors=errors,
+    )
+
+    assert errors == []
+
+
+def test_slot_form_list_reference(tmp_path, monkeypatch):
+    """A {list:slot} reference resolves on the list name part."""
+    monkeypatch.setattr(validate, "RULE_DIR", tmp_path)
+    _write_rules(tmp_path, "xx", {"act": "to {brightness:level}"})
+
+    errors: list[str] = []
+    validate.validate_rule_references(
+        "xx",
+        available_list_names={"brightness"},
+        errors=errors,
+    )
+
+    assert errors == []


### PR DESCRIPTION
Improvements to the slot-combination migration tooling, distilled from doing the full Spanish migration (#3890) and its adversarial review. Goal: make "is a migration done correctly?" enforceable by CI instead of relying on a human/adversarial reviewer.

## New CI gates (enforce migration correctness)

- **`check_overmatch` subcommand + CI step.** The slot-combination test suite only asserts `intent.name == expected` *within* one intent, so it structurally cannot catch one intent stealing another's utterance. `check_overmatch` compiles all of a language's migrated intents into a single `Intents` (mirroring `tests/test_slot_combinations.py`'s loader) and re-recognizes every test sentence across the merged set, failing if the winning intent differs from the test's own. This is exactly the class of bug found in the ES review (e.g. "pon la luz al máximo" stolen by `HassMediaSearchAndPlay`'s greedy `{search_query}`).
- **`prune --check` CI step.** Fails CI when a **fully-migrated** language carries dead rules/lists (dead weight `migrate_common` copies in and the per-intent migration inlines away). Partially-migrated and unmigrated languages are skipped (their copied rules/lists are still needed, and old-format files reference them).
- **`validate` now errors on dangling rule/list references** in `rules/<lang>/` (every `<rule>`/`{list}` a rule body uses must resolve) — the latent break the guide warns about (`<en_el>`/`<class>`), now caught at validate time instead of when a sentence first reaches it. Also a **warning for un-localized `example:`** (missing, or byte-identical to `en`).

Both new gates are wired into `.github/workflows/ci.yaml` for the affected languages (all migrated languages on a full run).

## New cleanup tool

- **`prune` subcommand** — codifies the guide's final prune step: builds a liveness graph (a rule/list is live only if a sentence, or another *live* rule, references it) and reports/`--write`s dead rules+lists; orphaned response keys are reported (removal behind `--prune-responses`, never auto-removing `default`). Unicode-aware references throughout (Python `[a-zA-Z]` silently drops `ñ/í` — a bug I hit hand-writing this for ES).

## Authoring-tool ergonomics

- **`migrate_common` auto-inlines skipped fully-optional rules** (e.g. `<en_el>`) into the copied rules that reference them, so Step 0 no longer leaves dangling references for a human to fix by hand (and its dangling-ref scan is now Unicode-aware).
- **`migrate_language` flags subset/duplicate templates** within a combo (exact duplicates, and templates subsumed by another with extra optionals) — these are unreachable as a unique best match and otherwise fail the "every template must be exercised" check with a confusing symptom.

## Repo cleanup required by the new gate

- **`en`: pruned dead expansion rules** (unused `<timer_duration>`/`<timer_start>` composites + `<currently>`/`<percent>`/`<state>`), found by `prune`, so the new gate is green. `de`/`nl` were already clean; `fr` is partially migrated so it's skipped.

## Guide updates

- An **en-parity filter** for the dropped-phrasing review angle (a phrasing is only a regression if `en`/`intents.yaml` has a combo to hold it — otherwise it's a by-design model limit), and a **Romance-language slot-absorption gotcha** (a wildcard or `{area}`/`{name}` next to a prepositional phrase over-absorbs it — "puerta del garaje", "Avatar la película").

## Not done (intentionally)

- One earlier idea — "`migrate_common` reports `Wrote 0 files`" — turned out **not** to be a bug (a fresh run correctly reports the count; I'd misread a second run where the files already existed), so it was dropped.

## Verification

- Full lint clean (black/isort/flake8, pylint 10.00/10).
- `validate` across all languages → All good! (no dangling-ref errors).
- `python3 -m pytest tests/` → **22327 passed** (includes new unit tests for `prune`, `check_overmatch`, the validate checks, `migrate_common`, and `migrate_language`).
- New gates verified locally: `check_overmatch` and `prune --check` pass for `en`/`de`/`nl`, skip `fr` appropriately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0121mwkLQ1cevRn3saJDFjMM)_