### PR TITLE
[DE] Add floor slot combinations for HassTurnOn and HassTurnOff

### DIFF
--- a/responses/de/HassTurnOff.yaml
+++ b/responses/de/HassTurnOff.yaml
@@ -6,6 +6,7 @@ responses:
       light: "Licht ausgeschaltet"
       light_all: "Alle Lichter ausgeschaltet"
       lights_area: "Licht ausgeschaltet"
+      lights_floor: "Licht ausgeschaltet"
       fan: "Ventilator ausgeschaltet"
       fan_all: "Alle Ventilatoren ausgeschaltet"
       fans_area: "Ventilator ausgeschaltet"

--- a/responses/de/HassTurnOn.yaml
+++ b/responses/de/HassTurnOn.yaml
@@ -6,6 +6,7 @@ responses:
       light: "Licht eingeschaltet"
       light_all: "Alle Lichter eingeschaltet"
       lights_area: "Licht eingeschaltet"
+      lights_floor: "Licht eingeschaltet"
       fan: "Ventilator eingeschaltet"
       fan_all: "Alle Ventilatoren eingeschaltet"
       fans_area: "Ventilator eingeschaltet"

--- a/sentences/de/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/de/HassTurnOff/floor_device_class_cover.yaml
@@ -1,0 +1,22 @@
+---
+# HassTurnOff - floor_device_class_cover
+# example: schließe die Rollläden im Obergeschoss
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "de"
+data:
+  - sentences:
+      - "<schliessen> [<artikel_bestimmt> ]{cover_classes:device_class} <floor>"
+      - "<schliessen> <floor> [<artikel_bestimmt> ]{cover_classes:device_class}"
+      - "[<artikel_bestimmt> ]{cover_classes:device_class} <floor> <schliessen_end_of_sentence>"
+      - "<floor> [<artikel_bestimmt> ]{cover_classes:device_class} <schliessen_end_of_sentence>"
+      - "(<machen>|<fahren>) <floor> [<artikel_bestimmt> ]{cover_classes:device_class} <zu>"
+      - "(<machen>|<fahren>) [<artikel_bestimmt> ]{cover_classes:device_class} <floor> <zu>"
+      - "[<artikel_bestimmt> ]{cover_classes:device_class} <floor> <zu>[[ ](machen|fahren)]"
+      - "<floor> [<artikel_bestimmt> ]{cover_classes:device_class} <zu>[[ ](machen|fahren)]"
+    example: "schließe die Rollläden im Obergeschoss"
+    inferred_domain: "cover"
+    response: "cover_device_class"

--- a/sentences/de/HassTurnOff/floor_domain.yaml
+++ b/sentences/de/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,21 @@
+---
+# HassTurnOff - floor_domain
+# example: schalte alle Lichter im Obergeschoss aus
+# slots:
+# - {floor}
+# - {domain}
+
+language: "de"
+data:
+  # lights
+  - sentences:
+      - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <floor> aus"
+      - "(<schalten>|dreh[e]) (<licht>|<lichter>|<alle_lichter>) <floor> ab"
+      - "(<schalten>|<machen>) <floor> (<licht>|<lichter>|<alle_lichter>) aus"
+      - "(<schalten>|dreh[e]) <floor> (<licht>|<lichter>|<alle_lichter>) ab"
+      - "(<licht>|<lichter>|<alle_lichter>) <floor> (aus[schalten]|abschalten|ausmachen|abdrehen)"
+      - "(<licht>|<lichter>|<alle_lichter>) (aus[schalten]|abschalten|ausmachen|abdrehen) <floor>"
+      - "<floor> (<licht>|<lichter>|<alle_lichter>) (aus[schalten]|abschalten|ausmachen|abdrehen)"
+    example: "schalte alle Lichter im Obergeschoss aus"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/sentences/de/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/de/HassTurnOn/floor_device_class_cover.yaml
@@ -1,0 +1,22 @@
+---
+# HassTurnOn - floor_device_class_cover
+# example: öffne die Rollläden im Obergeschoss
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "de"
+data:
+  - sentences:
+      - "öffne [<artikel_bestimmt> ]{cover_classes:device_class} <floor>"
+      - "öffne <floor> [<artikel_bestimmt> ]{cover_classes:device_class}"
+      - "[<artikel_bestimmt> ]{cover_classes:device_class} <floor> <öffnen_end_of_sentence>"
+      - "<floor> [<artikel_bestimmt> ]{cover_classes:device_class} <öffnen_end_of_sentence>"
+      - "(<machen>|<fahren>) <floor> [<artikel_bestimmt> ]{cover_classes:device_class} <auf>"
+      - "(<machen>|<fahren>) [<artikel_bestimmt> ]{cover_classes:device_class} <floor> <auf>"
+      - "[<artikel_bestimmt> ]{cover_classes:device_class} <floor> <auf>[[ ](machen|fahren)]"
+      - "<floor> [<artikel_bestimmt> ]{cover_classes:device_class} <auf>[[ ](machen|fahren)]"
+    example: "öffne die Rollläden im Obergeschoss"
+    inferred_domain: "cover"
+    response: "cover_device_class"

