### PR TITLE
[zh-TW] Complete existing intents (LightSet, GetState, TurnOn/Off floor)

### DIFF
--- a/lists/zh-TW/lights.yaml
+++ b/lists/zh-TW/lights.yaml
@@ -26,3 +26,13 @@ lists:
         out: 100
       - in: (最小|最暗|最低)
         out: 1
+  color_temperature_names:
+    values:
+      - in: 燭光
+        out: 1900
+      - in: (暖白|黃光)
+        out: 2700
+      - in: (冷白|自然光)
+        out: 4000
+      - in: (日光|白光)
+        out: 6500

--- a/lists/zh-TW/person.yaml
+++ b/lists/zh-TW/person.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+lists:
+  home_zone:
+    values:
+      - in: 家[裡]
+        out: home

--- a/responses/zh-TW/HassGetState.yaml
+++ b/responses/zh-TW/HassGetState.yaml
@@ -14,6 +14,19 @@ responses:
           沒有、{{ slots.name }}是{{ state.state_with_unit }}的
         {% endif %}
 
+      where: |
+        {% if not query.matched %}
+          抱歉，我不知道{{ slots.name }}這個人
+        {% else %}
+          {% if state.state == "not_home" %}
+            {{ slots.name }}不在家
+          {% elif state.state == "home" %}
+            {{ slots.name }}在家
+          {% else %}
+            {{ slots.name }}在{{ state.state }}
+          {% endif %}
+        {% endif %}
+
       any: |
         {% if query.matched %}
           {% set match = query.matched | map(attribute="name") | sort | list %}

--- a/responses/zh-TW/HassLightSet.yaml
+++ b/responses/zh-TW/HassLightSet.yaml
@@ -4,5 +4,13 @@ responses:
     HassLightSet:
       brightness: "{{ slots.name }}亮度已調整"
       brightness_area: "{{ slots.area }}亮度已調整為{{ slots.brightness }}"
+      brightness_floor: "{{ slots.floor }}亮度已調整為{{ slots.brightness }}"
+      brightness_here: "亮度已調整"
       color: "{{ slots.name }}顏色已調整"
       color_area: "{{ slots.area }}顏色已調整為{{ slots.color }}"
+      color_floor: "{{ slots.floor }}顏色已調整為{{ slots.color }}"
+      color_here: "顏色已調整"
+      temperature: "{{ slots.name }}色溫已調整"
+      temperature_area: "{{ slots.area }}色溫已調整為{{ slots.temperature }}"
+      temperature_floor: "{{ slots.floor }}色溫已調整為{{ slots.temperature }}"
+      temperature_here: "色溫已調整"

--- a/responses/zh-TW/HassTurnOff.yaml
+++ b/responses/zh-TW/HassTurnOff.yaml
@@ -5,6 +5,7 @@ responses:
       default: "{{ slots.name|default('') }}已關閉"
       lights_area: "燈光已關閉"
       fans_area: "風扇已關閉"
+      lights_floor: "{{ slots.floor }}的燈光已關閉"
       cover: "{{ slots.name|default('') }}已關閉"
       light_all: "所有燈光已關閉"
       cover_device_class: "{{ slots.device_class }}已關閉"

--- a/responses/zh-TW/HassTurnOn.yaml
+++ b/responses/zh-TW/HassTurnOn.yaml
@@ -6,6 +6,7 @@ responses:
       lights_area: "燈光已打開"
       light_all: "所有燈光已打開"
       fans_area: "風扇已打開"
+      lights_floor: "{{ slots.floor }}的燈光已打開"
       cover: "{{ slots.name|default('') }}已打開"
       cover_device_class: "{{ slots.device_class }}已打開"
       scene: "{{ slots.name|default('') }}已啟用"

