### PR TITLE
[zh-TW] Add vacuum intents (start, clean area, return to base)

### DIFF
--- a/responses/zh-TW/HassVacuumCleanArea.yaml
+++ b/responses/zh-TW/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "正在打掃{{ slots.area }}"

--- a/responses/zh-TW/HassVacuumReturnToBase.yaml
+++ b/responses/zh-TW/HassVacuumReturnToBase.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassVacuumReturnToBase:
+      default: "正在返回充電座"

--- a/responses/zh-TW/HassVacuumStart.yaml
+++ b/responses/zh-TW/HassVacuumStart.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassVacuumStart:
+      default: "已啟動"

--- a/sentences/zh-TW/HassVacuumCleanArea/area_only.yaml
+++ b/sentences/zh-TW/HassVacuumCleanArea/area_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(打掃|清掃)[一下]{area}"
+    example: "打掃客廳"
+    response: "default"

--- a/sentences/zh-TW/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/zh-TW/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(打掃|清掃)[一下](這裡|這邊)"
+    example: "打掃這裡"
+    response: "default"

--- a/sentences/zh-TW/HassVacuumCleanArea/name_area.yaml
+++ b/sentences/zh-TW/HassVacuumCleanArea/name_area.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "用{name}(打掃|清掃){area}"
+      - "[讓]{name}[去](打掃|清掃){area}"
+    name_domains:
+      - "vacuum"
+    example: "讓掃地機器人去打掃客廳"
+    response: "default"

--- a/sentences/zh-TW/HassVacuumReturnToBase/name_only.yaml
+++ b/sentences/zh-TW/HassVacuumReturnToBase/name_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[讓|叫]{name}(回充電座|回去充電|返回充電座)"
+    name_domains:
+      - "vacuum"
+    example: "讓掃地機器人回充電座"
+    response: "default"

--- a/sentences/zh-TW/HassVacuumStart/floor_only.yaml
+++ b/sentences/zh-TW/HassVacuumStart/floor_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(打掃|清掃)[一下]{floor}"
+    example: "打掃二樓"
+    response: "default"

--- a/sentences/zh-TW/HassVacuumStart/name_only.yaml
+++ b/sentences/zh-TW/HassVacuumStart/name_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(啟動|開始){name}"
+      - "[讓]{name}開始(打掃|工作|掃地)"
+    name_domains:
+      - "vacuum"
+    example: "啟動掃地機器人"
+    response: "default"

--- a/tests/zh-TW/HassVacuumCleanArea/area_only.yaml
+++ b/tests/zh-TW/HassVacuumCleanArea/area_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+areas:
+  - name: 客廳
+tests:
+  - sentences:
+      - 打掃客廳
+      - 清掃一下客廳
+    slots:
+      area: 客廳
+    response: "正在打掃客廳"

--- a/tests/zh-TW/HassVacuumCleanArea/context_area.yaml
+++ b/tests/zh-TW/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 打掃這裡
+      - 清掃一下這邊
+    response: "正在打掃__context_area__"

--- a/tests/zh-TW/HassVacuumCleanArea/name_area.yaml
+++ b/tests/zh-TW/HassVacuumCleanArea/name_area.yaml
@@ -1,0 +1,15 @@
+language: zh-TW
+areas:
+  - name: 客廳
+entities:
+  - name: 掃地機器人
+    domain: vacuum
+    area: 客廳
+tests:
+  - sentences:
+      - 用掃地機器人打掃客廳
+      - 讓掃地機器人去打掃客廳
+    slots:
+      name: 掃地機器人
+      area: 客廳
+    response: "正在打掃客廳"

--- a/tests/zh-TW/HassVacuumReturnToBase/name_only.yaml
+++ b/tests/zh-TW/HassVacuumReturnToBase/name_only.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+entities:
+  - name: 掃地機器人
+    domain: vacuum
+tests:
+  - sentences:
+      - 讓掃地機器人回充電座
+      - 掃地機器人回去充電
+    slots:
+      name: 掃地機器人
+    response: "正在返回充電座"

--- a/tests/zh-TW/HassVacuumStart/floor_only.yaml
+++ b/tests/zh-TW/HassVacuumStart/floor_only.yaml
@@ -1,0 +1,17 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 掃地機器人
+    domain: vacuum
+    area: 二樓臥室
+tests:
+  - sentences:
+      - 打掃二樓
+      - 清掃一下二樓
+    slots:
+      floor: 二樓
+    response: "已啟動"

--- a/tests/zh-TW/HassVacuumStart/name_only.yaml
+++ b/tests/zh-TW/HassVacuumStart/name_only.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+entities:
+  - name: 掃地機器人
+    domain: vacuum
+tests:
+  - sentences:
+      - 啟動掃地機器人
+      - 讓掃地機器人開始打掃
+    slots:
+      name: 掃地機器人
+    response: "已啟動"


### PR DESCRIPTION
## Changes

Adds three vacuum intents to zh-TW (Traditional Chinese), following the slot-combination format and mirroring the `en` combo structure:

- **HassVacuumStart** (name_only / floor_only) — 啟動掃地機器人 / 讓掃地機器人開始打掃 / 打掃二樓
- **HassVacuumCleanArea** (context_area / area_only / name_area) — 打掃這裡 / 打掃客廳 / 讓掃地機器人去打掃客廳; the context-area response renders the satellite's area (正在打掃客廳)
- **HassVacuumReturnToBase** (name_only) — 讓掃地機器人回充電座 / 掃地機器人回去充電

Taiwan vocabulary: 掃地機器人 for the robot, 充電座 for the dock (回充電座|回去充電|返回充電座).

Start verbs are (啟動|開始) rather than 打開 to avoid overlapping with HassTurnOn's name templates.

## Testing

- `python3 -m script.intentfest validate --language zh-TW` — All good
- `pytest tests/test_slot_combinations.py --language zh-TW` — 211 passed (branch verified standalone in an isolated worktree)