### PR TITLE
[zh-TW] Add HassFanSetSpeed and HassSetPosition

### DIFF
--- a/responses/zh-TW/HassFanSetSpeed.yaml
+++ b/responses/zh-TW/HassFanSetSpeed.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassFanSetSpeed:
+      default: "風扇轉速已調整"

--- a/responses/zh-TW/HassSetPosition.yaml
+++ b/responses/zh-TW/HassSetPosition.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+responses:
+  intents:
+    HassSetPosition:
+      default: "位置已調整"
+      cover_device_class: "{{ slots.device_class }}位置已調整"

--- a/sentences/zh-TW/HassFanSetSpeed/area_only.yaml
+++ b/sentences/zh-TW/HassFanSetSpeed/area_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{area}[的](風扇|電扇|吊扇)[的][轉速|速度]<set_to>[百分之]{fan_speed:percentage}[ ][%|趴]"
+      - "<set>{area}[的](風扇|電扇|吊扇)[的][轉速|速度][<to>][百分之]{fan_speed:percentage}[ ][%|趴]"
+    example: "把客廳的風扇轉速調到50%"
+    response: "default"

--- a/sentences/zh-TW/HassFanSetSpeed/default.yaml
+++ b/sentences/zh-TW/HassFanSetSpeed/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將][這裡|這邊][的](風扇|電扇|吊扇)[的][轉速|速度]<set_to>[百分之]{fan_speed:percentage}[ ][%|趴]"
+      - "<set>[這裡|這邊][的](風扇|電扇|吊扇)[的][轉速|速度][<to>][百分之]{fan_speed:percentage}[ ][%|趴]"
+    example: "把風扇轉速調到50%"
+    response: "default"

--- a/sentences/zh-TW/HassFanSetSpeed/floor_only.yaml
+++ b/sentences/zh-TW/HassFanSetSpeed/floor_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{floor}[的](風扇|電扇|吊扇)[的][轉速|速度]<set_to>[百分之]{fan_speed:percentage}[ ][%|趴]"
+      - "<set>{floor}[的](風扇|電扇|吊扇)[的][轉速|速度][<to>][百分之]{fan_speed:percentage}[ ][%|趴]"
+    example: "把二樓的風扇轉速調到50%"
+    response: "default"

--- a/sentences/zh-TW/HassFanSetSpeed/name_only.yaml
+++ b/sentences/zh-TW/HassFanSetSpeed/name_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{name}[的][轉速|速度]<set_to>[百分之]{fan_speed:percentage}[ ][%|趴]"
+      - "<set>{name}[的][轉速|速度][<to>][百分之]{fan_speed:percentage}[ ][%|趴]"
+    name_domains:
+      - "fan"
+    example: "把電風扇轉速調到50%"
+    response: "default"

--- a/sentences/zh-TW/HassSetPosition/area_device_class.yaml
+++ b/sentences/zh-TW/HassSetPosition/area_device_class.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{area}[的]{cover_classes:device_class}[的][位置]<set_to>[百分之]{position}[ ][%|趴]"
+      - "[把|將]{area}[的]{cover_classes:device_class}(開|關)到[百分之]{position}[ ][%|趴]"
+    inferred_domain: "cover"
+    example: "把臥室的窗簾開到50%"
+    response: "cover_device_class"

--- a/sentences/zh-TW/HassSetPosition/device_class.yaml
+++ b/sentences/zh-TW/HassSetPosition/device_class.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將][這裡|這邊][的]{cover_classes:device_class}[的][位置]<set_to>[百分之]{position}[ ][%|趴]"
+      - "[把|將][這裡|這邊][的]{cover_classes:device_class}(開|關)到[百分之]{position}[ ][%|趴]"
+    inferred_domain: "cover"
+    example: "把窗簾開到50%"
+    response: "cover_device_class"

--- a/sentences/zh-TW/HassSetPosition/name_area.yaml
+++ b/sentences/zh-TW/HassSetPosition/name_area.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{area}的{name}[的][位置]<set_to>[百分之]{position}[ ][%|趴]"
+      - "[把|將]{area}的{name}(開|關)到[百分之]{position}[ ][%|趴]"
+    name_domains:
+      - "cover"
+    example: "把臥室的窗簾開到50%"
+    response: "default"

--- a/sentences/zh-TW/HassSetPosition/name_only.yaml
+++ b/sentences/zh-TW/HassSetPosition/name_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{name}[的][位置]<set_to>[百分之]{position}[ ][%|趴]"
+      - "[把|將]{name}(開|關)到[百分之]{position}[ ][%|趴]"
+    name_domains:
+      - "cover"
+      - "valve"
+    example: "把窗簾開到50%"
+    response: "default"