--- a/sentences/zh-TW/HassGetState/device_class_state_floor.yaml
+++ b/sentences/zh-TW/HassGetState/device_class_state_floor.yaml
@@ -1,0 +1,22 @@
+language: zh-TW
+data:
+  - sentences:
+      - "{floor}[的][(有|有沒有|有任何)]{cover_classes:device_class}是{cover_states:state}[的][嗎]"
+    example: "二樓有任何窗簾是開著的嗎"
+    inferred_domain: "cover"
+    response: "any"
+  - sentences:
+      - "{floor}[的]<all>{cover_classes:device_class}[(都是|是|是不是)]{cover_states:state}[的][嗎]"
+    example: "二樓所有的窗簾都是開著嗎"
+    inferred_domain: "cover"
+    response: "all"
+  - sentences:
+      - "<which>{floor}[的]{cover_classes:device_class}[是]{cover_states:state}[的][嗎]"
+    example: "二樓哪一扇窗簾是關著的"
+    inferred_domain: "cover"
+    response: "which"
+  - sentences:
+      - "{floor}[的]<how_many>[扇]{cover_classes:device_class}是{cover_states:state}"
+    example: "二樓有多少扇窗簾是關上的"
+    inferred_domain: "cover"
+    response: "how_many"

--- a/sentences/zh-TW/HassGetState/domain_state_floor.yaml
+++ b/sentences/zh-TW/HassGetState/domain_state_floor.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+data:
+  # lights
+  - sentences:
+      - "{floor}[的][(有|有沒有)][任何][的]<light>[(是|是不是)]{on_off_states:state}[著][的][嗎]"
+    example: "二樓有任何燈是開著的嗎"
+    inferred_domain: "light"
+    response: "any"
+  - sentences:
+      - "{floor}[的]<all><light>[(是|是不是)][都是]{on_off_states:state}[著][的][嗎]"
+    example: "二樓所有的燈都是開著嗎"
+    inferred_domain: "light"
+    response: "all"
+  - sentences:
+      - "<which>{floor}[的]<light>[是]{on_off_states:state}[著][的][嗎]"
+    example: "二樓哪一盞燈是開著的"
+    inferred_domain: "light"
+    response: "which"
+  - sentences:
+      - "{floor}[的]<how_many>[(盞|個)]<light>[是]{on_off_states:state}[著][的][嗎]"
+    example: "二樓有多少盞燈是打開的"
+    inferred_domain: "light"
+    response: "how_many"

--- a/sentences/zh-TW/HassGetState/name_state_floor.yaml
+++ b/sentences/zh-TW/HassGetState/name_state_floor.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  # covers
+  - sentences:
+      - "{floor}[的]{name}[的][(是|是不是)]{cover_states:state}[著][的][嗎]"
+    example: "二樓的左側窗簾是關著的嗎"
+    name_domains:
+      - "cover"
+    response: "one_yesno"

--- a/sentences/zh-TW/HassGetState/name_where.yaml
+++ b/sentences/zh-TW/HassGetState/name_where.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "{name}[人][目前|現在]在哪[裡|邊]"
+      - "{name}[目前|現在]在什麼地方"
+    example: "小明在哪裡"
+    name_domains:
+      - "person"
+    response: "where"

--- a/sentences/zh-TW/HassGetState/name_zone.yaml
+++ b/sentences/zh-TW/HassGetState/name_zone.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "{name}(在|到)[了]{home_zone:state}[了](嗎|沒有|沒)"
+      - "{name}(在|到)[了]{zone:state}[了](嗎|沒有|沒)"
+    example: "小明在家嗎"
+    name_domains:
+      - "person"
+    response: "one_yesno"

--- a/sentences/zh-TW/HassLightSet/area_temperature.yaml
+++ b/sentences/zh-TW/HassLightSet/area_temperature.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{area}[(燈|燈光|照明)][的]色溫<set_to>{color_temperature:temperature}[[ ](K|k)]"
+      - "<set>{area}[(燈|燈光|照明)][的]色溫[<to>]{color_temperature:temperature}[[ ](K|k)]"
+      - "[把|將]{area}[(燈|燈光|照明)][的]色溫<set_to>{color_temperature_names:temperature}"
+      - "<set>{area}[(燈|燈光|照明)][的]色溫[<to>]{color_temperature_names:temperature}"
+    example: "把臥室燈光色溫調到2700K"
+    inferred_domain: "light"
+    response: "temperature_area"

