### PR TITLE
Fix wrong description for HassGetCurrentTime

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -786,7 +786,7 @@ HassGetCurrentTime:
   description: "Gets the current time"
   slot_combinations:
     default:
-      description: "Get the current weather"
+      description: "Get the current time"
       importance: "usable"
       slots: []
       example: "what time is it"


### PR DESCRIPTION
I found a wrong description during learning file structure in this repository to create #3986 .
I'm not sure the history but maybe it was created by copy/paste from GetCurrentWeather and missed fixing it.