--- a/sentences/de/HassTurnOn/floor_domain.yaml
+++ b/sentences/de/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,23 @@
+---
+# HassTurnOn - floor_domain
+# example: schalte alle Lichter im Obergeschoss an
+# slots:
+# - {floor}
+# - {domain}
+
+language: "de"
+data:
+  # lights
+  - sentences:
+      - "(<schalten>|<machen>) (<licht>|<lichter>|<alle_lichter>) <floor> an"
+      - "<schalten> (<licht>|<lichter>|<alle_lichter>) <floor> ein"
+      - "dreh[e] (<licht>|<lichter>|<alle_lichter>) <floor> auf"
+      - "(<schalten>|<machen>) <floor> (<licht>|<lichter>|<alle_lichter>) an"
+      - "<schalten> <floor> (<licht>|<lichter>|<alle_lichter>) ein"
+      - "dreh[e] <floor> (<licht>|<lichter>|<alle_lichter>) auf"
+      - "(<licht>|<lichter>|<alle_lichter>) <floor> ((an|ein)[schalten]|anmachen|aufdrehen)"
+      - "(<licht>|<lichter>|<alle_lichter>) ((an|ein)[schalten]|anmachen|aufdrehen) <floor>"
+      - "<floor> (<licht>|<lichter>|<alle_lichter>) ((an|ein)[schalten]|anmachen|aufdrehen)"
+    example: "schalte alle Lichter im Obergeschoss an"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/tests/de/HassTurnOff/floor_device_class_cover.yaml
+++ b/tests/de/HassTurnOff/floor_device_class_cover.yaml
@@ -1,0 +1,40 @@
+---
+# HassTurnOff - floor_device_class_cover
+# example: schließe die Rollläden im Obergeschoss
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "de"
+floors:
+  - name: "Obergeschoss"
+  - name: "Erdgeschoss"
+
+tests:
+  # shutters
+  - sentences:
+      - "Schließe die Rollläden im Obergeschoss"
+      - "Schließe im Obergeschoss die Rollläden"
+      - "Die Rollläden im Obergeschoss schließen"
+      - "Mach die Rollläden im Obergeschoss zu"
+      - "Mach im Obergeschoss die Rollläden zu"
+      - "Die Rollläden im Obergeschoss runterfahren"
+      - "Im Obergeschoss die Rollläden runterfahren"
+    slots:
+      floor: "Obergeschoss"
+      domain: "cover"
+      device_class: "shutter"
+    response: "Rollladen geschlossen"
+
+  # windows
+  - sentences:
+      - "Schließe die Fenster im Erdgeschoss"
+      - "Schließe im Erdgeschoss die Fenster"
+      - "Die Fenster im Erdgeschoss schließen"
+      - "Im Erdgeschoss die Fenster schließen"
+    slots:
+      floor: "Erdgeschoss"
+      domain: "cover"
+      device_class: "window"
+    response: "Fenster geschlossen"

--- a/tests/de/HassTurnOff/floor_domain.yaml
+++ b/tests/de/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,37 @@
+---
+# HassTurnOff - floor_domain
+# example: schalte alle Lichter im Obergeschoss aus
+# slots:
+# - {floor}
+# - {domain}
+
+language: "de"
+floors:
+  - name: "Obergeschoss"
+  - name: "Erdgeschoss"
+
+tests:
+  - sentences:
+      - "Schalte das Licht im Obergeschoss aus"
+      - "Schalte die Lichter im Obergeschoss ab"
+      - "Schalte alle Lichter im Obergeschoss aus"
+      - "Dreh das Licht im Obergeschoss ab"
+      - "Schalte im Obergeschoss alle Lichter aus"
+      - "Licht im Obergeschoss ausschalten"
+      - "Das Licht im Obergeschoss ausmachen"
+      - "Im Obergeschoss das Licht ausschalten"
+      - "Die Lichter ausmachen im Obergeschoss"
+      - "Dreh im Obergeschoss das Licht ab"
+    slots:
+      floor: "Obergeschoss"
+      domain: "light"
+    response: "Licht ausgeschaltet"
+
+  - sentences:
+      - "Schalte das Licht im Erdgeschoss aus"
+      - "Mach im Erdgeschoss alle Lichter aus"
+      - "Die Lampen im Erdgeschoss ausschalten"
+    slots:
+      floor: "Erdgeschoss"
+      domain: "light"
+    response: "Licht ausgeschaltet"