--- a/sentences/zh-TW/HassLightSet/brightness_only.yaml
+++ b/sentences/zh-TW/HassLightSet/brightness_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將][這裡|這邊][的]亮度<set_to>[百分之]{brightness}[ ][%|趴]"
+      - "<set>[這裡|這邊][的]亮度[<to>][百分之]{brightness}[ ][%|趴]"
+      - "[把|將][這裡|這邊][的]亮度<set_to>{brightness_level:brightness}"
+      - "<set>[這裡|這邊][的]亮度[<to>]{brightness_level:brightness}"
+    example: "把這裡的亮度調到50%"
+    inferred_domain: "light"
+    response: "brightness_here"

--- a/sentences/zh-TW/HassLightSet/color_only.yaml
+++ b/sentences/zh-TW/HassLightSet/color_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將][這裡|這邊][的][<all>]<light>[顏色][<set_to>]{color}"
+      - "<set>[這裡|這邊][的][<all>]<light>[顏色]<to>{color}"
+    example: "把這裡的燈調成紅色"
+    inferred_domain: "light"
+    response: "color_here"

--- a/sentences/zh-TW/HassLightSet/floor_brightness.yaml
+++ b/sentences/zh-TW/HassLightSet/floor_brightness.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{floor}[(照明|燈光)][亮度]<set_to>[百分之]{brightness}[ ][%|趴]"
+      - "<set>{floor}[(照明|燈光)][亮度][<to>][百分之]{brightness}[ ][%|趴]"
+      - "[把|將]{floor}[(照明|燈光)][亮度]<set_to>{brightness_level:brightness}"
+      - "<set>{floor}[(照明|燈光)][亮度][<to>]{brightness_level:brightness}"
+    example: "把二樓亮度調到50%"
+    inferred_domain: "light"
+    response: "brightness_floor"

--- a/sentences/zh-TW/HassLightSet/floor_color.yaml
+++ b/sentences/zh-TW/HassLightSet/floor_color.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{floor}[(照明|燈光)][顏色][<set_to>]{color}"
+      - "<set>{floor}[(照明|燈光)][顏色]<to>{color}"
+    example: "把二樓燈光設定成紅色"
+    inferred_domain: "light"
+    response: "color_floor"

--- a/sentences/zh-TW/HassLightSet/floor_temperature.yaml
+++ b/sentences/zh-TW/HassLightSet/floor_temperature.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{floor}[(燈|燈光|照明)][的]色溫<set_to>{color_temperature:temperature}[[ ](K|k)]"
+      - "<set>{floor}[(燈|燈光|照明)][的]色溫[<to>]{color_temperature:temperature}[[ ](K|k)]"
+      - "[把|將]{floor}[(燈|燈光|照明)][的]色溫<set_to>{color_temperature_names:temperature}"
+      - "<set>{floor}[(燈|燈光|照明)][的]色溫[<to>]{color_temperature_names:temperature}"
+    example: "把二樓燈光色溫調到2700K"
+    inferred_domain: "light"
+    response: "temperature_floor"