--- a/tests/zh-TW/HassFanSetSpeed/area_only.yaml
+++ b/tests/zh-TW/HassFanSetSpeed/area_only.yaml
@@ -1,0 +1,15 @@
+language: zh-TW
+areas:
+  - name: 客廳
+entities:
+  - name: 吊扇
+    domain: fan
+    area: 客廳
+tests:
+  - sentences:
+      - 把客廳的風扇轉速調到50%
+      - 調整客廳的吊扇速度為百分之50
+    slots:
+      area: 客廳
+      percentage: 50
+    response: "風扇轉速已調整"

--- a/tests/zh-TW/HassFanSetSpeed/default.yaml
+++ b/tests/zh-TW/HassFanSetSpeed/default.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 把風扇轉速調到50%
+      - 調整這裡的電扇速度為百分之50
+    slots:
+      percentage: 50
+    response: "風扇轉速已調整"

--- a/tests/zh-TW/HassFanSetSpeed/floor_only.yaml
+++ b/tests/zh-TW/HassFanSetSpeed/floor_only.yaml
@@ -1,0 +1,18 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 吊扇
+    domain: fan
+    area: 二樓臥室
+tests:
+  - sentences:
+      - 把二樓的風扇轉速調到50%
+      - 調整二樓的吊扇速度為百分之50
+    slots:
+      floor: 二樓
+      percentage: 50
+    response: "風扇轉速已調整"

--- a/tests/zh-TW/HassFanSetSpeed/name_only.yaml
+++ b/tests/zh-TW/HassFanSetSpeed/name_only.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+entities:
+  - name: 電風扇
+    domain: fan
+tests:
+  - sentences:
+      - 把電風扇轉速調到50%
+      - 調整電風扇的速度為百分之50
+    slots:
+      name: 電風扇
+      percentage: 50
+    response: "風扇轉速已調整"

--- a/tests/zh-TW/HassSetPosition/area_device_class.yaml
+++ b/tests/zh-TW/HassSetPosition/area_device_class.yaml
@@ -1,0 +1,18 @@
+language: zh-TW
+areas:
+  - name: 臥室
+entities:
+  - name: 臥室的大窗戶
+    domain: cover
+    area: 臥室
+    attributes:
+      device_class: window
+tests:
+  - sentences:
+      - 把臥室的窗戶位置調到50%
+      - 把臥室的窗戶開到50%
+    slots:
+      area: 臥室
+      device_class: window
+      position: 50
+    response: "window位置已調整"

--- a/tests/zh-TW/HassSetPosition/device_class.yaml
+++ b/tests/zh-TW/HassSetPosition/device_class.yaml
@@ -1,0 +1,14 @@
+language: zh-TW
+entities:
+  - name: 臥室的大窗戶
+    domain: cover
+    attributes:
+      device_class: window
+tests:
+  - sentences:
+      - 把這裡的窗戶位置調到50%
+      - 把窗戶開到50%
+    slots:
+      device_class: window
+      position: 50
+    response: "window位置已調整"

--- a/tests/zh-TW/HassSetPosition/name_area.yaml
+++ b/tests/zh-TW/HassSetPosition/name_area.yaml
@@ -1,0 +1,16 @@
+language: zh-TW
+areas:
+  - name: 臥室
+entities:
+  - name: 窗簾
+    domain: cover
+    area: 臥室
+tests:
+  - sentences:
+      - 把臥室的窗簾位置調到50%
+      - 把臥室的窗簾開到50%
+    slots:
+      area: 臥室
+      name: 窗簾
+      position: 50
+    response: "位置已調整"

--- a/tests/zh-TW/HassSetPosition/name_only.yaml
+++ b/tests/zh-TW/HassSetPosition/name_only.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+entities:
+  - name: 窗簾
+    domain: cover
+tests:
+  - sentences:
+      - 把窗簾的位置調到50%
+      - 把窗簾開到50%
+    slots:
+      name: 窗簾
+      position: 50
+    response: "位置已調整"


### PR DESCRIPTION
## Changes

Adds two intents to zh-TW (Traditional Chinese), following the slot-combination format and mirroring the `en` combo structure:

### HassFanSetSpeed (default / name_only / area_only / floor_only)
- 把風扇轉速調到50% / 調整客廳的吊扇速度為百分之50
- Percentage forms follow the established zh-TW idiom: `[百分之]{fan_speed:percentage}[ ][%|趴]`
- Fan words: 風扇|電扇|吊扇 (matching existing HassTurnOn fan sentences)

### HassSetPosition (name_only / device_class / area_device_class / name_area)
- 把窗簾開到50% / 把臥室的窗戶位置調到50%
- `(開|關)到{position}%` alternates with `位置<set_to>{position}%`
- Reuses the existing zh-TW `cover_classes` list; `name_only` covers `cover` + `valve` per `intents.yaml` (other combos: `cover` only, as declared)

## Testing

- `python3 -m script.intentfest validate --language zh-TW` — All good
- `pytest tests/test_slot_combinations.py --language zh-TW` — 211 passed (branch verified in an isolated worktree)
- Exercised on a real HAOS install via Assist