### PR TITLE
[SK ]Add missing Slovak slot combinations and infinitive variants

### DIFF
--- a/lists/sk/lights.yaml
+++ b/lists/sk/lights.yaml
@@ -30,3 +30,13 @@ lists:
         out: 100
       - in: (min|minimum|[čo] (najmenš(ie|í|iu)|najnižš(ie|í|iu)|maximálnu) [hodnotu|úroveň])
         out: 1
+  color_temperature_names:
+    values:
+      - in: (sviečk(ové|ovú) [svetlo]|teplotu sviečk(y|ového svetla))
+        out: 1900
+      - in: (tepl(á|ú) biel(a|u)|tepl(é|u) svetlo)
+        out: 2700
+      - in: (studen(á|ú) biel(a|u)|chladn(á|ú) biel(a|u)|studen(é|u) svetlo)
+        out: 4000
+      - in: (denn(é|u) svetlo|denn(á|ú) biel(a|u))
+        out: 6500

--- a/lists/sk/media.yaml
+++ b/lists/sk/media.yaml
@@ -6,3 +6,19 @@ lists:
         out: up
       - in: "(zníž[iť]|ub(er|rať)|tichšie)"
         out: down
+  media_class:
+    values:
+      - in: interpret(a|u)
+        out: artist
+      - in: album
+        out: album
+      - in: (skladb(a|u)|pesničk(a|u)|stop(a|u))
+        out: track
+      - in: playlist
+        out: playlist
+      - in: podcast
+        out: podcast
+      - in: film
+        out: movie
+      - in: (seriál|reláci(a|u)|televíznu reláciu)
+        out: tv_show

--- a/responses/sk/HassLightSet.yaml
+++ b/responses/sk/HassLightSet.yaml
@@ -8,3 +8,4 @@ responses:
       color: "Farba zmenená na {{ slots.color }}"
       color_area: "Farba v oblasti zmenená na {{ slots.color }}"
       color_here: "Farba tu bola nastavená na {{ slots.color }}"
+      temperature: "Teplota farby nastavená"

--- a/sentences/sk/HassClimateGetTemperature/floor_only.yaml
+++ b/sentences/sk/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "<what_is> <temp> [je] <floor>"
+      - "<how_many> stupňov [je] <floor>"
+    response: default

--- a/sentences/sk/HassClimateSetTemperature/floor_temperature.yaml
+++ b/sentences/sk/HassClimateSetTemperature/floor_temperature.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "<set> <temp> <floor> [na] <temperature>"
+      - "<set> <floor> <temp> [na] <temperature>"
+    response: default

--- a/sentences/sk/HassClimateSetTemperature/name_temperature.yaml
+++ b/sentences/sk/HassClimateSetTemperature/name_temperature.yaml
@@ -1,0 +1,8 @@
+language: sk
+data:
+  - sentences:
+      - "<set> <temp> [<in> ]{name} [na] <temperature>"
+      - "<set> [<in> ]{name} [<temp>] [na] <temperature>"
+    name_domains:
+      - "climate"
+    response: default

--- a/sentences/sk/HassLightSet/area_temperature.yaml
+++ b/sentences/sk/HassLightSet/area_temperature.yaml
@@ -1,0 +1,8 @@
+language: sk
+data:
+  - sentences:
+      - "<set> teplotu [farby] <area> [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+      - "<set> <area> [svetl(á|o)] [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature}) [teplotu [farby]]"
+      - "<set> teplotu [farby] [svetiel|svetla] <area> [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+    inferred_domain: "light"
+    response: temperature

--- a/sentences/sk/HassLightSet/floor_brightness.yaml
+++ b/sentences/sk/HassLightSet/floor_brightness.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "<set> (jas [svetla|svetiel];<floor>) [na] (<brightness>|{brightness_level:brightness})"
+      - "<set> <floor> [svetl(á|o)] [na] (<brightness>|{brightness_level:brightness}) [jas]"
+    inferred_domain: "light"
+    response: brightness