--- a/sentences/zh-TW/HassLightSet/name_temperature.yaml
+++ b/sentences/zh-TW/HassLightSet/name_temperature.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{name}[(燈|燈光)][的]色溫<set_to>{color_temperature:temperature}[[ ](K|k)]"
+      - "<set>{name}[(燈|燈光)][的]色溫[<to>]{color_temperature:temperature}[[ ](K|k)]"
+      - "[把|將]{name}[(燈|燈光)][的]色溫<set_to>{color_temperature_names:temperature}"
+      - "<set>{name}[(燈|燈光)][的]色溫[<to>]{color_temperature_names:temperature}"
+    example: "把臥室檯燈色溫調到2700K"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/zh-TW/HassLightSet/temperature_only.yaml
+++ b/sentences/zh-TW/HassLightSet/temperature_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將][這裡|這邊][的][(燈|燈光)[的]]色溫<set_to>{color_temperature:temperature}[[ ](K|k)]"
+      - "<set>[這裡|這邊][的][(燈|燈光)[的]]色溫[<to>]{color_temperature:temperature}[[ ](K|k)]"
+      - "[把|將][這裡|這邊][的][(燈|燈光)[的]]色溫<set_to>{color_temperature_names:temperature}"
+      - "<set>[這裡|這邊][的][(燈|燈光)[的]]色溫[<to>]{color_temperature_names:temperature}"
+    example: "把這裡的色溫調到2700K"
+    inferred_domain: "light"
+    response: "temperature_here"

--- a/sentences/zh-TW/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/zh-TW/HassTurnOff/area_device_class_cover.yaml
@@ -3,6 +3,6 @@ data:
   - sentences:
       - "<close>{area}[的]{cover_classes:device_class}"
       - "[把|將]{area}[的]{cover_classes:device_class}<close>"
-    example: "關閉廚房窗簾"
+    example: "關閉臥室窗簾"
     inferred_domain: "cover"
     response: "cover_device_class"

--- a/sentences/zh-TW/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/zh-TW/HassTurnOff/floor_device_class_cover.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<close>{floor}[的]{cover_classes:device_class}"
+      - "[把|將]{floor}[的]{cover_classes:device_class}<close>"
+    example: "打開二樓的窗簾"
+    inferred_domain: "cover"
+    response: "cover_device_class"

--- a/sentences/zh-TW/HassTurnOff/floor_domain.yaml
+++ b/sentences/zh-TW/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+data:
+  # lights
+  - sentences:
+      - "<turn_off>{floor}[的][<all>]<light>"
+      - "<turn_off>[<all>]{floor}[的]<light>"
+      - "[把|將]{floor}[的][<all>]<light><turn_off>"
+      - "[把|將][<all>]{floor}[的]<light><turn_off>"
+    example: "打開二樓的燈"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/sentences/zh-TW/HassTurnOff/name_floor.yaml
+++ b/sentences/zh-TW/HassTurnOff/name_floor.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+data:
+  # on-able domains
+  - sentences:
+      - "<turn_off>{floor}[的]{name}[的][(<light>|<switch>)]"
+      - "[把|將]{floor}[的]{name}[的][(<light>|<switch>)]<turn_off>"
+    example: "打開二樓的吊扇"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+
+  # covers
+  - sentences:
+      - "<close>{floor}[的]{name}[的]"
+      - "[把|將]{floor}[的]{name}[的]<close>"
+    example: "打開二樓的窗簾"
+    name_domains:
+      - "cover"
+    response: "cover"

--- a/sentences/zh-TW/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/zh-TW/HassTurnOn/floor_device_class_cover.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<open>{floor}[的]{cover_classes:device_class}"
+      - "[把|將]{floor}[的]{cover_classes:device_class}<open>"
+    example: "打開二樓的窗簾"
+    inferred_domain: "cover"
+    response: "cover_device_class"

--- a/sentences/zh-TW/HassTurnOn/floor_domain.yaml
+++ b/sentences/zh-TW/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+data:
+  # lights
+  - sentences:
+      - "<turn_on>{floor}[的][<all>]<light>"
+      - "<turn_on>[<all>]{floor}[的]<light>"
+      - "[把|將]{floor}[的][<all>]<light><turn_on>"
+      - "[把|將][<all>]{floor}[的]<light><turn_on>"
+    example: "打開二樓的燈"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/sentences/zh-TW/HassTurnOn/name_floor.yaml
+++ b/sentences/zh-TW/HassTurnOn/name_floor.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+data:
+  # on-able domains
+  - sentences:
+      - "<turn_on>{floor}[的]{name}[的][(<light>|<switch>)]"
+      - "[把|將]{floor}[的]{name}[的][(<light>|<switch>)]<turn_on>"
+    example: "打開二樓的吊扇"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+
+  # covers
+  - sentences:
+      - "<open>{floor}[的]{name}[的]"
+      - "[把|將]{floor}[的]{name}[的]<open>"
+    example: "打開二樓的窗簾"
+    name_domains:
+      - "cover"
+    response: "cover"

