### PR TITLE
[DE] Support natural word order in HassGetState domain queries with area and floor

### DIFF
--- a/sentences/de/HassGetState/domain_state_area.yaml
+++ b/sentences/de/HassGetState/domain_state_area.yaml
@@ -11,6 +11,7 @@ data:
   # ---- lights ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <area> (Licht[er]|Lampe[n]|Beleuchtung[en]) {on_off_states:state}"
+      - "<are_any> (Licht[er]|Lampe[n]|Beleuchtung[en]) <area> {on_off_states:state}"
       - "<are_any> (Licht[er]|Lampe[n]|Beleuchtung[en]) {on_off_states:state} <area>"
     example: "ist irgendein Licht in der Küche an"
     inferred_domain: "light"
@@ -23,12 +24,14 @@ data:
     response: "all"
   - sentences:
       - "<which> (Licht[er]|Lampe[n]|Beleuchtung[en]) <area> (ist|sind) {on_off_states:state}"
+      - "<which> (Licht[er]|Lampe[n]|Beleuchtung[en]) (ist|sind) <area> {on_off_states:state}"
       - "<which> (Licht[er]|Lampe[n]|Beleuchtung[en]) (ist|sind) {on_off_states:state} <area>"
     example: "welche Lichter sind in der Küche an"
     inferred_domain: "light"
     response: "which"
   - sentences:
       - "<how_many> (Lichter|Lampen|Beleuchtungen) <area> (ist|sind) {on_off_states:state}"
+      - "<how_many> (Lichter|Lampen|Beleuchtungen) (ist|sind) <area> {on_off_states:state}"
       - "<how_many> (Lichter|Lampen|Beleuchtungen) (ist|sind) {on_off_states:state} <area>"
     example: "wie viele Lichter sind in der Küche an"
     inferred_domain: "light"
@@ -37,6 +40,7 @@ data:
   # ---- fans ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <area> (Ventilator[en]|Lüfter) {on_off_states:state}"
+      - "<are_any> (Ventilator[en]|Lüfter) <area> {on_off_states:state}"
       - "<are_any> (Ventilator[en]|Lüfter) {on_off_states:state} <area>"
     example: "ist irgendein Ventilator im Schlafzimmer an"
     inferred_domain: "fan"
@@ -49,12 +53,14 @@ data:
     response: "all"
   - sentences:
       - "<which> (Ventilator[en]|Lüfter) <area> (ist|sind) {on_off_states:state}"
+      - "<which> (Ventilator[en]|Lüfter) (ist|sind) <area> {on_off_states:state}"
       - "<which> (Ventilator[en]|Lüfter) (ist|sind) {on_off_states:state} <area>"
     example: "welche Ventilatoren sind im Schlafzimmer an"
     inferred_domain: "fan"
     response: "which"
   - sentences:
       - "<how_many> (Ventilatoren|Lüfter) <area> (ist|sind) {on_off_states:state}"
+      - "<how_many> (Ventilatoren|Lüfter) (ist|sind) <area> {on_off_states:state}"
       - "<how_many> (Ventilatoren|Lüfter) (ist|sind) {on_off_states:state} <area>"
     example: "wie viele Ventilatoren sind im Schlafzimmer an"
     inferred_domain: "fan"
@@ -63,6 +69,7 @@ data:
   # ---- switches ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <area> (Schalter|Steckdose[n]) {on_off_states:state}"
+      - "<are_any> (Schalter|Steckdose[n]) <area> {on_off_states:state}"
       - "<are_any> (Schalter|Steckdose[n]) {on_off_states:state} <area>"
     example: "ist irgendein Schalter im Büro an"
     inferred_domain: "switch"
@@ -75,12 +82,14 @@ data:
     response: "all"
   - sentences:
       - "<which> (Schalter|Steckdose[n]) <area> (ist|sind) {on_off_states:state}"
+      - "<which> (Schalter|Steckdose[n]) (ist|sind) <area> {on_off_states:state}"
       - "<which> (Schalter|Steckdose[n]) (ist|sind) {on_off_states:state} <area>"
     example: "welche Schalter sind im Büro an"
     inferred_domain: "switch"
     response: "which"
   - sentences:
       - "<how_many> (Schalter|Steckdosen) <area> (ist|sind) {on_off_states:state}"