--- a/sentences/sk/HassLightSet/floor_color.yaml
+++ b/sentences/sk/HassLightSet/floor_color.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "<set> <floor> [svetl(á|o)] [na] {color} [farbu]"
+      - "<set> (farbu [svetla|svetiel];<floor>) [na] {color}"
+    inferred_domain: "light"
+    response: color

--- a/sentences/sk/HassLightSet/floor_temperature.yaml
+++ b/sentences/sk/HassLightSet/floor_temperature.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "<set> teplotu [farby] <floor> [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+      - "<set> <floor> [svetl(á|o)] [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature}) [teplotu [farby]]"
+    inferred_domain: "light"
+    response: temperature

--- a/sentences/sk/HassLightSet/name_temperature.yaml
+++ b/sentences/sk/HassLightSet/name_temperature.yaml
@@ -1,0 +1,8 @@
+language: sk
+data:
+  - sentences:
+      - "<set> [teplotu [farby]] {name} [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+      - "<set> [teplotu [farby] [svetla]] [na] {name} [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+    name_domains:
+      - "light"
+    response: temperature

--- a/sentences/sk/HassLightSet/temperature_only.yaml
+++ b/sentences/sk/HassLightSet/temperature_only.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "[<set>] ([<here>];teplotu [farby]) [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+      - "[<set>] [teplotu [farby] [svetla]] [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature}) [<here>]"
+    inferred_domain: "light"
+    response: temperature

--- a/sentences/sk/HassMediaNext/area_only.yaml
+++ b/sentences/sk/HassMediaNext/area_only.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "ďalš(ia|iu|í) [stop(a|u)|skladb(a|u)|pesničk(a|u)|položk(a|u)|program|kanál] <area>"
+      - "preskoč[iť] [túto|tento] [stopu|skladbu|pesničku|položku|program|kanál] <area>"
+      - "preskoč[iť] na ďalš(ia|iu|í) [stopu|skladbu|pesničku|položku|program|kanál] <area>"
+    response: default

--- a/sentences/sk/HassMediaNext/default.yaml
+++ b/sentences/sk/HassMediaNext/default.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "ďalš(ia|iu|í) [stop(a|u)|skladb(a|u)|pesničk(a|u)|položk(a|u)|program|kanál]"
+      - "preskoč[iť] [túto|tento] [stopu|skladbu|pesničku|položku|program|kanál]"
+      - "preskoč[iť] na ďalš(ia|iu|í) [stopu|skladbu|pesničku|položku|program|kanál]"
+    response: default

--- a/sentences/sk/HassMediaPause/area_only.yaml
+++ b/sentences/sk/HassMediaPause/area_only.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "[po]zastav[iť] [prehrávanie|hudbu] <area>"
+      - "zastav[iť] <area> [prehrávanie|hudbu]"
+    response: default

--- a/sentences/sk/HassMediaPause/default.yaml
+++ b/sentences/sk/HassMediaPause/default.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "[po]zastav[iť]"
+      - "zastav[iť] [prehrávanie]"
+    response: default

--- a/sentences/sk/HassMediaSearchAndPlay/area_media_class.yaml
+++ b/sentences/sk/HassMediaSearchAndPlay/area_media_class.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "[pre]hra(j|ť) {media_class} {search_query} <area>"
+      - "[s]pusti[ť] {media_class} {search_query} <area>"
+    response: default

--- a/sentences/sk/HassMediaSearchAndPlay/media_class_only.yaml
+++ b/sentences/sk/HassMediaSearchAndPlay/media_class_only.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "[pre]hra(j|ť) {media_class} {search_query}"
+      - "[s]pusti[ť] {media_class} {search_query}"
+    response: default