--- a/tests/zh-TW/HassGetState/device_class_state_floor.yaml
+++ b/tests/zh-TW/HassGetState/device_class_state_floor.yaml
@@ -1,0 +1,56 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室大窗戶
+    domain: cover
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: open
+    attributes:
+      device_class: window
+  - name: 臥室小窗戶
+    domain: cover
+    area: 二樓臥室
+    state:
+      in: 關閉
+      out: closed
+    attributes:
+      device_class: window
+tests:
+  - sentences:
+      - 二樓有任何窗戶是開著的嗎？
+    slots:
+      floor: 二樓
+      domain: cover
+      device_class: window
+      state: open
+    response: 是的、臥室大窗戶
+  - sentences:
+      - 二樓所有的窗戶都是開著嗎？
+    slots:
+      floor: 二樓
+      domain: cover
+      device_class: window
+      state: open
+    response: 沒有、臥室小窗戶不是
+  - sentences:
+      - 哪一扇二樓的窗戶是開著的？
+    slots:
+      floor: 二樓
+      domain: cover
+      device_class: window
+      state: open
+    response: 臥室大窗戶
+  - sentences:
+      - 二樓有多少扇窗戶是開著的
+    slots:
+      floor: 二樓
+      domain: cover
+      device_class: window
+      state: open
+    response: "1"

--- a/tests/zh-TW/HassGetState/domain_state_floor.yaml
+++ b/tests/zh-TW/HassGetState/domain_state_floor.yaml
@@ -1,0 +1,48 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室吸頂燈
+    domain: light
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "on"
+  - name: 臥室檯燈
+    domain: light
+    area: 二樓臥室
+    state:
+      in: 關閉
+      out: "off"
+tests:
+  - sentences:
+      - 二樓有任何燈是開著的嗎？
+    slots:
+      floor: 二樓
+      domain: light
+      state: "on"
+    response: 是的、臥室吸頂燈
+  - sentences:
+      - 二樓所有的燈都是開著嗎？
+    slots:
+      floor: 二樓
+      domain: light
+      state: "on"
+    response: 沒有、臥室檯燈不是
+  - sentences:
+      - 哪一盞二樓的燈是開著的？
+    slots:
+      floor: 二樓
+      domain: light
+      state: "on"
+    response: 臥室吸頂燈
+  - sentences:
+      - 二樓有多少盞燈是打開的？
+    slots:
+      floor: 二樓
+      domain: light
+      state: "on"
+    response: "1"

--- a/tests/zh-TW/HassGetState/name_state_floor.yaml
+++ b/tests/zh-TW/HassGetState/name_state_floor.yaml
@@ -1,0 +1,21 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 左側窗簾
+    domain: cover
+    area: 二樓臥室
+    state:
+      in: 關閉
+      out: closed
+tests:
+  - sentences:
+      - 二樓的左側窗簾是關著的嗎？
+    slots:
+      floor: 二樓
+      name: 左側窗簾
+      state: closed
+    response: 是的

--- a/tests/zh-TW/HassGetState/name_where.yaml
+++ b/tests/zh-TW/HassGetState/name_where.yaml
@@ -1,0 +1,20 @@
+language: zh-TW
+entities:
+  - name: 小明
+    domain: person
+    state: home
+  - name: 小美
+    domain: person
+    state: not_home
+tests:
+  - sentences:
+      - 小明在哪裡？
+      - 小明現在在什麼地方？
+    slots:
+      name: 小明
+    response: "小明在家"
+  - sentences:
+      - 小美在哪裡？
+    slots:
+      name: 小美
+    response: "小美不在家"

