### PR TITLE
[DE] Add vacuum area slot combinations

### DIFF
--- a/sentences/de/HassVacuumReturnToBase/area_only.yaml
+++ b/sentences/de/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassVacuumReturnToBase - area_only
+# example: schicke den Staubsauger in der Küche zurück zur Basis
+# slots: {area}
+
+language: "de"
+data:
+  - sentences:
+      - "(schick[e]|befehl[e]) [den ](Staubsauger|Saugroboter|Sauger) <area> zurück[ (zur|(in|an) die) (Basis[station]|Ladestation)]"
+      - "[den ](Staubsauger|Saugroboter|Sauger) <area> (zurück[ ]schicken|(zur|(in|an) die) (Basis[station]|Ladestation) [zurück[ ]]schicken)"
+    example: "schicke den Staubsauger in der Küche zurück zur Basis"
+    response: "default"

--- a/sentences/de/HassVacuumStart/area_only.yaml
+++ b/sentences/de/HassVacuumStart/area_only.yaml
@@ -1,0 +1,13 @@
+---
+# HassVacuumStart - area_only
+# example: starte den Staubsauger in der Küche
+# slots: {area}
+
+language: "de"
+data:
+  - sentences:
+      - "(<schalten>|<machen>) [den ](Staubsauger|Saugroboter|Sauger) <area> <an>"
+      - "(<ausfuehren>|<aktivieren>) [den ](Staubsauger|Saugroboter|Sauger) <area>"
+      - "[den ](Staubsauger|Saugroboter|Sauger) <area> (starten|<an>[schalten|machen])"
+    example: "starte den Staubsauger in der Küche"
+    response: "default"

--- a/tests/de/HassVacuumReturnToBase/area_only.yaml
+++ b/tests/de/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,26 @@
+---
+# HassVacuumReturnToBase - area_only
+# example: schicke den Staubsauger in der Küche zurück zur Basis
+# slots: {area}
+
+language: "de"
+areas:
+  - name: "Küche"
+  - name: "Wohnzimmer"
+
+tests:
+  - sentences:
+      - "Schick den Staubsauger in der Küche zurück"
+      - "Schicke den Staubsauger in der Küche zurück zur Basis"
+      - "Den Staubsauger in der Küche zurückschicken"
+    slots:
+      area: "Küche"
+    response: "Kehrt zurück"
+
+  - sentences:
+      - "Schicke den Saugroboter im Wohnzimmer zurück zur Ladestation"
+      - "Den Saugroboter im Wohnzimmer zur Ladestation zurückschicken"
+      - "Den Sauger im Wohnzimmer zur Basis schicken"
+    slots:
+      area: "Wohnzimmer"
+    response: "Kehrt zurück"

--- a/tests/de/HassVacuumStart/area_only.yaml
+++ b/tests/de/HassVacuumStart/area_only.yaml
@@ -1,0 +1,27 @@
+---
+# HassVacuumStart - area_only
+# example: starte den Staubsauger in der Küche
+# slots: {area}
+
+language: "de"
+areas:
+  - name: "Küche"
+  - name: "Wohnzimmer"
+
+tests:
+  - sentences:
+      - "Starte den Staubsauger in der Küche"
+      - "Schalte den Staubsauger in der Küche an"
+      - "Schalte den Staubsauger in der Küche ein"
+      - "Den Staubsauger in der Küche starten"
+    slots:
+      area: "Küche"
+    response: "Gestartet"
+
+  - sentences:
+      - "Aktiviere den Staubsauger im Wohnzimmer"
+      - "Mach den Saugroboter im Wohnzimmer an"
+      - "Den Sauger im Wohnzimmer anschalten"
+    slots:
+      area: "Wohnzimmer"
+    response: "Gestartet"


### PR DESCRIPTION
Adds the two missing German area_only combinations for HassVacuumStart and HassVacuumReturnToBase.

HassVacuumCleanArea already owns the "clean this area" phrasing in German ("die Küche saugen"), so the new HassVacuumStart sentences target the vacuum located in an area instead ("starte den Staubsauger in der Küche"), and HassVacuumReturnToBase sends it back to its base ("schicke den Staubsauger in der Küche zurück zur Basis").

Local checks: intentfest validate, pytest --language de (324 passed), check_overmatch (0 over-matches, 0 no-match), prune --check clean.