--- a/sentences/sk/HassMediaSearchAndPlay/name_area_media_class.yaml
+++ b/sentences/sk/HassMediaSearchAndPlay/name_area_media_class.yaml
@@ -1,0 +1,8 @@
+language: sk
+data:
+  - sentences:
+      - "[pre]hra(j|ť) {media_class} {search_query} <in> {name} <area>"
+      - "[s]pusti[ť] {media_class} {search_query} <in> {name} <area>"
+    name_domains:
+      - "media_player"
+    response: default

--- a/sentences/sk/HassMediaSearchAndPlay/name_media_class.yaml
+++ b/sentences/sk/HassMediaSearchAndPlay/name_media_class.yaml
@@ -1,0 +1,8 @@
+language: sk
+data:
+  - sentences:
+      - "[pre]hra(j|ť) {media_class} {search_query} <in> {name}"
+      - "[s]pusti[ť] {media_class} {search_query} <in> {name}"
+    name_domains:
+      - "media_player"
+    response: default

--- a/sentences/sk/HassMediaUnpause/area_only.yaml
+++ b/sentences/sk/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "pokrač(uj|ovať) [v prehrávaní] <area>"
+      - "(obnov|obnoviť) [prehrávanie] <area>"
+    response: default

--- a/sentences/sk/HassMediaUnpause/default.yaml
+++ b/sentences/sk/HassMediaUnpause/default.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "pokrač(uj|ovať) [v prehrávaní]"
+      - "(obnov|obnoviť) [prehrávanie]"
+    response: default

--- a/sentences/sk/HassSetPosition/floor_device_class.yaml
+++ b/sentences/sk/HassSetPosition/floor_device_class.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "(<close_curtain>|<open_curtain>|<set>) [(pozíciu|(ná|s)klon|uhol|polohu)] {cover_classes:device_class} <floor> [na] <position>"
+    inferred_domain: "cover"
+    response: cover_device_class

--- a/sentences/sk/HassSetPosition/name_area.yaml
+++ b/sentences/sk/HassSetPosition/name_area.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "(<close_curtain>|<open_curtain>|<set>) [(pozíciu|(ná|s)klon|uhol|polohu)] {name} <area> [na] <position>"
+    name_domains:
+      - "cover"
+    response: default

--- a/sentences/sk/HassSetPosition/name_floor.yaml
+++ b/sentences/sk/HassSetPosition/name_floor.yaml
@@ -1,0 +1,7 @@
+language: sk
+data:
+  - sentences:
+      - "(<close_curtain>|<open_curtain>|<set>) [(pozíciu|(ná|s)klon|uhol|polohu)] {name} <floor> [na] <position>"
+    name_domains:
+      - "cover"
+    response: default

--- a/sentences/sk/HassSetVolume/area_only.yaml
+++ b/sentences/sk/HassSetVolume/area_only.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "<set> hlasitosť <area> [na] <volume>"
+      - "<set> hlasitosť [na] <volume> <area>"
+    response: default

--- a/sentences/sk/HassSetVolume/default.yaml
+++ b/sentences/sk/HassSetVolume/default.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "<set> hlasitosť [na] <volume>"
+      - "<set> [zvuk] [na] <volume>"
+    response: default

--- a/sentences/sk/HassShoppingListAddItem/item_only.yaml
+++ b/sentences/sk/HassShoppingListAddItem/item_only.yaml
@@ -1,5 +1,5 @@
 language: sk
 data:
   - sentences:
-      - "(daj|pridaj|pripíš) {shopping_list_item:item} (do|na)[ nákupn(ý|ého)] zoznam[u]"
+      - "(da(j|ť)|prida(j|ť)|prip(íš|ísať)) {shopping_list_item:item} (do|na)[ nákupn(ý|ého)] zoznam[u]"
     response: item_added

--- a/sentences/sk/HassVacuumReturnToBase/area_only.yaml
+++ b/sentences/sk/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,6 @@
+language: sk
+data:
+  - sentences:
+      - "(vrá(ť|tiť)|po(šli|slať)) [(do (doku|základne)|na základňu|domov)] <area>"
+      - "<area> (vrá(ť|tiť)|po(šli|slať)) [(do (doku|základne)|na základňu|domov)]"
+    response: default

