### PR TITLE
[zh-TW] Add lawn mower, to-do and shopping list intents

### DIFF
--- a/responses/zh-TW/HassLawnMowerDock.yaml
+++ b/responses/zh-TW/HassLawnMowerDock.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassLawnMowerDock:
+      default: "正在返回充電座"

--- a/responses/zh-TW/HassLawnMowerStartMowing.yaml
+++ b/responses/zh-TW/HassLawnMowerStartMowing.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassLawnMowerStartMowing:
+      default: "已開始除草"

--- a/responses/zh-TW/HassListAddItem.yaml
+++ b/responses/zh-TW/HassListAddItem.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassListAddItem:
+      item_added: "已加入{{ slots.item }}"

--- a/responses/zh-TW/HassListCompleteItem.yaml
+++ b/responses/zh-TW/HassListCompleteItem.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassListCompleteItem:
+      item_completed: "已勾選{{ slots.item }}"

--- a/responses/zh-TW/HassListRemoveItem.yaml
+++ b/responses/zh-TW/HassListRemoveItem.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassListRemoveItem:
+      item_deleted: "已移除{{ slots.item }}"

--- a/responses/zh-TW/HassShoppingListAddItem.yaml
+++ b/responses/zh-TW/HassShoppingListAddItem.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassShoppingListAddItem:
+      item_added: "已加入{{ slots.item }}"

--- a/responses/zh-TW/HassShoppingListCompleteItem.yaml
+++ b/responses/zh-TW/HassShoppingListCompleteItem.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassShoppingListCompleteItem:
+      item_completed: "已勾選{{ slots.item }}"

--- a/sentences/zh-TW/HassLawnMowerDock/default.yaml
+++ b/sentences/zh-TW/HassLawnMowerDock/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "停止(除草|割草)"
+    example: "停止除草"
+    response: "default"

--- a/sentences/zh-TW/HassLawnMowerDock/name_only.yaml
+++ b/sentences/zh-TW/HassLawnMowerDock/name_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[讓|叫]{name}停止(除草|割草)"
+      - "停止{name}"
+    name_domains:
+      - "lawn_mower"
+    example: "讓除草機停止除草"
+    response: "default"

--- a/sentences/zh-TW/HassLawnMowerStartMowing/default.yaml
+++ b/sentences/zh-TW/HassLawnMowerStartMowing/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "開始(除草|割草)"
+    example: "開始除草"
+    response: "default"

--- a/sentences/zh-TW/HassLawnMowerStartMowing/name_only.yaml
+++ b/sentences/zh-TW/HassLawnMowerStartMowing/name_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[讓]{name}開始(除草|割草)"
+    name_domains:
+      - "lawn_mower"
+    example: "讓除草機開始除草"
+    response: "default"

--- a/sentences/zh-TW/HassListAddItem/name_item.yaml
+++ b/sentences/zh-TW/HassListAddItem/name_item.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{todo_list_item:item}(加到|加入|放到|放進)[我的]{name}[清單]"
+      - "(在|往)[我的]{name}[清單][裡|中](加入|加上|新增){todo_list_item:item}"
+      - "[我的]{name}[清單](加入|新增){todo_list_item:item}"
+    example: "把蘋果加到好市多清單"
+    name_domains:
+      - "todo"
+    response: "item_added"

--- a/sentences/zh-TW/HassListCompleteItem/name_item.yaml
+++ b/sentences/zh-TW/HassListCompleteItem/name_item.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{name}[清單](上|中|裡)[的]{todo_list_item:item}(勾選|劃掉|標記為完成)"
+      - "(勾選|完成|劃掉){name}[清單](上|中|裡)[的]{todo_list_item:item}"
+    name_domains:
+      - "todo"
+    example: "勾選待辦清單上的倒垃圾"
+    response: "item_completed"

--- a/sentences/zh-TW/HassListRemoveItem/name_item.yaml
+++ b/sentences/zh-TW/HassListRemoveItem/name_item.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{todo_list_item:item}從[我的]{name}[清單](上|中|裡)(刪除|移除|拿掉)"
+      - "(刪除|移除){name}[清單](上|中|裡)[的]{todo_list_item:item}"
+    name_domains:
+      - "todo"
+    example: "把倒垃圾從待辦清單中移除"
+    response: "item_deleted"

--- a/sentences/zh-TW/HassShoppingListAddItem/item_only.yaml
+++ b/sentences/zh-TW/HassShoppingListAddItem/item_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{shopping_list_item:item}(加到|加入|放到|放進)[我的]購物清單"
+      - "[我的]購物清單(加入|新增){shopping_list_item:item}"
+    example: "把蘋果加到購物清單"
+    response: "item_added"