+      - "<how_many> (Schalter|Steckdosen) (ist|sind) <area> {on_off_states:state}"
       - "<how_many> (Schalter|Steckdosen) (ist|sind) {on_off_states:state} <area>"
     example: "wie viele Schalter sind im Büro an"
     inferred_domain: "switch"
@@ -89,6 +98,7 @@ data:
   # ---- locks ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <area> {lock_domains:domain} {lock_states:state}"
+      - "<are_any> {lock_domains:domain} <area> {lock_states:state}"
       - "<are_any> {lock_domains:domain} {lock_states:state} <area>"
     example: "ist irgendeine Tür in der Garage aufgeschlossen"
     inferred_domain: "lock"
@@ -101,12 +111,14 @@ data:
     response: "all"
   - sentences:
       - "<which> {lock_domains:domain} <area> (ist|sind) {lock_states:state}"
+      - "<which> {lock_domains:domain} (ist|sind) <area> {lock_states:state}"
       - "<which> {lock_domains:domain} (ist|sind) {lock_states:state} <area>"
     example: "welche Türen sind in der Garage aufgeschlossen"
     inferred_domain: "lock"
     response: "which"
   - sentences:
       - "<how_many> {lock_domains:domain} <area> (ist|sind) {lock_states:state}"
+      - "<how_many> {lock_domains:domain} (ist|sind) <area> {lock_states:state}"
       - "<how_many> {lock_domains:domain} (ist|sind) {lock_states:state} <area>"
     example: "wie viele Türen sind in der Garage abgeschlossen"
     inferred_domain: "lock"

--- a/sentences/de/HassGetState/domain_state_floor.yaml
+++ b/sentences/de/HassGetState/domain_state_floor.yaml
@@ -11,6 +11,7 @@ data:
   # ---- lights ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <floor> (Licht[er]|Lampe[n]|Beleuchtung[en]) {on_off_states:state}"
+      - "<are_any> (Licht[er]|Lampe[n]|Beleuchtung[en]) <floor> {on_off_states:state}"
       - "<are_any> (Licht[er]|Lampe[n]|Beleuchtung[en]) {on_off_states:state} <floor>"
     example: "ist irgendein Licht im Erdgeschoss an"
     inferred_domain: "light"
@@ -23,12 +24,14 @@ data:
     response: "all"
   - sentences:
       - "<which> (Licht[er]|Lampe[n]|Beleuchtung[en]) <floor> (ist|sind) {on_off_states:state}"
+      - "<which> (Licht[er]|Lampe[n]|Beleuchtung[en]) (ist|sind) <floor> {on_off_states:state}"
       - "<which> (Licht[er]|Lampe[n]|Beleuchtung[en]) (ist|sind) {on_off_states:state} <floor>"
     example: "welche Lichter sind im Erdgeschoss an"
     inferred_domain: "light"
     response: "which"
   - sentences:
       - "<how_many> (Lichter|Lampen|Beleuchtungen) <floor> (ist|sind) {on_off_states:state}"
+      - "<how_many> (Lichter|Lampen|Beleuchtungen) (ist|sind) <floor> {on_off_states:state}"
       - "<how_many> (Lichter|Lampen|Beleuchtungen) (ist|sind) {on_off_states:state} <floor>"
     example: "wie viele Lichter sind im Erdgeschoss an"
     inferred_domain: "light"
@@ -37,6 +40,7 @@ data:
   # ---- fans ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <floor> (Ventilator[en]|Lüfter) {on_off_states:state}"
+      - "<are_any> (Ventilator[en]|Lüfter) <floor> {on_off_states:state}"
       - "<are_any> (Ventilator[en]|Lüfter) {on_off_states:state} <floor>"
     example: "ist irgendein Ventilator im Obergeschoss an"
     inferred_domain: "fan"