--- a/sentences/sk/HassVacuumStart/area_only.yaml
+++ b/sentences/sk/HassVacuumStart/area_only.yaml
@@ -1,0 +1,5 @@
+language: sk
+data:
+  - sentences:
+      - "(uprac|upratať|vyčist[iť]|spus(ti|ť)|aktiv(uj|ovať)) <area>"
+    response: default

--- a/sentences/sk/HassVacuumStart/floor_only.yaml
+++ b/sentences/sk/HassVacuumStart/floor_only.yaml
@@ -1,0 +1,5 @@
+language: sk
+data:
+  - sentences:
+      - "(uprac|upratať|vyčist[iť]|spus(ti|ť)|aktiv(uj|ovať)) <floor>"
+    response: default

--- a/sentences/sk/HassVacuumStart/name_only.yaml
+++ b/sentences/sk/HassVacuumStart/name_only.yaml
@@ -1,7 +1,7 @@
 language: sk
 data:
   - sentences:
-      - "([s]pus(ti|ť)|aktivuj) {name}"
+      - "([s]pus(ti|ť)|aktiv(uj|ovať)) {name}"
     name_domains:
       - "vacuum"
     response: default

--- a/tests/sk/HassClimateGetTemperature/floor_only.yaml
+++ b/tests/sk/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,20 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+areas:
+  - name: "Spálňa"
+    floor: "prvom poschodí"
+entities:
+  - name: "Termostat"
+    domain: climate
+    area: "Spálňa"
+    state: "21"
+    attributes:
+      current_temperature: 21
+tests:
+  - sentences:
+      - "aká je teplota na prvom poschodí"
+      - "koľko stupňov je na prvom poschodí"
+    slots:
+      floor: "prvom poschodí"
+    response: "21 stupňov"

--- a/tests/sk/HassClimateSetTemperature/floor_temperature.yaml
+++ b/tests/sk/HassClimateSetTemperature/floor_temperature.yaml
@@ -1,0 +1,11 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+tests:
+  - sentences:
+      - "nastav teplotu na prvom poschodí na 22"
+      - "uprav na prvom poschodí teplotu na 22 stupňov"
+    slots:
+      floor: "prvom poschodí"
+      temperature: 22
+    response: "Teplota nastavená na 22 stupňov"

--- a/tests/sk/HassClimateSetTemperature/name_temperature.yaml
+++ b/tests/sk/HassClimateSetTemperature/name_temperature.yaml
@@ -1,0 +1,12 @@
+language: sk
+entities:
+  - name: "Termostat"
+    domain: climate
+tests:
+  - sentences:
+      - "nastav teplotu na Termostat na 22°"
+      - "uprav Termostat na 22 stupňov"
+    slots:
+      name: "Termostat"
+      temperature: 22
+    response: "Teplota nastavená na 22 stupňov"

--- a/tests/sk/HassLightSet/area_temperature.yaml
+++ b/tests/sk/HassLightSet/area_temperature.yaml
@@ -1,0 +1,12 @@
+language: sk
+areas:
+  - name: "spáln(i|e)|spálň(a|u)"
+tests:
+  - sentences:
+      - "nastav teplotu farby v spálni na 2700"
+      - "nastav teplotu svetiel v spálni na teplú bielu"
+      - "nastav v spálni svetlá na 2700k"
+    slots:
+      temperature: 2700
+      area: "spáln(i|e)|spálň(a|u)"
+    response: "Teplota farby nastavená"

--- a/tests/sk/HassLightSet/floor_brightness.yaml
+++ b/tests/sk/HassLightSet/floor_brightness.yaml
@@ -1,0 +1,11 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+tests:
+  - sentences:
+      - "nastav jas na prvom poschodí na 50%"
+      - "nastav na prvom poschodí svetlá na 50 jas"
+    slots:
+      brightness: 50
+      floor: "prvom poschodí"
+    response: "Jas nastavený na 50 %"