--- a/tests/zh-TW/HassGetState/name_zone.yaml
+++ b/tests/zh-TW/HassGetState/name_zone.yaml
@@ -1,0 +1,22 @@
+language: zh-TW
+entities:
+  - name: 小明
+    domain: person
+    state: home
+  - name: 小美
+    domain: person
+    state: 公司
+tests:
+  - sentences:
+      - 小明在家嗎？
+      - 小明到家了嗎？
+    slots:
+      name: 小明
+      state: home
+    response: "是的"
+  - sentences:
+      - 小美在公司嗎？
+    slots:
+      name: 小美
+      state: 公司
+    response: "是的"

--- a/tests/zh-TW/HassLightSet/area_temperature.yaml
+++ b/tests/zh-TW/HassLightSet/area_temperature.yaml
@@ -1,0 +1,30 @@
+language: zh-TW
+areas:
+  - name: 臥室
+entities:
+  - name: 臥室檯燈
+    domain: light
+    area: 臥室
+    state:
+      in: 關閉
+      out: "off"
+tests:
+  - sentences:
+      - 把臥室燈光色溫調到2700K
+      - 調整臥室的色溫為2700
+    slots:
+      area: 臥室
+      temperature: 2700
+    response: "臥室色溫已調整為2700"
+  - sentences:
+      - 把臥室色溫調成冷白
+    slots:
+      area: 臥室
+      temperature: 4000
+    response: "臥室色溫已調整為冷白"
+  - sentences:
+      - 調整臥室燈光色溫為白光
+    slots:
+      area: 臥室
+      temperature: 6500
+    response: "臥室色溫已調整為白光"

--- a/tests/zh-TW/HassLightSet/brightness_only.yaml
+++ b/tests/zh-TW/HassLightSet/brightness_only.yaml
@@ -1,0 +1,20 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 把這裡的亮度調到50%
+      - 調整這邊的亮度為百分之50
+    slots:
+      brightness: 50
+    response: "亮度已調整"
+  - sentences:
+      - 把這裡的亮度調到最亮
+      - 調整亮度為最亮
+    slots:
+      brightness: 100
+    response: "亮度已調整"
+  - sentences:
+      - 把這邊的亮度調到最暗
+      - 調整這裡的亮度為最低
+    slots:
+      brightness: 1
+    response: "亮度已調整"

--- a/tests/zh-TW/HassLightSet/color_only.yaml
+++ b/tests/zh-TW/HassLightSet/color_only.yaml
@@ -1,0 +1,14 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 把這裡的燈調成紅色
+      - 把所有的燈調成紅色
+    slots:
+      color: red
+    response: "顏色已調整"
+  - sentences:
+      - 調整這邊的燈光顏色為藍色
+      - 調整全部的燈為藍色
+    slots:
+      color: blue
+    response: "顏色已調整"

--- a/tests/zh-TW/HassLightSet/floor_brightness.yaml
+++ b/tests/zh-TW/HassLightSet/floor_brightness.yaml
@@ -1,0 +1,28 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室吸頂燈
+    domain: light
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "on"
+tests:
+  - sentences:
+      - 把二樓亮度調到50%
+      - 調整二樓燈光亮度為百分之50
+    slots:
+      floor: 二樓
+      brightness: 50
+    response: "二樓亮度已調整為50"
+  - sentences:
+      - 把二樓亮度調到最亮
+      - 調整二樓照明為最亮
+    slots:
+      floor: 二樓
+      brightness: 100
+    response: "二樓亮度已調整為最亮"

--- a/tests/zh-TW/HassLightSet/floor_color.yaml
+++ b/tests/zh-TW/HassLightSet/floor_color.yaml
@@ -1,0 +1,21 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室吸頂燈
+    domain: light
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "on"
+tests:
+  - sentences:
+      - 把二樓燈光調成紅色
+      - 調整二樓照明顏色為紅色
+    slots:
+      floor: 二樓
+      color: red
+    response: "二樓顏色已調整為red"