@@ -49,12 +53,14 @@ data:
     response: "all"
   - sentences:
       - "<which> (Ventilator[en]|Lüfter) <floor> (ist|sind) {on_off_states:state}"
+      - "<which> (Ventilator[en]|Lüfter) (ist|sind) <floor> {on_off_states:state}"
       - "<which> (Ventilator[en]|Lüfter) (ist|sind) {on_off_states:state} <floor>"
     example: "welche Ventilatoren sind im Obergeschoss an"
     inferred_domain: "fan"
     response: "which"
   - sentences:
       - "<how_many> (Ventilatoren|Lüfter) <floor> (ist|sind) {on_off_states:state}"
+      - "<how_many> (Ventilatoren|Lüfter) (ist|sind) <floor> {on_off_states:state}"
       - "<how_many> (Ventilatoren|Lüfter) (ist|sind) {on_off_states:state} <floor>"
     example: "wie viele Ventilatoren sind im Obergeschoss an"
     inferred_domain: "fan"
@@ -63,6 +69,7 @@ data:
   # ---- switches ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <floor> (Schalter|Steckdose[n]) {on_off_states:state}"
+      - "<are_any> (Schalter|Steckdose[n]) <floor> {on_off_states:state}"
       - "<are_any> (Schalter|Steckdose[n]) {on_off_states:state} <floor>"
     example: "ist irgendein Schalter im Erdgeschoss an"
     inferred_domain: "switch"
@@ -75,12 +82,14 @@ data:
     response: "all"
   - sentences:
       - "<which> (Schalter|Steckdose[n]) <floor> (ist|sind) {on_off_states:state}"
+      - "<which> (Schalter|Steckdose[n]) (ist|sind) <floor> {on_off_states:state}"
       - "<which> (Schalter|Steckdose[n]) (ist|sind) {on_off_states:state} <floor>"
     example: "welche Schalter sind im Erdgeschoss an"
     inferred_domain: "switch"
     response: "which"
   - sentences:
       - "<how_many> (Schalter|Steckdosen) <floor> (ist|sind) {on_off_states:state}"
+      - "<how_many> (Schalter|Steckdosen) (ist|sind) <floor> {on_off_states:state}"
       - "<how_many> (Schalter|Steckdosen) (ist|sind) {on_off_states:state} <floor>"
     example: "wie viele Schalter sind im Erdgeschoss an"
     inferred_domain: "switch"
@@ -89,6 +98,7 @@ data:
   # ---- locks ----
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <floor> {lock_domains:domain} {lock_states:state}"
+      - "<are_any> {lock_domains:domain} <floor> {lock_states:state}"
       - "<are_any> {lock_domains:domain} {lock_states:state} <floor>"
     example: "ist irgendeine Tür im Erdgeschoss aufgeschlossen"
     inferred_domain: "lock"
@@ -101,12 +111,14 @@ data:
     response: "all"
   - sentences:
       - "<which> {lock_domains:domain} <floor> (ist|sind) {lock_states:state}"
+      - "<which> {lock_domains:domain} (ist|sind) <floor> {lock_states:state}"
       - "<which> {lock_domains:domain} (ist|sind) {lock_states:state} <floor>"
     example: "welche Türen sind im Erdgeschoss aufgeschlossen"
     inferred_domain: "lock"
     response: "which"
   - sentences:
       - "<how_many> {lock_domains:domain} <floor> (ist|sind) {lock_states:state}"
+      - "<how_many> {lock_domains:domain} (ist|sind) <floor> {lock_states:state}"
       - "<how_many> {lock_domains:domain} (ist|sind) {lock_states:state} <floor>"
     example: "wie viele Türen sind im Erdgeschoss abgeschlossen"
     inferred_domain: "lock"

--- a/tests/de/HassGetState/domain_state_area.yaml
+++ b/tests/de/HassGetState/domain_state_area.yaml
@@ -6,6 +6,10 @@ areas:
   - name: "Küche"
   - name: "Flur"
   - name: "Wohnzimmer"