--- a/tests/sk/HassLightSet/floor_color.yaml
+++ b/tests/sk/HassLightSet/floor_color.yaml
@@ -1,0 +1,11 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+tests:
+  - sentences:
+      - "nastav na prvom poschodí svetlá na červenú farbu"
+      - "nastav farbu na prvom poschodí na červenú"
+    slots:
+      color: "red"
+      floor: "prvom poschodí"
+    response: "Farba zmenená na red"

--- a/tests/sk/HassLightSet/floor_temperature.yaml
+++ b/tests/sk/HassLightSet/floor_temperature.yaml
@@ -1,0 +1,11 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+tests:
+  - sentences:
+      - "nastav teplotu farby na prvom poschodí na 2700"
+      - "nastav na prvom poschodí svetlá na teplú bielu"
+    slots:
+      temperature: 2700
+      floor: "prvom poschodí"
+    response: "Teplota farby nastavená"

--- a/tests/sk/HassLightSet/name_temperature.yaml
+++ b/tests/sk/HassLightSet/name_temperature.yaml
@@ -1,0 +1,13 @@
+language: sk
+entities:
+  - name: "nočn(á|ú|ej) lamp(a|u|y|e)"
+    domain: light
+tests:
+  - sentences:
+      - "nastav teplotu nočnej lampy na 2700k"
+      - "nastav teplotu farby na nočnej lampe na 2700"
+      - "nastav teplotu nočnej lampy na teplú bielu"
+    slots:
+      temperature: 2700
+      name: "nočn(á|ú|ej) lamp(a|u|y|e)"
+    response: "Teplota farby nastavená"

--- a/tests/sk/HassLightSet/temperature_only.yaml
+++ b/tests/sk/HassLightSet/temperature_only.yaml
@@ -1,0 +1,13 @@
+language: sk
+areas:
+  - name: "Obývačka"
+tests:
+  - sentences:
+      - "nastav tu teplotu farby na 2700 k"
+      - "nastav teplotu farby na teplú bielu"
+      - "nastav teplotu farby svetla na 2700 k tu"
+    context:
+      area: "Obývačka"
+    slots:
+      temperature: 2700
+    response: "Teplota farby nastavená"

--- a/tests/sk/HassMediaNext/area_only.yaml
+++ b/tests/sk/HassMediaNext/area_only.yaml
@@ -1,0 +1,11 @@
+language: sk
+areas:
+  - name: "obývačk(a|e|u|y)"
+tests:
+  - sentences:
+      - "ďalšia položka v obývačke"
+      - "preskoč túto skladbu v obývačke"
+      - "preskoč na ďalšiu pesničku v obývačke"
+    slots:
+      area: "obývačk(a|e|u|y)"
+    response: "Prehrávam ďalšie"

--- a/tests/sk/HassMediaNext/default.yaml
+++ b/tests/sk/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+language: sk
+areas:
+  - name: "Obývačka"
+tests:
+  - sentences:
+      - "ďalšia položka"
+      - "preskoč túto skladbu"
+      - "preskoč na ďalšiu pesničku"
+    context:
+      area: "Obývačka"
+    response: "Prehrávam ďalšie"

--- a/tests/sk/HassMediaPause/area_only.yaml
+++ b/tests/sk/HassMediaPause/area_only.yaml
@@ -1,0 +1,10 @@
+language: sk
+areas:
+  - name: "obývačk(a|e|u|y)"
+tests:
+  - sentences:
+      - "pozastav hudbu v obývačke"
+      - "zastav obývačku prehrávanie"
+    slots:
+      area: "obývačk(a|e|u|y)"
+    response: "Pozastavené"

