### PR TITLE
[DE] Add remaining HassSetPosition slot combinations

### DIFF
--- a/sentences/de/HassSetPosition/floor_device_class.yaml
+++ b/sentences/de/HassSetPosition/floor_device_class.yaml
@@ -1,0 +1,13 @@
+---
+# HassSetPosition - floor_device_class
+# slots: {floor}, {device_class}, {domain}, {position}
+
+language: "de"
+data:
+  - sentences:
+      - "(<machen>|<fahren>|<setzen>|öffne|<schliessen>) [<artikel_bestimmt> ]{cover_classes:device_class}[ Position] (auf {position}[ (Prozent|%)];<floor>)"
+      - "(<machen>|<fahren>|<setzen>|öffne|<schliessen>) <floor> [<artikel_bestimmt> ]{cover_classes:device_class}[ Position] auf {position}[ (Prozent|%)]"
+      - "[<artikel_bestimmt> ]{cover_classes:device_class} <floor> auf {position}[ (Prozent|%)][ (machen|fahren|<schliessen_end_of_sentence>|<setzen_end_of_sentence>)]"
+    example: "mache im Obergeschoss die Rollläden auf 20%"
+    inferred_domain: "cover"
+    response: "cover_device_class"

--- a/sentences/de/HassSetPosition/name_area.yaml
+++ b/sentences/de/HassSetPosition/name_area.yaml
@@ -1,0 +1,18 @@
+---
+# HassSetPosition - name_area
+# slots: {name}, {area}, {position}
+
+language: "de"
+data:
+  # Set position by name in an area to a percentage value
+  - sentences:
+      - "(öffne|<schliessen>|<machen>|<fahren>|<setzen>) [<artikel_bestimmt> ]{name} (auf {position}[ (Prozent|%)];<area>)"
+      - "(öffne|<schliessen>|<machen>|<fahren>|<setzen>) <area> [<artikel_bestimmt> ]{name} auf {position}[ (Prozent|%)]"
+      - "[<artikel_bestimmt> ]{name} <area> auf {position}[ (Prozent|%)] (öffnen|<schliessen_end_of_sentence>|machen|fahren|setzen|stellen)"
+      - "<setze> [die ]Position[ <von_dem>] [<artikel_bestimmt> ]{name} <area>[ auf] {position}[ (Prozent|%)]"
+      - "<stelle> [die ]Position[ <von_dem>] [<artikel_bestimmt> ]{name} <area>[ auf] {position}[ (Prozent|%)][ ein]"
+      - "[die ]Position[ <von_dem>] [<artikel_bestimmt> ]{name} <area>[ auf] {position}[ (Prozent|%)] <setzen_end_of_sentence>"
+    example: "stelle den Vorhang links im Wohnzimmer auf 50%"
+    name_domains:
+      - "cover"
+    response: "default"

--- a/sentences/de/HassSetPosition/name_floor.yaml
+++ b/sentences/de/HassSetPosition/name_floor.yaml
@@ -1,0 +1,18 @@
+---
+# HassSetPosition - name_floor
+# slots: {name}, {floor}, {position}
+
+language: "de"
+data:
+  # Set position by name on a floor to a percentage value
+  - sentences:
+      - "(öffne|<schliessen>|<machen>|<fahren>|<setzen>) [<artikel_bestimmt> ]{name} (auf {position}[ (Prozent|%)];<floor>)"
+      - "(öffne|<schliessen>|<machen>|<fahren>|<setzen>) <floor> [<artikel_bestimmt> ]{name} auf {position}[ (Prozent|%)]"
+      - "[<artikel_bestimmt> ]{name} <floor> auf {position}[ (Prozent|%)] (öffnen|<schliessen_end_of_sentence>|machen|fahren|setzen|stellen)"
+      - "<setze> [die ]Position[ <von_dem>] [<artikel_bestimmt> ]{name} <floor>[ auf] {position}[ (Prozent|%)]"
+      - "<stelle> [die ]Position[ <von_dem>] [<artikel_bestimmt> ]{name} <floor>[ auf] {position}[ (Prozent|%)][ ein]"
+      - "[die ]Position[ <von_dem>] [<artikel_bestimmt> ]{name} <floor>[ auf] {position}[ (Prozent|%)] <setzen_end_of_sentence>"
+    example: "stelle den Vorhang links im Obergeschoss auf 50%"
+    name_domains:
+      - "cover"
+    response: "default"

