### PR TITLE
Add missing en floor_domain / floor_device_class_cover for HassTurnOn/Off

### DIFF
--- a/sentences/en/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/en/HassTurnOff/floor_device_class_cover.yaml
@@ -1,0 +1,16 @@
+---
+# HassTurnOff - floor_device_class_cover
+# example: close the curtains on the first floor
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "en"
+data:
+  - sentences:
+      - "<close> [<all>] [<the>] {cover_classes:device_class} <in> [<the>] {floor} [floor]"
+      - "<close> [<all>] [<the>] {floor} [floor] {cover_classes:device_class}"
+    example: "close the curtains on the first floor"
+    inferred_domain: "cover"
+    response: "cover_device_class"

--- a/sentences/en/HassTurnOff/floor_domain.yaml
+++ b/sentences/en/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,22 @@
+---
+# HassTurnOff - floor_domain
+# example: turn off the lights on the first floor
+# slots:
+# - {floor}
+# - {domain}
+
+language: "en"
+
+data:
+  # lights
+  - sentences:
+      - "[<the>] {floor} [floor] <light> (off|out)"
+      - "<light> (off|out) <in> [<the>] {floor} [floor]"
+      - "<turn> (off|out) [<all>] [<the>] {floor} [floor] <light>"
+      - "<turn> (off|out) [(<all>|<the>)] <light> <in> [<the>] {floor} [floor]"
+      - "<turn> [<all>] [<the>] {floor} [floor] <light> (off|out)"
+      - "deactivate [<all>] [<the>] {floor} [floor] <light>"
+      - "deactivate [(<all>|<the>)] <light> <in> [<the>] {floor} [floor]"
+    example: "turn off the lights on the first floor"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/sentences/en/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/en/HassTurnOn/floor_device_class_cover.yaml
@@ -1,0 +1,16 @@
+---
+# HassTurnOn - floor_device_class_cover
+# example: open the curtains on the first floor
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "en"
+data:
+  - sentences:
+      - "<open> [<all>] [<the>] {cover_classes:device_class} <in> [<the>] {floor} [floor]"
+      - "<open> [<all>] [<the>] {floor} [floor] {cover_classes:device_class}"
+    example: "open the curtains on the first floor"
+    inferred_domain: "cover"
+    response: "cover_device_class"

--- a/sentences/en/HassTurnOn/floor_domain.yaml
+++ b/sentences/en/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,22 @@
+---
+# HassTurnOn - floor_domain
+# example: turn on the lights on the first floor
+# slots:
+# - {floor}
+# - {domain}
+
+language: "en"
+
+data:
+  # lights
+  - sentences:
+      - "(light up|illuminate) [<the>] {floor} [floor]"
+      - "[<the>] {floor} [floor] <light> on"
+      - "<turn> on [<all>] [<the>] {floor} [floor] <light>"
+      - "<turn> on [(<all>|<the>)] <light> <in> [<the>] {floor} [floor]"
+      - "<turn> [<all>] [<the>] {floor} [floor] <light> on"
+      - "activate [<all>] [<the>] {floor} [floor] <light>"
+      - "activate [(<all>|<the>)] <light> <in> [<the>] {floor} [floor]"
+    example: "turn on the lights on the first floor"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/tests/en/HassTurnOff/floor_device_class_cover.yaml
+++ b/tests/en/HassTurnOff/floor_device_class_cover.yaml
@@ -1,0 +1,21 @@
+---
+# HassTurnOff - floor_device_class_cover
+# example: close the curtains on the first floor
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "en"
+floors:
+  - name: "First Floor"
+
+tests:
+  - sentences:
+      - "close the curtains on the first floor"
+      - "close the first floor curtains"
+    slots:
+      floor: "First Floor"
+      domain: "cover"
+      device_class: "curtain"
+    response: "Closing the curtain"

--- a/tests/en/HassTurnOff/floor_domain.yaml
+++ b/tests/en/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,24 @@
+---
+# HassTurnOff - floor_domain
+# example: turn off the lights on the first floor
+# slots:
+# - {floor}
+# - {domain}
+
+language: "en"
+floors:
+  - name: "First Floor"
+
+tests:
+  - sentences:
+      - "first floor lights off"
+      - "lights off on the first floor"
+      - "turn off the first floor lights"
+      - "turn off the lights on the first floor"
+      - "turn the first floor lights off"
+      - "deactivate the first floor lights"
+      - "deactivate the lights on the first floor"
+    slots:
+      domain: "light"
+      floor: "First Floor"
+    response: "Turned off the lights"

--- a/tests/en/HassTurnOn/floor_device_class_cover.yaml
+++ b/tests/en/HassTurnOn/floor_device_class_cover.yaml
@@ -1,0 +1,21 @@
+---
+# HassTurnOn - floor_device_class_cover
+# example: open the curtains on the first floor
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "en"
+floors:
+  - name: "First Floor"
+
+tests:
+  - sentences:
+      - "open the curtains on the first floor"
+      - "open the first floor curtains"
+    slots:
+      floor: "First Floor"
+      domain: "cover"
+      device_class: "curtain"
+    response: "Opening the curtain"

--- a/tests/en/HassTurnOn/floor_domain.yaml
+++ b/tests/en/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,25 @@
+---
+# HassTurnOn - floor_domain
+# example: turn on the lights on the first floor
+# slots:
+# - {floor}
+# - {domain}
+
+language: "en"
+floors:
+  - name: "First Floor"
+
+tests:
+  - sentences:
+      - "light up the first floor"
+      - "illuminate the first floor"
+      - "first floor lights on"
+      - "turn on the first floor lights"
+      - "turn on the lights on the first floor"
+      - "turn the first floor lights on"
+      - "activate the first floor lights"
+      - "activate the lights on the first floor"
+    slots:
+      domain: "light"
+      floor: "First Floor"
+    response: "Turned on the lights"


### PR DESCRIPTION
## Summary
Two `slot_combinations` declared in `intents.yaml` for `HassTurnOn` and `HassTurnOff` had no English sentence/test files. This adds them:

- **`floor_domain`** — turn lights on/off by floor
  (e.g. "turn on the lights on the first floor", "turn off the first floor lights")
- **`floor_device_class_cover`** — open/close covers by device class on a floor
  (e.g. "open the curtains on the first floor", "close the first floor curtains")

8 files total (sentence + test for each combo × both intents).

## Design notes
- Modeled on the existing `area_domain` / `area_device_class_cover` combos, swapping the area phrasing for the floor pattern `<in> [<the>] {floor} [floor]` already used by `name_floor` (`<in>` expands to include "on", so "on the first floor" works).
- `floor_domain` covers lights only, matching the `intents.yaml` `inferred_domains` (`light`) and the existing `lights_floor` response — there is no `fans_floor` response.
- Each sentence template has a uniquely-matching test sentence (no "untested sentence template" errors). Awkward double-"on" phrasings from a literal area→floor translation were dropped.

## Validation
- `python -m script.intentfest validate --language en` → All good!
- `pytest tests --language en` → 357 passed
- `check_overmatch --language en` → 0 cross-intent over-matches, 0 no-match

🤖 Generated with [Claude Code](https://claude.com/claude-code)