### PR TITLE
[DE] Fix area rule preposition handling

### DIFF
--- a/rules/de/common.yaml
+++ b/rules/de/common.yaml
@@ -3,10 +3,11 @@ expansion_rules:
   artikel_bestimmt: (der|die|das|dem|den|des)
   possessivpronom_mein: (mein|meine|meines|meiner|meinem|meinen)
   possessivpronom_unser: (unser|unsere|unseres|unserer|unserem|unseren)
+  preposition: (in|an|bei|auf)
   name: "[<artikel_bestimmt> ]{name}"
   area:
-    "[(<preposition>|<artikel_bestimmt>) ]{area}|(<preposition> der|(an|in) die|in
-    dem|im|am|<von_dem>) {area}|des {area}s"
+    "[(<preposition>|<artikel_bestimmt>) ]{area}|(<preposition> (der|dem)|(an|in)
+    die|im|am|<von_dem>) {area}|des {area}s"
   floor: "[([(in|auf) ]<artikel_bestimmt>|im|<von_dem>) ]{floor}[[ ]Geschoss]"
   hier:
     (hier[ (im|in diesem) (Raum|Bereich|Zimmer)]|(im|in diesem|diesen|den) (Raum|Bereich)|(im|in

--- a/rules/de/covers.yaml
+++ b/rules/de/covers.yaml
@@ -1,3 +1,0 @@
-language: de
-expansion_rules:
-  preposition: (in|an|bei|auf)

--- a/tests/de/HassTurnOn/area_domain.yaml
+++ b/tests/de/HassTurnOn/area_domain.yaml
@@ -9,6 +9,7 @@ language: "de"
 areas:
   - name: "Küche"
   - name: "Wohnzimmer"
+  - name: "Balkon"
 
 tests:
   # lights
@@ -27,6 +28,17 @@ tests:
       - "in der Küche Lichtern"
     slots:
       area: "Küche"
+      domain: "light"
+    response: "Licht eingeschaltet"
+
+  # lights, preposition with dative article (issue 3990)
+  - sentences:
+      - "Schalte das Licht auf dem Balkon ein"
+      - "Schalte auf dem Balkon das Licht ein"
+      - "Licht auf dem Balkon einschalten"
+      - "Mach das Licht auf dem Balkon an"
+    slots:
+      area: "Balkon"
       domain: "light"
     response: "Licht eingeschaltet"
 


### PR DESCRIPTION
Fixes #3990.

The `preposition` rule referenced by the `area` rule in `rules/de/common.yaml` was misplaced into `rules/de/covers.yaml` during the modern-syntax migration (#3887). It belongs to the shared grammar rules, so this moves it back next to `artikel_bestimmt` and removes the now empty covers.yaml. All rule files are merged per language, so the move itself is a readability fix, not a behavior change.

The actual gap behind the issue: the area rule only combined a preposition with the article "der" ("in der Küche", "auf der Terrasse"), while the dative article "dem" was limited to "in dem", "im" and "am". "Schalte das Licht auf dem Balkon ein" was not recognized. The rule now allows "dem" after any preposition (auf dem, an dem, bei dem), covered with new test sentences.

"Licht im Garten einschalten" from the issue already worked via the explicit "im" alternative.

Local checks: intentfest validate, pytest --language de (324 passed), check_overmatch (0 over-matches, 0 no-match), prune --check clean.