--- a/tests/zh-TW/HassLightSet/floor_temperature.yaml
+++ b/tests/zh-TW/HassLightSet/floor_temperature.yaml
@@ -1,0 +1,28 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室吸頂燈
+    domain: light
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "on"
+tests:
+  - sentences:
+      - 把二樓燈光色溫調到2700K
+      - 調整二樓的色溫為2700
+    slots:
+      floor: 二樓
+      temperature: 2700
+    response: "二樓色溫已調整為2700"
+  - sentences:
+      - 把二樓色溫調成暖白
+      - 調整二樓燈光色溫為暖白
+    slots:
+      floor: 二樓
+      temperature: 2700
+    response: "二樓色溫已調整為暖白"

--- a/tests/zh-TW/HassLightSet/name_temperature.yaml
+++ b/tests/zh-TW/HassLightSet/name_temperature.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+entities:
+  - name: 臥室檯燈
+    domain: light
+    state:
+      in: 關閉
+      out: "off"
+tests:
+  - sentences:
+      - 把臥室檯燈色溫調到2700K
+      - 調整臥室檯燈的色溫為2700
+      - 把臥室檯燈色溫調成暖白
+      - 調整臥室檯燈色溫為黃光
+    slots:
+      name: 臥室檯燈
+      temperature: 2700
+    response: "臥室檯燈色溫已調整"
+  - sentences:
+      - 把臥室檯燈色溫調成自然光
+    slots:
+      name: 臥室檯燈
+      temperature: 4000
+    response: "臥室檯燈色溫已調整"

--- a/tests/zh-TW/HassLightSet/temperature_only.yaml
+++ b/tests/zh-TW/HassLightSet/temperature_only.yaml
@@ -1,0 +1,14 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 把這裡的色溫調到2700K
+      - 調整色溫為2700
+      - 把這邊的燈色溫調成暖白
+    slots:
+      temperature: 2700
+    response: "色溫已調整"
+  - sentences:
+      - 調整這裡的色溫到日光
+    slots:
+      temperature: 6500
+    response: "色溫已調整"

--- a/tests/zh-TW/HassTurnOff/floor_device_class_cover.yaml
+++ b/tests/zh-TW/HassTurnOff/floor_device_class_cover.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室大窗戶
+    domain: cover
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "open"
+    attributes:
+      device_class: window
+tests:
+  - sentences:
+      - 關閉二樓的窗戶
+      - 把二樓的窗戶關閉
+    slots:
+      device_class: window
+      floor: 二樓
+    response: "window已關閉"

--- a/tests/zh-TW/HassTurnOff/floor_domain.yaml
+++ b/tests/zh-TW/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室吸頂燈
+    domain: light
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "on"
+tests:
+  - sentences:
+      - 關閉二樓的燈
+      - 把所有二樓的燈關閉
+      - 關掉所有二樓的燈
+      - 把二樓的燈關閉
+    slots:
+      domain: light
+      floor: 二樓
+    response: "二樓的燈光已關閉"

--- a/tests/zh-TW/HassTurnOff/name_floor.yaml
+++ b/tests/zh-TW/HassTurnOff/name_floor.yaml
@@ -1,0 +1,34 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 吊扇
+    domain: fan
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "on"
+  - name: 左側窗簾
+    domain: cover
+    area: 二樓臥室
+    state:
+      in: 開啟
+      out: "open"
+tests:
+  - sentences:
+      - 關閉二樓的吊扇
+      - 把二樓的吊扇關閉
+    slots:
+      name: 吊扇
+      floor: 二樓
+    response: "吊扇已關閉"
+  - sentences:
+      - 關閉二樓的左側窗簾
+      - 把二樓的左側窗簾關閉
+    slots:
+      name: 左側窗簾
+      floor: 二樓
+    response: "左側窗簾已關閉"

