### PR TITLE
[zh-TW] Add weather, date/time, broadcast and assistant intents

### DIFF
--- a/responses/zh-TW/HassBroadcast.yaml
+++ b/responses/zh-TW/HassBroadcast.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassBroadcast:
+      default: "已廣播"

--- a/responses/zh-TW/HassGetCurrentDate.yaml
+++ b/responses/zh-TW/HassGetCurrentDate.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassGetCurrentDate:
+      default: "{{ slots.date.year }}年{{ slots.date.month }}月{{ slots.date.day }}日"

--- a/responses/zh-TW/HassGetCurrentTime.yaml
+++ b/responses/zh-TW/HassGetCurrentTime.yaml
@@ -1,0 +1,15 @@
+language: zh-TW
+responses:
+  intents:
+    HassGetCurrentTime:
+      default: >-
+        {%- set m = '{0:02d}'.format(slots.time.minute) -%}
+        {%- if slots.time.hour == 0 -%}
+        午夜12點{{ m }}分
+        {%- elif slots.time.hour < 12 -%}
+        上午{{ slots.time.hour }}點{{ m }}分
+        {%- elif slots.time.hour == 12 -%}
+        中午12點{{ m }}分
+        {%- else -%}
+        下午{{ slots.time.hour - 12 }}點{{ m }}分
+        {%- endif -%}

--- a/responses/zh-TW/HassGetWeather.yaml
+++ b/responses/zh-TW/HassGetWeather.yaml
@@ -1,0 +1,32 @@
+language: zh-TW
+responses:
+  intents:
+    HassGetWeather:
+      default: >-
+        {%- set weather_condition = {
+          'clear': '晴朗',
+          'clear-night': '晴朗',
+          'cloudy': '多雲',
+          'exceptional': '特殊天氣',
+          'fog': '有霧',
+          'hail': '冰雹',
+          'lightning': '打雷',
+          'lightning-rainy': '雷雨',
+          'partlycloudy': '局部多雲',
+          'pouring': '大雨',
+          'rainy': '下雨',
+          'snowy': '下雪',
+          'snowy-rainy': '雨雪交加',
+          'sunny': '晴天',
+          'windy': '有風',
+          'windy-variant': '有風'
+        } -%}
+        {%- set temp = state.attributes.get('temperature') | float(none) -%}
+        {%- set unit = state.attributes.get('temperature_unit') or '' -%}
+        {%- set cond = weather_condition.get((state.state | string).lower(), "") -%}
+        {%- if temp is none -%}
+        {{ cond }}
+        {%- else -%}
+        {%- set temp = temp | round(1) -%}
+        {{ temp | int if temp == temp | int else temp }} {{ unit }}，{{ cond }}
+        {%- endif -%}

--- a/responses/zh-TW/HassNevermind.yaml
+++ b/responses/zh-TW/HassNevermind.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/zh-TW/HassRespond.yaml
+++ b/responses/zh-TW/HassRespond.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+responses:
+  intents:
+    HassRespond:
+      default: ""
+      hello: "你好，這裡是Home Assistant"
+      listening: "不會，我只有在你說出喚醒詞之後才會錄音"
+      data: "你的資料只會傳送到你的Home Assistant伺服器"
+      commands: "想知道可以說什麼，請造訪home-assistant.io/voice"
+      creator: "我是由全世界的Home Assistant社群共同創造的"

--- a/sentences/zh-TW/HassBroadcast/message_only.yaml
+++ b/sentences/zh-TW/HassBroadcast/message_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(廣播|通知)[大家][說]{message}"
+    example: "廣播晚餐好了"
+    response: "default"

--- a/sentences/zh-TW/HassGetCurrentDate/default.yaml
+++ b/sentences/zh-TW/HassGetCurrentDate/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "今天[是](幾月幾號|幾號)"
+      - "今天[的]日期[是多少]"
+    example: "今天幾號"
+    response: "default"

--- a/sentences/zh-TW/HassGetCurrentTime/default.yaml
+++ b/sentences/zh-TW/HassGetCurrentTime/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "現在幾點[鐘][了]"
+      - "[現在][的]時間是(多少|幾點)"
+    example: "現在幾點"
+    response: "default"

--- a/sentences/zh-TW/HassGetWeather/default.yaml
+++ b/sentences/zh-TW/HassGetWeather/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[現在|今天][外面]天氣(如何|怎麼樣|怎樣|好嗎)"
+      - "(今天|現在)[的]天氣"
+    example: "今天天氣如何"
+    response: "default"

--- a/sentences/zh-TW/HassGetWeather/name_only.yaml
+++ b/sentences/zh-TW/HassGetWeather/name_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "{name}[的]天氣(如何|怎麼樣|怎樣|好嗎)"
+      - "(今天|現在){name}[的]天氣"
+    name_domains:
+      - "weather"
+    example: "台北的天氣如何"
+    response: "default"

--- a/sentences/zh-TW/HassNevermind/default.yaml
+++ b/sentences/zh-TW/HassNevermind/default.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+data:
+  - sentences:
+      - "沒事[了]"
+      - "沒關係"
+      - "算了[吧]"
+      - "取消"
+      - "閉嘴"
+      - "再見"
+    example: "沒事了"
+    response: "default"