--- a/tests/sk/HassMediaPause/default.yaml
+++ b/tests/sk/HassMediaPause/default.yaml
@@ -1,0 +1,10 @@
+language: sk
+areas:
+  - name: "Obývačka"
+tests:
+  - sentences:
+      - "pozastav"
+      - "zastav prehrávanie"
+    context:
+      area: "Obývačka"
+    response: "Pozastavené"

--- a/tests/sk/HassMediaSearchAndPlay/area_media_class.yaml
+++ b/tests/sk/HassMediaSearchAndPlay/area_media_class.yaml
@@ -1,0 +1,14 @@
+language: sk
+areas:
+  - name: "kuchyňa"
+media:
+  - title: "Balada o štyroch koňoch"
+tests:
+  - sentences:
+      - "prehraj skladbu Balada o štyroch koňoch v kuchyňa"
+      - "spustiť skladbu Balada o štyroch koňoch v kuchyňa"
+    slots:
+      search_query: "Balada o štyroch koňoch"
+      area: "kuchyňa"
+      media_class: "track"
+    response: "Prehrávanie sa spúšťa"

--- a/tests/sk/HassMediaSearchAndPlay/media_class_only.yaml
+++ b/tests/sk/HassMediaSearchAndPlay/media_class_only.yaml
@@ -1,0 +1,17 @@
+language: sk
+media:
+  - title: "Balada o štyroch koňoch"
+tests:
+  - sentences:
+      - "prehraj skladbu Balada o štyroch koňoch"
+      - "spustiť skladbu Balada o štyroch koňoch"
+    slots:
+      search_query: "Balada o štyroch koňoch"
+      media_class: "track"
+    response: "Prehrávanie sa spúšťa"
+  - sentences:
+      - "prehraj interpreta Queen"
+    slots:
+      search_query: "Queen"
+      media_class: "artist"
+    response: "Prehrávanie sa spúšťa"

--- a/tests/sk/HassMediaSearchAndPlay/name_area_media_class.yaml
+++ b/tests/sk/HassMediaSearchAndPlay/name_area_media_class.yaml
@@ -1,0 +1,18 @@
+language: sk
+entities:
+  - name: "TV"
+    domain: media_player
+areas:
+  - name: "kuchyňa"
+media:
+  - title: "Balada o štyroch koňoch"
+tests:
+  - sentences:
+      - "prehraj interpreta Queen na TV v kuchyňa"
+      - "spustiť interpreta Queen na TV v kuchyňa"
+    slots:
+      search_query: "Queen"
+      name: "TV"
+      area: "kuchyňa"
+      media_class: "artist"
+    response: "Prehrávanie sa spúšťa"

--- a/tests/sk/HassMediaSearchAndPlay/name_media_class.yaml
+++ b/tests/sk/HassMediaSearchAndPlay/name_media_class.yaml
@@ -1,0 +1,15 @@
+language: sk
+entities:
+  - name: "TV"
+    domain: media_player
+media:
+  - title: "Balada o štyroch koňoch"
+tests:
+  - sentences:
+      - "prehraj skladbu Balada o štyroch koňoch na TV"
+      - "spustiť skladbu Balada o štyroch koňoch na TV"
+    slots:
+      search_query: "Balada o štyroch koňoch"
+      name: "TV"
+      media_class: "track"
+    response: "Prehrávanie sa spúšťa"

--- a/tests/sk/HassMediaUnpause/area_only.yaml
+++ b/tests/sk/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,12 @@
+language: sk
+areas:
+  - name: "obývačk(a|e|u|y)"
+tests:
+  - sentences:
+      - "pokračuj v prehrávaní v obývačke"
+      - "pokračovať v prehrávaní v obývačke"
+      - "obnov prehrávanie v obývačke"
+      - "obnoviť prehrávanie v obývačke"
+    slots:
+      area: "obývačk(a|e|u|y)"
+    response: "Spustené"