--- a/tests/zh-TW/HassTurnOn/floor_device_class_cover.yaml
+++ b/tests/zh-TW/HassTurnOn/floor_device_class_cover.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室大窗戶
+    domain: cover
+    area: 二樓臥室
+    state:
+      in: 關閉
+      out: "closed"
+    attributes:
+      device_class: window
+tests:
+  - sentences:
+      - 打開二樓的窗戶
+      - 把二樓的窗戶打開
+    slots:
+      device_class: window
+      floor: 二樓
+    response: "window已打開"

--- a/tests/zh-TW/HassTurnOn/floor_domain.yaml
+++ b/tests/zh-TW/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,23 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 臥室吸頂燈
+    domain: light
+    area: 二樓臥室
+    state:
+      in: 關閉
+      out: "off"
+tests:
+  - sentences:
+      - 打開二樓的燈
+      - 把所有二樓的燈打開
+      - 開啟所有二樓的燈
+      - 把二樓的燈打開
+    slots:
+      domain: light
+      floor: 二樓
+    response: "二樓的燈光已打開"

--- a/tests/zh-TW/HassTurnOn/name_floor.yaml
+++ b/tests/zh-TW/HassTurnOn/name_floor.yaml
@@ -1,0 +1,34 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 吊扇
+    domain: fan
+    area: 二樓臥室
+    state:
+      in: 關閉
+      out: "off"
+  - name: 左側窗簾
+    domain: cover
+    area: 二樓臥室
+    state:
+      in: 關閉
+      out: "closed"
+tests:
+  - sentences:
+      - 打開二樓的吊扇
+      - 把二樓的吊扇打開
+    slots:
+      name: 吊扇
+      floor: 二樓
+    response: "吊扇已打開"
+  - sentences:
+      - 打開二樓的左側窗簾
+      - 把二樓的左側窗簾打開
+    slots:
+      name: 左側窗簾
+      floor: 二樓
+    response: "左側窗簾已打開"


### PR DESCRIPTION
## Changes

Fills the remaining combo gaps in the intents zh-TW already ships, mirroring the `en` combo structure:

### HassLightSet (4/12 → 12/12 combos)
- **brightness_only / color_only / temperature_only** (context-area) — 把這裡的亮度調到50% / 把所有的燈調成紅色 / 調整色溫為2700
- **name_temperature / area_temperature** — 把臥室檯燈色溫調成暖白 / 調整臥室燈光色溫為白光
- **floor_brightness / floor_color / floor_temperature** — 把二樓亮度調到50%
- New `color_temperature_names` list with Taiwan lighting vocabulary: 燭光→1900, 暖白|黃光→2700, 冷白|自然光→4000, 日光|白光→6500 (the numeric range reuses the shared `color_temperature` list)

### HassGetState (+5 combos)
- **name_where** — 小明在哪裡 (renders 在家/不在家/zone name; maps the literal person states `home`/`not_home` to natural Chinese)
- **name_zone** — 小明在家嗎 / 小美在公司嗎. New `home_zone` list maps spoken 家[裡] to the literal person state `home` — a wildcard can't do this for CJK, unlike `en` where the spoken word "home" happens to equal the state value
- **domain_state_floor / device_class_state_floor / name_state_floor** — 二樓有任何燈是開著的嗎

### HassTurnOn / HassTurnOff (+3 combos each)
- **floor_domain** — 打開二樓的燈 (lights only, per `intents.yaml`)
- **name_floor** — 打開二樓的吊扇 / 關閉二樓的左側窗簾
- **floor_device_class_cover** — 打開二樓的窗戶

## Testing

- `python3 -m script.intentfest validate --language zh-TW` — All good
- `pytest tests/test_slot_combinations.py --language zh-TW` — 211 passed (branch verified standalone in an isolated worktree)
- Exercised on a real HAOS install via Assist

Independent of #3966 (no shared files).