--- a/sentences/zh-TW/HassRespond/default.yaml
+++ b/sentences/zh-TW/HassRespond/default.yaml
@@ -1,0 +1,26 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(你好|哈囉|嗨)"
+    example: "你好"
+    response: "hello"
+
+  - sentences:
+      - "你(會|是)[不會|不是]一直[在](聽|錄音)嗎"
+    example: "你會一直聽嗎"
+    response: "listening"
+
+  - sentences:
+      - "我的資料[會](傳|送)到哪[裡|邊]"
+    example: "我的資料會傳到哪裡"
+    response: "data"
+
+  - sentences:
+      - "我(可以|能)(說|問)什麼"
+    example: "我可以說什麼"
+    response: "commands"
+
+  - sentences:
+      - "你是誰(創造|製作|做)的"
+    example: "你是誰創造的"
+    response: "creator"

--- a/tests/zh-TW/HassBroadcast/message_only.yaml
+++ b/tests/zh-TW/HassBroadcast/message_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 廣播晚餐好了
+      - 通知大家說晚餐好了
+    slots:
+      message: 晚餐好了
+    response: "已廣播"

--- a/tests/zh-TW/HassGetCurrentDate/default.yaml
+++ b/tests/zh-TW/HassGetCurrentDate/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 今天幾號？
+      - 今天是幾月幾號？
+      - 今天的日期是多少？
+    response: "2013年9月17日"

--- a/tests/zh-TW/HassGetCurrentTime/default.yaml
+++ b/tests/zh-TW/HassGetCurrentTime/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 現在幾點？
+      - 現在幾點鐘了？
+      - 時間是多少？
+    response: "上午1點02分"

--- a/tests/zh-TW/HassGetWeather/default.yaml
+++ b/tests/zh-TW/HassGetWeather/default.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+entities:
+  - name: 家
+    domain: weather
+    state: rainy
+    attributes:
+      temperature: 25
+      temperature_unit: "°C"
+tests:
+  - sentences:
+      - 今天天氣如何？
+      - 現在的天氣
+    response: "25 °C，下雨"

--- a/tests/zh-TW/HassGetWeather/name_only.yaml
+++ b/tests/zh-TW/HassGetWeather/name_only.yaml
@@ -1,0 +1,15 @@
+language: zh-TW
+entities:
+  - name: 台北
+    domain: weather
+    state: sunny
+    attributes:
+      temperature: 30
+      temperature_unit: "°C"
+tests:
+  - sentences:
+      - 台北的天氣如何？
+      - 今天台北的天氣
+    slots:
+      name: 台北
+    response: "30 °C，晴天"

--- a/tests/zh-TW/HassNevermind/default.yaml
+++ b/tests/zh-TW/HassNevermind/default.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 沒事了
+      - 沒關係
+      - 算了
+      - 取消
+      - 閉嘴
+      - 再見
+    response: ""

--- a/tests/zh-TW/HassRespond/default.yaml
+++ b/tests/zh-TW/HassRespond/default.yaml
@@ -1,0 +1,17 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 你好
+    response: "你好，這裡是Home Assistant"
+  - sentences:
+      - 你會一直聽嗎？
+    response: "不會，我只有在你說出喚醒詞之後才會錄音"
+  - sentences:
+      - 我的資料會傳到哪裡？
+    response: "你的資料只會傳送到你的Home Assistant伺服器"
+  - sentences:
+      - 我可以說什麼？
+    response: "想知道可以說什麼，請造訪home-assistant.io/voice"
+  - sentences:
+      - 你是誰創造的？
+    response: "我是由全世界的Home Assistant社群共同創造的"


### PR DESCRIPTION
## Changes

Adds six small intents to zh-TW (Traditional Chinese), following the slot-combination format and mirroring the `en` combo structure:

- **HassGetWeather** (default / name_only) — 今天天氣如何 / 台北的天氣如何. The response maps conditions to Chinese (下雨/晴天/多雲/雷雨…), rounds the temperature to 1 decimal, and answers with just the condition when the temperature attribute is missing (no `None °C` read-outs)
- **HassGetCurrentDate** — 今天幾號 → `2026年7月4日`
- **HassGetCurrentTime** — 現在幾點 → `下午5點49分` (上午/中午/下午/午夜)
- **HassBroadcast** (message_only) — (廣播|通知)[大家][說]{message}, e.g. 廣播晚餐好了
- **HassRespond** — all five response keys (hello/listening/data/commands/creator) translated
- **HassNevermind** — 沒事[了]/沒關係/算了[吧]/取消/閉嘴/再見

## Testing

- `python3 -m script.intentfest validate --language zh-TW` — All good
- `pytest tests/test_slot_combinations.py --language zh-TW` — 211 passed (branch verified in an isolated worktree)
- Verified end-to-end on a real HAOS install: 今天幾號 → `2026年7月4日`, 今天天氣如何 → `30.6 °C，多雲`