--- a/tests/sk/HassMediaUnpause/default.yaml
+++ b/tests/sk/HassMediaUnpause/default.yaml
@@ -1,0 +1,12 @@
+language: sk
+areas:
+  - name: "Obývačka"
+tests:
+  - sentences:
+      - "pokračuj"
+      - "pokračovať"
+      - "obnov prehrávanie"
+      - "obnoviť prehrávanie"
+    context:
+      area: "Obývačka"
+    response: "Spustené"

--- a/tests/sk/HassSetPosition/floor_device_class.yaml
+++ b/tests/sk/HassSetPosition/floor_device_class.yaml
@@ -1,0 +1,15 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+tests:
+  - sentences:
+      - "nastav rolety na prvom poschodí na 50%"
+      - "roztiahni závesy na prvom poschodí na 50%"
+    slots:
+      floor: "prvom poschodí"
+      domain: "cover"
+      device_class:
+        - blind
+        - curtain
+      position: 50
+    response: "Poloha nastavená"

--- a/tests/sk/HassSetPosition/name_area.yaml
+++ b/tests/sk/HassSetPosition/name_area.yaml
@@ -1,0 +1,16 @@
+language: sk
+areas:
+  - name: "spáln(i|e|a|u)"
+entities:
+  - name: "spálňov(á|ú|ej) žalúzi(a|u|e)"
+    domain: cover
+    area: "spáln(i|e|a|u)"
+tests:
+  - sentences:
+      - "nastav spálňovú žalúziu v spálni na 20%"
+      - "zatiahni spálňovú žalúziu v spálni na 20%"
+    slots:
+      name: "spálňov(á|ú|ej) žalúzi(a|u|e)"
+      area: "spáln(i|e|a|u)"
+      position: 20
+    response: "Poloha nastavená"

--- a/tests/sk/HassSetPosition/name_floor.yaml
+++ b/tests/sk/HassSetPosition/name_floor.yaml
@@ -1,0 +1,19 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+areas:
+  - name: "spálňa"
+    floor: "prvom poschodí"
+entities:
+  - name: "spálňov(á|ú|ej) žalúzi(a|u|e)"
+    domain: cover
+    area: "spálňa"
+tests:
+  - sentences:
+      - "nastav spálňovú žalúziu na prvom poschodí na 20%"
+      - "roztiahni spálňovú žalúziu na prvom poschodí na 20%"
+    slots:
+      name: "spálňov(á|ú|ej) žalúzi(a|u|e)"
+      floor: "prvom poschodí"
+      position: 20
+    response: "Poloha nastavená"

--- a/tests/sk/HassSetVolume/area_only.yaml
+++ b/tests/sk/HassSetVolume/area_only.yaml
@@ -1,0 +1,11 @@
+language: sk
+areas:
+  - name: "obývačk(a|e|u|y)"
+tests:
+  - sentences:
+      - "nastav hlasitosť v obývačke na 90%"
+      - "zvýš hlasitosť na 90 v obývačke"
+    slots:
+      area: "obývačk(a|e|u|y)"
+      volume_level: 90
+    response: "Hlasitosť nastavená"

--- a/tests/sk/HassSetVolume/default.yaml
+++ b/tests/sk/HassSetVolume/default.yaml
@@ -1,0 +1,13 @@
+language: sk
+areas:
+  - name: "Obývačka"
+tests:
+  - sentences:
+      - "nastav hlasitosť na 90%"
+      - "zvýš hlasitosť na 90"
+      - "nastav zvuk na 90%"
+    context:
+      area: "Obývačka"
+    slots:
+      volume_level: 90
+    response: "Hlasitosť nastavená"

--- a/tests/sk/HassShoppingListAddItem/item_only.yaml
+++ b/tests/sk/HassShoppingListAddItem/item_only.yaml
@@ -2,9 +2,12 @@ language: sk
 tests:
   - sentences:
       - "pridaj toaletný papier do nákupného zoznamu"
+      - "pridať toaletný papier do nákupného zoznamu"
       - "pridaj toaletný papier do zoznamu"
       - "daj toaletný papier na zoznam"