+  # von den Beispiel-Sätzen (example:) der Satzdatei referenziert
+  - name: "Schlafzimmer"
+  - name: "Büro"
+  - name: "Garage"
 
 entities:
   # außerhalb des Bereichs: muss aus Küchen-Abfragen AUSGESCHLOSSEN werden
@@ -49,7 +53,11 @@ entities:
 tests:
   # ---- lights (prefix-area + suffix-area) ----
   - sentences:
-      ["sind in der Küche Lichter an", "ist irgendein Licht an in der Küche"]
+      [
+        "sind in der Küche Lichter an",
+        "ist irgendein Licht in der Küche an",
+        "ist irgendein Licht an in der Küche",
+      ]
     slots: { state: "on", area: "Küche" }
     response: "Ja, Küchenlicht"
   - sentences:
@@ -62,6 +70,7 @@ tests:
   - sentences:
       [
         "welche Lichter in der Küche sind an",
+        "welche Lichter sind in der Küche an",
         "welche Lichter sind an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -69,6 +78,7 @@ tests:
   - sentences:
       [
         "wie viele Lichter in der Küche sind an",
+        "wie viele Lichter sind in der Küche an",
         "wie viele Lichter sind an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -78,6 +88,7 @@ tests:
   - sentences:
       [
         "sind in der Küche Ventilatoren an",
+        "ist irgendein Ventilator in der Küche an",
         "ist irgendein Ventilator an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -92,6 +103,7 @@ tests:
   - sentences:
       [
         "welche Ventilatoren in der Küche sind an",
+        "welche Ventilatoren sind in der Küche an",
         "welche Ventilatoren sind an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -99,6 +111,7 @@ tests:
   - sentences:
       [
         "wie viele Ventilatoren in der Küche sind an",
+        "wie viele Ventilatoren sind in der Küche an",
         "wie viele Ventilatoren sind an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -108,6 +121,7 @@ tests:
   - sentences:
       [
         "sind in der Küche Schalter an",
+        "ist irgendein Schalter in der Küche an",
         "ist irgendein Schalter an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -122,6 +136,7 @@ tests:
   - sentences:
       [
         "welche Schalter in der Küche sind an",
+        "welche Schalter sind in der Küche an",
         "welche Schalter sind an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -129,6 +144,7 @@ tests:
   - sentences:
       [
         "wie viele Schalter in der Küche sind an",
+        "wie viele Schalter sind in der Küche an",
         "wie viele Schalter sind an in der Küche",
       ]
     slots: { state: "on", area: "Küche" }
@@ -138,6 +154,7 @@ tests:
   - sentences:
       [
         "sind im Flur Türen aufgeschlossen",
+        "ist irgendeine Tür im Flur aufgeschlossen",
         "ist irgendeine Tür aufgeschlossen im Flur",
       ]
     slots: { state: "unlocked", area: "Flur" }
@@ -152,6 +169,7 @@ tests:
   - sentences:
       [
         "welche Türen im Flur sind aufgeschlossen",
+        "welche Türen sind im Flur aufgeschlossen",
         "welche Türen sind aufgeschlossen im Flur",
       ]
     slots: { state: "unlocked", area: "Flur" }
@@ -159,6 +177,7 @@ tests:
   - sentences:
       [
         "wie viele Türen im Flur sind abgeschlossen",
+        "wie viele Türen sind im Flur abgeschlossen",
         "wie viele Türen sind abgeschlossen im Flur",
       ]
     slots: { state: "locked", area: "Flur" }

--- a/tests/de/HassGetState/domain_state_floor.yaml
+++ b/tests/de/HassGetState/domain_state_floor.yaml
@@ -58,6 +58,7 @@ tests:
   - sentences:
       [
         "sind im Erdgeschoss Lichter an",
+        "ist irgendein Licht im Erdgeschoss an",
         "ist irgendein Licht an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -72,6 +73,7 @@ tests:
   - sentences:
       [
         "welche Lichter im Erdgeschoss sind an",
+        "welche Lichter sind im Erdgeschoss an",
         "welche Lichter sind an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -79,6 +81,7 @@ tests:
   - sentences:
       [
         "wie viele Lichter im Erdgeschoss sind an",
+        "wie viele Lichter sind im Erdgeschoss an",
         "wie viele Lichter sind an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -88,6 +91,7 @@ tests:
   - sentences:
       [
         "sind im Erdgeschoss Ventilatoren an",
+        "ist irgendein Ventilator im Erdgeschoss an",
         "ist irgendein Ventilator an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -102,6 +106,7 @@ tests:
   - sentences:
       [
         "welche Ventilatoren im Erdgeschoss sind an",
+        "welche Ventilatoren sind im Erdgeschoss an",
         "welche Ventilatoren sind an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -109,6 +114,7 @@ tests:
   - sentences:
       [
         "wie viele Ventilatoren im Erdgeschoss sind an",
+        "wie viele Ventilatoren sind im Erdgeschoss an",
         "wie viele Ventilatoren sind an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -118,6 +124,7 @@ tests:
   - sentences:
       [
         "sind im Erdgeschoss Schalter an",
+        "ist irgendein Schalter im Erdgeschoss an",
         "ist irgendein Schalter an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -132,6 +139,7 @@ tests:
   - sentences:
       [
         "welche Schalter im Erdgeschoss sind an",
+        "welche Schalter sind im Erdgeschoss an",
         "welche Schalter sind an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -139,6 +147,7 @@ tests:
   - sentences:
       [
         "wie viele Schalter im Erdgeschoss sind an",
+        "wie viele Schalter sind im Erdgeschoss an",
         "wie viele Schalter sind an im Erdgeschoss",
       ]
     slots: { state: "on", floor: "Erdgeschoss" }
@@ -148,6 +157,7 @@ tests:
   - sentences:
       [
         "sind im Erdgeschoss Türen aufgeschlossen",
+        "ist irgendeine Tür im Erdgeschoss aufgeschlossen",
         "ist irgendeine Tür aufgeschlossen im Erdgeschoss",
       ]
     slots: { state: "unlocked", floor: "Erdgeschoss" }
@@ -162,6 +172,7 @@ tests:
   - sentences:
       [
         "welche Türen im Erdgeschoss sind aufgeschlossen",
+        "welche Türen sind im Erdgeschoss aufgeschlossen",
         "welche Türen sind aufgeschlossen im Erdgeschoss",
       ]
     slots: { state: "unlocked", floor: "Erdgeschoss" }
@@ -169,6 +180,7 @@ tests:
   - sentences:
       [
         "wie viele Türen im Erdgeschoss sind abgeschlossen",
+        "wie viele Türen sind im Erdgeschoss abgeschlossen",
         "wie viele Türen sind abgeschlossen im Erdgeschoss",
       ]
     slots: { state: "locked", floor: "Erdgeschoss" }


### PR DESCRIPTION
The German domain_state_area and domain_state_floor files for HassGetState only recognized the area or floor in two positions: before the noun ("welche Lichter in der Küche sind an") or trailing after the state ("welche Lichter sind an in der Küche"). The most natural word order in German puts the prepositional phrase between the verb and the state: "welche Lichter sind in der Küche an", "ist irgendein Ventilator im Schlafzimmer an", "wie viele Türen sind im Erdgeschoss abgeschlossen". None of these parsed, and the report_unparsed_examples script listed all 24 documented examples of the two files as no match.

This PR adds one alternative sentence per any/which/how_many block (lights, fans, switches and locks) covering that middle position, for both area and floor. The new lines reuse the existing are_any/which/how_many and area/floor expansion rules and keep the tight on_off_states/lock_states constraints, no rules or lists were changed. The area test fixtures gain the Schlafzimmer, Büro and Garage areas because the documented examples reference them and example recognition resolves areas from the combination's own fixtures.

Every affected block got new test sentences in the existing test groups, written first and confirmed failing with "Sentence was not recognized" before the grammar change. Verified afterwards: intentfest validate is clean, the full German test suite passes (324 tests), check_overmatch reports 0 cross-intent over-matches and 0 no-match sentences, prune reports no dead rules or lists, and report_unparsed_examples for German drops from 48 to 24 problems with all 24 domain_state entries gone.