--- a/tests/de/HassTurnOn/floor_device_class_cover.yaml
+++ b/tests/de/HassTurnOn/floor_device_class_cover.yaml
@@ -1,0 +1,40 @@
+---
+# HassTurnOn - floor_device_class_cover
+# example: öffne die Rollläden im Obergeschoss
+# slots:
+# - {floor}
+# - {domain}
+# - {device_class}
+
+language: "de"
+floors:
+  - name: "Obergeschoss"
+  - name: "Erdgeschoss"
+
+tests:
+  # shutters
+  - sentences:
+      - "Öffne die Rollläden im Obergeschoss"
+      - "Öffne im Obergeschoss die Rollläden"
+      - "Die Rollläden im Obergeschoss öffnen"
+      - "Mach die Rollläden im Obergeschoss auf"
+      - "Mach im Obergeschoss die Rollläden auf"
+      - "Die Rollläden im Obergeschoss hochfahren"
+      - "Im Obergeschoss die Rollläden hochfahren"
+    slots:
+      floor: "Obergeschoss"
+      domain: "cover"
+      device_class: "shutter"
+    response: "Rollladen geöffnet"
+
+  # windows
+  - sentences:
+      - "Öffne die Fenster im Erdgeschoss"
+      - "Öffne im Erdgeschoss die Fenster"
+      - "Die Fenster im Erdgeschoss öffnen"
+      - "Im Erdgeschoss die Fenster öffnen"
+    slots:
+      floor: "Erdgeschoss"
+      domain: "cover"
+      device_class: "window"
+    response: "Fenster geöffnet"

--- a/tests/de/HassTurnOn/floor_domain.yaml
+++ b/tests/de/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,38 @@
+---
+# HassTurnOn - floor_domain
+# example: schalte alle Lichter im Obergeschoss an
+# slots:
+# - {floor}
+# - {domain}
+
+language: "de"
+floors:
+  - name: "Obergeschoss"
+  - name: "Erdgeschoss"
+
+tests:
+  - sentences:
+      - "Schalte das Licht im Obergeschoss an"
+      - "Schalte die Lichter im Obergeschoss ein"
+      - "Schalte alle Lichter im Obergeschoss an"
+      - "Dreh das Licht im Obergeschoss auf"
+      - "Schalte im Obergeschoss alle Lichter an"
+      - "Licht im Obergeschoss an"
+      - "Das Licht im Obergeschoss einschalten"
+      - "Im Obergeschoss das Licht anmachen"
+      - "Die Lichter anmachen im Obergeschoss"
+      - "Dreh im Obergeschoss das Licht auf"
+    slots:
+      floor: "Obergeschoss"
+      domain: "light"
+    response: "Licht eingeschaltet"
+
+  - sentences:
+      - "Schalte das Licht im Erdgeschoss ein"
+      - "Schalte im Erdgeschoss das Licht ein"
+      - "Mach im Erdgeschoss alle Lichter an"
+      - "Die Lampen im Erdgeschoss einschalten"
+    slots:
+      floor: "Erdgeschoss"
+      domain: "light"
+    response: "Licht eingeschaltet"


### PR DESCRIPTION
Adds the four missing German floor combinations: floor_domain and floor_device_class_cover for HassTurnOn and HassTurnOff.

The sentences mirror the existing German area variants using the shared floor rule ("Schalte alle Lichter im Obergeschoss an", "Schließe die Rollläden im Obergeschoss"). Scope matches the English files: lights for floor_domain, covers for floor_device_class_cover. Also adds the lights_floor responses for German and test files covering every sentence template.

Local checks: intentfest validate, pytest --language de (324 passed), check_overmatch (0 over-matches, 0 no-match), prune --check clean.