+      - "dať toaletný papier na zoznam"
       - "pripíš toaletný papier na zoznam"
+      - "pripísať toaletný papier na zoznam"
     slots:
       item: "toaletný papier"
     response: "Pridané: toaletný papier"

--- a/tests/sk/HassVacuumReturnToBase/area_only.yaml
+++ b/tests/sk/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,10 @@
+language: sk
+areas:
+  - name: "obývačk(a|e|u|y)"
+tests:
+  - sentences:
+      - "vráť do doku v obývačke"
+      - "v obývačke pošli na základňu"
+    slots:
+      area: "obývačk(a|e|u|y)"
+    response: "Vraciam do doku"

--- a/tests/sk/HassVacuumStart/area_only.yaml
+++ b/tests/sk/HassVacuumStart/area_only.yaml
@@ -1,0 +1,11 @@
+language: sk
+areas:
+  - name: "obývačk(a|e|u|y)"
+tests:
+  - sentences:
+      - "uprac obývačku"
+      - "upratať obývačku"
+      - "vyčistiť obývačku"
+    slots:
+      area: "obývačk(a|e|u|y)"
+    response: "Spúšťam"

--- a/tests/sk/HassVacuumStart/floor_only.yaml
+++ b/tests/sk/HassVacuumStart/floor_only.yaml
@@ -1,0 +1,11 @@
+language: sk
+floors:
+  - name: "prvom poschodí"
+tests:
+  - sentences:
+      - "uprac na prvom poschodí"
+      - "upratať na prvom poschodí"
+      - "vyčistiť na prvom poschodí"
+    slots:
+      floor: "prvom poschodí"
+    response: "Spúšťam"

--- a/tests/sk/HassVacuumStart/name_only.yaml
+++ b/tests/sk/HassVacuumStart/name_only.yaml
@@ -7,6 +7,7 @@ tests:
       - "spusti Vysávač"
       - "pusť Vysávač"
       - "aktivuj Vysávač"
+      - "aktivovať Vysávač"
     slots:
       name: "Vysávač"
     response: "Spúšťam"


### PR DESCRIPTION

This PR completes missing Slovak slot-combination coverage and adds selected infinitive verb variants for better NLU robustness.

### Added Slovak slot combinations (sentences + tests)

- `HassLightSet`
  - `name_temperature`
  - `floor_brightness`
  - `floor_color`
  - `temperature_only`
  - `area_temperature`
  - `floor_temperature`

- `HassSetPosition`
  - `name_area`
  - `name_floor`
  - `floor_device_class`

- `HassClimateGetTemperature`
  - `floor_only`

- `HassClimateSetTemperature`
  - `name_temperature`
  - `floor_temperature`

- `HassMediaSearchAndPlay`
  - `media_class_only`
  - `name_media_class`
  - `area_media_class`
  - `name_area_media_class`

- `HassMediaPause`
  - `default`
  - `area_only`

- `HassMediaUnpause`
  - `default`
  - `area_only`

- `HassMediaNext`
  - `default`
  - `area_only`

- `HassSetVolume`
  - `default`
  - `area_only`

- `HassVacuumStart`
  - `area_only`
  - `floor_only`

- `HassVacuumReturnToBase`
  - `area_only`

### Lists / responses updated

- `lists/sk/lights.yaml`
  - added `color_temperature_names`
- `lists/sk/media.yaml`
  - added `media_class`
- `responses/sk/HassLightSet.yaml`
  - added `temperature` response key (`Teplota farby nastavená`)

### Infinitive coverage improvements

- `HassVacuumStart`
  - added support for infinitive forms where safe (`upratať`, `aktivovať`, `spustiť` via pattern)
- `HassMediaUnpause`
  - added explicit infinitives:
    - `pokračovať`
    - `obnoviť`
- `HassShoppingListAddItem`
  - added explicit infinitives:
    - `dať`
    - `pridať`
    - `pripísať`
