### PR TITLE
Auto-detect fully-migrated languages instead of LANGUAGES_TO_TEST

### DIFF
--- a/docs/syntax_migration_guide.md
+++ b/docs/syntax_migration_guide.md
@@ -612,15 +612,6 @@ weight. Delete the blocks that have moved to their new homes:
   > resolution for this language (it reads that file). If you still need `parse`
   > during the adversarial review, restore it temporarily and delete it again.
 
-- **The required-coverage gate turns on automatically.** Once no flat
-  `<domain>_<intent>.yaml` files remain, `tests/test_slot_combinations.py` treats
-  the language as fully migrated (`is_fully_migrated()`) and starts asserting that
-  every `required` combo has a sentence+test file. Existing combo files are always
-  fully tested regardless; the gate only adds this completeness check (partial
-  migrations are exempt so in-progress work doesn't fail). No manual list to
-  update — just run the tests after deleting the last flat file and fix any
-  newly-failing required combos.
-
 Then run `validate` + the tests one last time to confirm the language is green
 with `_common.yaml` slimmed down.
 

--- a/docs/syntax_migration_guide.md
+++ b/docs/syntax_migration_guide.md
@@ -612,23 +612,14 @@ weight. Delete the blocks that have moved to their new homes:
   > resolution for this language (it reads that file). If you still need `parse`
   > during the adversarial review, restore it temporarily and delete it again.
 
-  Once the last flat file is gone, `tests/test_slot_combinations.py` detects the
-  language as **fully migrated** automatically (`is_fully_migrated()` — no legacy
-  `<domain>_<intent>.yaml` files left beside the slot-combination subdirectories)
-  and turns on the **required-coverage gate** for it.
-
-  The gate only governs **completeness**, not whether the language is testable.
-  Every slot-combination file a language has — partial or full — is always fully
-  exercised (matching, slots, responses, template coverage); a combo that has no
-  test file is simply skipped. The gate adds one extra assertion on top of that:
-  for a fully migrated language, a `required` combo that has **no** sentence+test
-  file is a hard failure. A partially migrated language is deliberately exempt,
-  because mid-migration it legitimately hasn't created every required combo yet,
-  so enforcing completeness would just produce false failures and block
-  incremental work. So deleting the last flat file is what flips the gate from
-  "test what's here" to "and require the full `required` set" — run the tests
-  right after and fix any newly-failing required combos. There is no manual list
-  to update.
+- **The required-coverage gate turns on automatically.** Once no flat
+  `<domain>_<intent>.yaml` files remain, `tests/test_slot_combinations.py` treats
+  the language as fully migrated (`is_fully_migrated()`) and starts asserting that
+  every `required` combo has a sentence+test file. Existing combo files are always
+  fully tested regardless; the gate only adds this completeness check (partial
+  migrations are exempt so in-progress work doesn't fail). No manual list to
+  update — just run the tests after deleting the last flat file and fix any
+  newly-failing required combos.
 
 Then run `validate` + the tests one last time to confirm the language is green
 with `_common.yaml` slimmed down.

--- a/docs/syntax_migration_guide.md
+++ b/docs/syntax_migration_guide.md
@@ -612,12 +612,16 @@ weight. Delete the blocks that have moved to their new homes:
   > resolution for this language (it reads that file). If you still need `parse`
   > during the adversarial review, restore it temporarily and delete it again.
 
-- **Add the language to `LANGUAGES_TO_TEST` in `tests/test_slot_combinations.py`.**
-  Until the language is in this set, the suite runs the matching/coverage checks
-  for any combo files that exist but does **not** enforce that every `required`
-  combo actually has a sentence+test file (`do_test_slot_combination` only asserts
-  the file exists for languages in `LANGUAGES_TO_TEST`). Adding it turns on that
-  required-coverage gate — do it last and fix any newly-failing required combos.
+  Once the last flat file is gone, `tests/test_slot_combinations.py` detects the
+  language as **fully migrated** automatically (`is_fully_migrated()` — no legacy
+  `<domain>_<intent>.yaml` files left beside the slot-combination subdirectories)
+  and turns on the **required-coverage gate** for it: it now enforces that every
+  `required` combo actually has a sentence+test file, not just that the combo
+  files which exist match. (Before that point the suite still runs the
+  matching/coverage checks for any combo files present, but does not require the
+  full `required` set.) So deleting the last flat file is what flips the gate on —
+  run the tests right after and fix any newly-failing required combos. There is no
+  manual list to update.
 
 Then run `validate` + the tests one last time to confirm the language is green
 with `_common.yaml` slimmed down.

--- a/docs/syntax_migration_guide.md
+++ b/docs/syntax_migration_guide.md
@@ -615,13 +615,20 @@ weight. Delete the blocks that have moved to their new homes:
   Once the last flat file is gone, `tests/test_slot_combinations.py` detects the
   language as **fully migrated** automatically (`is_fully_migrated()` — no legacy
   `<domain>_<intent>.yaml` files left beside the slot-combination subdirectories)
-  and turns on the **required-coverage gate** for it: it now enforces that every
-  `required` combo actually has a sentence+test file, not just that the combo
-  files which exist match. (Before that point the suite still runs the
-  matching/coverage checks for any combo files present, but does not require the
-  full `required` set.) So deleting the last flat file is what flips the gate on —
-  run the tests right after and fix any newly-failing required combos. There is no
-  manual list to update.
+  and turns on the **required-coverage gate** for it.
+
+  The gate only governs **completeness**, not whether the language is testable.
+  Every slot-combination file a language has — partial or full — is always fully
+  exercised (matching, slots, responses, template coverage); a combo that has no
+  test file is simply skipped. The gate adds one extra assertion on top of that:
+  for a fully migrated language, a `required` combo that has **no** sentence+test
+  file is a hard failure. A partially migrated language is deliberately exempt,
+  because mid-migration it legitimately hasn't created every required combo yet,
+  so enforcing completeness would just produce false failures and block
+  incremental work. So deleting the last flat file is what flips the gate from
+  "test what's here" to "and require the full `required` set" — run the tests
+  right after and fix any newly-failing required combos. There is no manual list
+  to update.
 
 Then run `validate` + the tests one last time to confirm the language is green
 with `_common.yaml` slimmed down.

--- a/tests/test_slot_combinations.py
+++ b/tests/test_slot_combinations.py
@@ -5,7 +5,7 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from functools import partial
+from functools import lru_cache, partial
 from typing import Any, Optional
 
 import pytest
@@ -81,7 +81,26 @@ def _build_fixtures(test_dict: dict[str, Any]) -> dict[str, Any]:
 
 CONTEXT_AREA_NAME = "__context_area__"
 TEST_DATETIME = datetime(year=2013, month=9, day=17, hour=1, minute=2)
-LANGUAGES_TO_TEST = {"en", "de", "es", "fr"}
+
+
+@lru_cache(maxsize=None)
+def is_fully_migrated(language: str) -> bool:
+    """Return True if a language has fully migrated to the slot-combination format.
+
+    A language is considered fully migrated once its sentences live in per-intent
+    slot-combination subdirectories (``sentences/<lang>/<Intent>/<combo>.yaml``) and
+    no legacy flat ``sentences/<lang>/<domain>_<intent>.yaml`` files remain (only
+    ``_common.yaml`` is allowed alongside the subdirectories).
+
+    The required-combo coverage gate is only enforced for fully migrated languages,
+    so this is detected automatically instead of maintaining a hand-kept list.
+    """
+    lang_dir = SENTENCES_DIR / language
+    has_combo_dirs = any(child.is_dir() for child in lang_dir.iterdir())
+    has_legacy_files = any(
+        path.name != "_common.yaml" for path in lang_dir.glob("*.yaml")
+    )
+    return has_combo_dirs and not has_legacy_files
 
 
 @dataclass
@@ -228,7 +247,7 @@ def do_test_slot_combination(
         f"file={test_file_path.relative_to(BASE_DIR)}"
     )
 
-    if (lang_resources.language in LANGUAGES_TO_TEST) and (
+    if is_fully_migrated(lang_resources.language) and (
         (combo_info.get("importance") == "required")
         or (
             "required" in combo_info.get("name_domains", {})


### PR DESCRIPTION
## Summary

`tests/test_slot_combinations.py` enforced the required-combo coverage gate only for languages listed in a hand-maintained `LANGUAGES_TO_TEST = {"en", "de", "es", "fr"}` set. That list had already gone stale: `nl` is fully migrated but wasn't listed, so its required combos were never enforced.

This replaces the manual set with `is_fully_migrated(language)`, which detects a fully-migrated language directly from the filesystem: it has per-intent slot-combination subdirectories and no legacy flat `<domain>_<intent>.yaml` sentence files left (only `_common.yaml`). The gate now switches on automatically the moment the last flat file is deleted — there's no list to keep up to date.

## Why only gate fully-migrated languages

The gate governs **completeness, not testability**. Every slot-combination file a language has — partial or full — is always fully exercised (matching, slots, responses, template coverage); a combo with no test file is simply skipped. The gate adds exactly one assertion on top: for a fully-migrated language, a `required` combo with **no** sentence+test file is a hard failure. Partial migrations are deliberately exempt, because mid-migration a language legitimately hasn't created every required combo yet — enforcing completeness there would produce false failures and block incremental work.

## Notes

- This newly enforces required coverage on `nl` (previously silently exempt). It passes today.
- The migration guide's final-cleanup step is updated: deleting the last flat file is now what flips the gate on, replacing the old "add the language to `LANGUAGES_TO_TEST`" step.

## Testing

- `pytest tests/test_slot_combinations.py --language en,de,es,fr,nl,hu,it` → 1477 passed (`nl` now passes with the gate enabled; partially-migrated `hu`/`it` correctly not over-enforced).
- `black` / `isort` / `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmXvMt2fChLt2tuDj1WqLX)_