--- a/sentences/zh-TW/HassShoppingListCompleteItem/item_only.yaml
+++ b/sentences/zh-TW/HassShoppingListCompleteItem/item_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]購物清單(上|中|裡)[的]{shopping_list_item:item}(勾選|劃掉|標記為完成)"
+      - "(勾選|完成|劃掉)購物清單(上|中|裡)[的]{shopping_list_item:item}"
+    example: "勾選購物清單上的蘋果"
+    response: "item_completed"

--- a/tests/zh-TW/HassLawnMowerDock/default.yaml
+++ b/tests/zh-TW/HassLawnMowerDock/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 停止除草
+      - 停止割草
+    response: "正在返回充電座"

--- a/tests/zh-TW/HassLawnMowerDock/name_only.yaml
+++ b/tests/zh-TW/HassLawnMowerDock/name_only.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+entities:
+  - name: 除草機
+    domain: lawn_mower
+tests:
+  - sentences:
+      - 讓除草機停止除草
+      - 停止除草機
+    slots:
+      name: 除草機
+    response: "正在返回充電座"

--- a/tests/zh-TW/HassLawnMowerStartMowing/default.yaml
+++ b/tests/zh-TW/HassLawnMowerStartMowing/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 開始除草
+      - 開始割草
+    response: "已開始除草"

--- a/tests/zh-TW/HassLawnMowerStartMowing/name_only.yaml
+++ b/tests/zh-TW/HassLawnMowerStartMowing/name_only.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+entities:
+  - name: 除草機
+    domain: lawn_mower
+tests:
+  - sentences:
+      - 讓除草機開始除草
+      - 除草機開始割草
+    slots:
+      name: 除草機
+    response: "已開始除草"

--- a/tests/zh-TW/HassListAddItem/name_item.yaml
+++ b/tests/zh-TW/HassListAddItem/name_item.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+entities:
+  - name: 好市多
+    domain: todo
+tests:
+  - sentences:
+      - 把蘋果加到好市多清單
+      - 在好市多清單裡加入蘋果
+      - 好市多清單新增蘋果
+    slots:
+      item: 蘋果
+      name: 好市多
+    response: "已加入蘋果"

--- a/tests/zh-TW/HassListCompleteItem/name_item.yaml
+++ b/tests/zh-TW/HassListCompleteItem/name_item.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+entities:
+  - name: 待辦清單
+    domain: todo
+tests:
+  - sentences:
+      - 把待辦清單上的倒垃圾勾選
+      - 勾選待辦清單上的倒垃圾
+    slots:
+      name: 待辦清單
+      item: 倒垃圾
+    response: "已勾選倒垃圾"

--- a/tests/zh-TW/HassListRemoveItem/name_item.yaml
+++ b/tests/zh-TW/HassListRemoveItem/name_item.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+entities:
+  - name: 待辦清單
+    domain: todo
+tests:
+  - sentences:
+      - 把倒垃圾從待辦清單中移除
+      - 刪除待辦清單上的倒垃圾
+    slots:
+      name: 待辦清單
+      item: 倒垃圾
+    response: "已移除倒垃圾"

--- a/tests/zh-TW/HassShoppingListAddItem/item_only.yaml
+++ b/tests/zh-TW/HassShoppingListAddItem/item_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 把蘋果加到購物清單
+      - 購物清單加入蘋果
+    slots:
+      item: 蘋果
+    response: "已加入蘋果"

--- a/tests/zh-TW/HassShoppingListCompleteItem/item_only.yaml
+++ b/tests/zh-TW/HassShoppingListCompleteItem/item_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 把購物清單上的蘋果勾選
+      - 勾選購物清單上的蘋果
+    slots:
+      item: 蘋果
+    response: "已勾選蘋果"


### PR DESCRIPTION
## Changes

Adds seven intents to zh-TW (Traditional Chinese), following the slot-combination format and mirroring the `en` combo structure:

### Lawn mower
- **HassLawnMowerStartMowing** (default / name_only) — 開始除草 / 讓除草機開始除草
- **HassLawnMowerDock** (default / name_only) — 停止除草 / 停止除草機
- Taiwan vocabulary: 除草機 as the canonical term; input also accepts 割草機

### To-do lists (todo domain, dynamic {name})
- **HassListAddItem** — 把蘋果加到好市多清單 / 在好市多清單裡加入蘋果
- **HassListCompleteItem** — 勾選待辦清單上的倒垃圾
- **HassListRemoveItem** — 把倒垃圾從待辦清單中移除

### Shopping list (built-in, no name slot)
- **HassShoppingListAddItem** — 把蘋果加到購物清單
- **HassShoppingListCompleteItem** — 勾選購物清單上的蘋果

Responses render the item back (已加入蘋果 / 已勾選倒垃圾 / 已移除倒垃圾).

## Testing

- `python3 -m script.intentfest validate --language zh-TW` — All good
- `pytest tests/test_slot_combinations.py --language zh-TW` — 211 passed (branch verified standalone in an isolated worktree)