--- a/tests/de/HassSetPosition/floor_device_class.yaml
+++ b/tests/de/HassSetPosition/floor_device_class.yaml
@@ -1,0 +1,35 @@
+---
+# HassSetPosition - floor_device_class
+
+language: de
+floors:
+  - name: "Obergeschoss"
+  - name: "Erdgeschoss"
+
+tests:
+  # shutters
+  - sentences:
+      - "stelle die Rollläden im Obergeschoss auf 20%"
+      - "öffne die Rollläden im Obergeschoss auf 20%"
+      - "mache die Rollläden auf 20% im Obergeschoss"
+      - "fahre im Obergeschoss die Rollläden auf 20%"
+      - "die Rollläden im Obergeschoss auf 20% fahren"
+      - "Rollläden im Obergeschoss auf 20% schließen"
+    slots:
+      floor: "Obergeschoss"
+      domain: cover
+      device_class: shutter
+      position: 20
+    response: "Position von Rollladen festgelegt"
+
+  # curtains
+  - sentences:
+      - "schließe die Vorhänge im Erdgeschoss auf 30%"
+      - "mache im Erdgeschoss die Vorhänge auf 30%"
+      - "die Vorhänge im Erdgeschoss auf 30% schließen"
+    slots:
+      floor: "Erdgeschoss"
+      domain: cover
+      device_class: curtain
+      position: 30
+    response: "Position von Vorhang festgelegt"

--- a/tests/de/HassSetPosition/name_area.yaml
+++ b/tests/de/HassSetPosition/name_area.yaml
@@ -1,0 +1,31 @@
+---
+# HassSetPosition - name_area
+
+language: de
+entities:
+  - name: "Vorhang links"
+    domain: cover
+    attributes:
+      device_class: curtain
+areas:
+  - name: Wohnzimmer
+
+tests:
+  # percentage value, cover by name in an area
+  - sentences:
+      - "stelle den Vorhang links im Wohnzimmer auf 50%"
+      - "öffne den Vorhang links auf 50% im Wohnzimmer"
+      - "fahre den Vorhang links im Wohnzimmer auf 50 Prozent"
+      - "schließe den Vorhang links im Wohnzimmer auf 50%"
+      - "mache im Wohnzimmer den Vorhang links auf 50%"
+      - "stelle im Wohnzimmer den Vorhang links auf 50 Prozent"
+      - "den Vorhang links im Wohnzimmer auf 50% fahren"
+      - "Vorhang links im Wohnzimmer auf 50% schließen"
+      - "setze die Position von dem Vorhang links im Wohnzimmer auf 50%"
+      - "stelle die Position vom Vorhang links im Wohnzimmer auf 50% ein"
+      - "die Position vom Vorhang links im Wohnzimmer auf 50% stellen"
+    slots:
+      name: "Vorhang links"
+      area: Wohnzimmer
+      position: 50
+    response: "Position festgelegt"

--- a/tests/de/HassSetPosition/name_floor.yaml
+++ b/tests/de/HassSetPosition/name_floor.yaml
@@ -1,0 +1,40 @@
+---
+# HassSetPosition - name_floor
+
+language: de
+entities:
+  - name: "Vorhang links"
+    domain: cover
+    attributes:
+      device_class: curtain
+floors:
+  - name: "Obergeschoss"
+  - name: "Dachboden"
+
+tests:
+  # percentage value, cover by name on a floor
+  - sentences:
+      - "stelle den Vorhang links im Obergeschoss auf 50%"
+      - "öffne den Vorhang links auf 50% im Obergeschoss"
+      - "schließe den Vorhang links im Obergeschoss auf 50%"
+      - "mache im Obergeschoss den Vorhang links auf 50%"
+      - "den Vorhang links im Obergeschoss auf 50% fahren"
+      - "Vorhang links im Obergeschoss auf 50% schließen"
+      - "setze die Position von dem Vorhang links im Obergeschoss auf 50%"
+      - "stelle die Position vom Vorhang links im Obergeschoss auf 50% ein"
+      - "die Position vom Vorhang links im Obergeschoss auf 50% stellen"
+    slots:
+      name: "Vorhang links"
+      floor: "Obergeschoss"
+      position: 50
+    response: "Position festgelegt"
+
+  # percentage value, cover by name on the attic floor
+  - sentences:
+      - "fahre den Vorhang links auf dem Dachboden auf 50 Prozent"
+      - "mache auf dem Dachboden den Vorhang links auf 50%"
+    slots:
+      name: "Vorhang links"
+      floor: "Dachboden"
+      position: 50
+    response: "Position festgelegt"


### PR DESCRIPTION
German was missing three declared slot combinations, all in HassSetPosition: name_area, name_floor and floor_device_class. This PR adds them, which brings German to full coverage of the declared slot combinations.

The new sentence files reuse the position phrasing already established in the German name_only and area_device_class files (öffnen/schließen/fahren/stellen plus "auf X Prozent") and the shared area and floor rules from rules/de/common.yaml. No new rules, lists or responses were needed and no existing file was changed. Following intents.yaml, the name combos are limited to the cover domain and floor_device_class infers the cover domain from the device class words, same as the existing area_device_class file.

Each combination comes with a test file whose sentences cover every sentence template, using the same fixtures as the neighbouring German tests (Vorhang links, Wohnzimmer, Obergeschoss, Erdgeschoss, Dachboden).

Verified locally: script.intentfest validate for de passes, the full pytest run for de passes (324 tests), check_overmatch reports 0 cross-intent over-matches and 0 no-match sentences, prune reports no dead rules or lists, and report_unparsed_examples shows no new unparsed examples (the three new example sentences all parse). write_missing_slot_combinations.py now reports 0 missing combinations for German.
