### PR TITLE
Fix script/test so --language works (loads tests/conftest.py)

### DIFF
--- a/script/test
+++ b/script/test
@@ -16,4 +16,8 @@ if [ -d "${venv}" ]; then
 fi
 
 python3 -m script.intentfest validate "$@"
-pytest -vv -n auto "$@"
+# Pass the "tests" path explicitly so pytest loads tests/conftest.py as an
+# initial conftest. Without a path, pytest relies on `testpaths`, which does not
+# register conftest options early enough, so `--language` (defined in
+# tests/conftest.py via pytest_addoption) is rejected as an unknown argument.
+pytest -vv -n auto tests "$@"


### PR DESCRIPTION
## Problem

`script/test --language <lang>` fails with `pytest: error: unrecognized arguments: --language` for any PR whose changes are confined to `sentences/`, `responses/`, or `tests/`. CI's `extract-languages` step only emits a non-empty `--language` in exactly that case (a change outside those dirs makes it run full tests instead), so the bug is normally masked — most language PRs also touch `rules/`/`lists/`, taking the full-test path. A migration that creates no `rules/`/`lists/` (e.g. mn, PR #3912) hits the `--language` path and fails CI.

## Cause

`script/test` ran `pytest -vv -n auto "$@"` with **no test path**. Without a path, pytest uses `testpaths` for collection but does **not** load `tests/conftest.py` as an *initial* conftest, so `pytest_addoption("--language")` (defined there) is never registered → the argument is rejected before collection.

## Fix

Pass the `tests` path explicitly: `pytest -vv -n auto tests "$@"`. This makes pytest load `tests/conftest.py` as an initial conftest, registering `--language`. Verified locally: `pytest tests --language en` collects 357 tests, whereas `pytest --language en` errors.

No behavior change for the no-arg `script/test` case (`tests` is already the sole `testpaths` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BW5FhdPgJr9rzMhmXtpBS

---
_Generated by [Claude Code](https://claude.ai/code/session_016BW5FhdPgJr9rzMhmXtpBS)_