### PR TITLE
[DE] Fix unparsed HassGetState examples for device class and name queries

### DIFF
--- a/sentences/de/HassGetState/device_class_state_area.yaml
+++ b/sentences/de/HassGetState/device_class_state_area.yaml
@@ -13,6 +13,7 @@ data:
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <area> {cover_classes:device_class} {cover_states:state}"
       - "<are_any> {cover_classes:device_class} {cover_states:state} <area>"
+      - "<are_any> {cover_classes:device_class} <area> {cover_states:state}"
     example: "ist irgendein Fenster im Schlafzimmer offen"
     inferred_domain: "cover"
     response: "any"
@@ -25,12 +26,14 @@ data:
   - sentences:
       - "<which> {cover_classes:device_class} <area> (ist|sind) {cover_states:state}"
       - "<which> {cover_classes:device_class} (ist|sind) {cover_states:state} <area>"
+      - "<which> {cover_classes:device_class} (ist|sind) <area> {cover_states:state}"
     example: "welche Fenster sind im Schlafzimmer offen"
     inferred_domain: "cover"
     response: "which"
   - sentences:
       - "<how_many> {cover_classes:device_class} <area> (ist|sind) {cover_states:state}"
       - "<how_many> {cover_classes:device_class} (ist|sind) {cover_states:state} <area>"
+      - "<how_many> {cover_classes:device_class} (ist|sind) <area> {cover_states:state}"
     example: "wie viele Fenster sind im Schlafzimmer offen"
     inferred_domain: "cover"
     response: "how_many"

--- a/sentences/de/HassGetState/device_class_state_floor.yaml
+++ b/sentences/de/HassGetState/device_class_state_floor.yaml
@@ -13,6 +13,7 @@ data:
   - sentences:
       - "(ist|sind|gibt es|stehen)[ <irgend>] <floor> {cover_classes:device_class} {cover_states:state}"
       - "<are_any> {cover_classes:device_class} {cover_states:state} <floor>"
+      - "<are_any> {cover_classes:device_class} <floor> {cover_states:state}"
     example: "ist irgendein Fenster im Obergeschoss offen"
     inferred_domain: "cover"
     response: "any"
@@ -25,12 +26,14 @@ data:
   - sentences:
       - "<which> {cover_classes:device_class} <floor> (ist|sind) {cover_states:state}"
       - "<which> {cover_classes:device_class} (ist|sind) {cover_states:state} <floor>"
+      - "<which> {cover_classes:device_class} (ist|sind) <floor> {cover_states:state}"
     example: "welche Fenster sind im Obergeschoss offen"
     inferred_domain: "cover"
     response: "which"
   - sentences:
       - "<how_many> {cover_classes:device_class} <floor> (ist|sind) {cover_states:state}"
       - "<how_many> {cover_classes:device_class} (ist|sind) {cover_states:state} <floor>"
+      - "<how_many> {cover_classes:device_class} (ist|sind) <floor> {cover_states:state}"
     example: "wie viele Fenster sind im Obergeschoss offen"
     inferred_domain: "cover"
     response: "how_many"

--- a/sentences/de/HassGetState/name_state_area.yaml
+++ b/sentences/de/HassGetState/name_state_area.yaml
@@ -12,6 +12,7 @@ data:
   - sentences:
       - "(ist|steht) [<artikel_bestimmt> ]{name} {cover_states:state} <area>"
       - "(ist|steht) <area> [<artikel_bestimmt> ]{name} {cover_states:state}"
+      - "(ist|steht) [<artikel_bestimmt> ]{name} <area> {cover_states:state}"
     example: "ist das Garagentor in der Garage offen"
     name_domains:
       - "cover"
@@ -21,6 +22,7 @@ data:
   - sentences:
       - "ist [<artikel_bestimmt> ]{name} {lock_states:state} <area>"
       - "ist <area> [<artikel_bestimmt> ]{name} {lock_states:state}"
+      - "ist [<artikel_bestimmt> ]{name} <area> {lock_states:state}"
     example: "ist die Haustür im Eingang abgeschlossen"
     name_domains:
       - "lock"
@@ -30,6 +32,7 @@ data:
   - sentences:
       - "(ist|steht) [<artikel_bestimmt> ]{name} {bs_open_states:state} <area>"
       - "(ist|steht) <area> [<artikel_bestimmt> ]{name} {bs_open_states:state}"
+      - "(ist|steht) [<artikel_bestimmt> ]{name} <area> {bs_open_states:state}"
     example: "ist das Fenster im Schlafzimmer offen"
     name_domains:
       - "binary_sensor"
@@ -39,6 +42,7 @@ data:
   - sentences:
       - "ist [<artikel_bestimmt> ]{name} {bs_occupancy_states:state} <area>"
       - "ist <area> [<artikel_bestimmt> ]{name} {bs_occupancy_states:state}"
+      - "ist [<artikel_bestimmt> ]{name} <area> {bs_occupancy_states:state}"
     example: "ist der Bewegungsmelder im Büro belegt"
     name_domains:
       - "binary_sensor"

--- a/sentences/de/HassGetState/name_state_floor.yaml
+++ b/sentences/de/HassGetState/name_state_floor.yaml
@@ -12,6 +12,7 @@ data:
   - sentences:
       - "(ist|steht) [<artikel_bestimmt> ]{name} {cover_states:state} <floor>"
       - "(ist|steht) <floor> [<artikel_bestimmt> ]{name} {cover_states:state}"
+      - "(ist|steht) [<artikel_bestimmt> ]{name} <floor> {cover_states:state}"
     example: "ist das Garagentor im Erdgeschoss offen"
     name_domains:
       - "cover"
@@ -21,6 +22,7 @@ data:
   - sentences:
       - "ist [<artikel_bestimmt> ]{name} {lock_states:state} <floor>"
       - "ist <floor> [<artikel_bestimmt> ]{name} {lock_states:state}"
+      - "ist [<artikel_bestimmt> ]{name} <floor> {lock_states:state}"
     example: "ist die Haustür im Erdgeschoss abgeschlossen"
     name_domains:
       - "lock"
@@ -30,6 +32,7 @@ data:
   - sentences:
       - "(ist|steht) [<artikel_bestimmt> ]{name} {bs_open_states:state} <floor>"
       - "(ist|steht) <floor> [<artikel_bestimmt> ]{name} {bs_open_states:state}"
+      - "(ist|steht) [<artikel_bestimmt> ]{name} <floor> {bs_open_states:state}"
     example: "ist das Schlafzimmerfenster im Obergeschoss offen"
     name_domains:
       - "binary_sensor"
@@ -39,6 +42,7 @@ data:
   - sentences:
       - "ist [<artikel_bestimmt> ]{name} {bs_occupancy_states:state} <floor>"
       - "ist <floor> [<artikel_bestimmt> ]{name} {bs_occupancy_states:state}"
+      - "ist [<artikel_bestimmt> ]{name} <floor> {bs_occupancy_states:state}"
     example: "ist der Bewegungsmelder im Obergeschoss belegt"
     name_domains:
       - "binary_sensor"

--- a/tests/de/HassGetState/device_class_state_area.yaml
+++ b/tests/de/HassGetState/device_class_state_area.yaml
@@ -32,6 +32,7 @@ tests:
       [
         "sind im Schlafzimmer Fenster offen",
         "ist irgendein Fenster offen im Schlafzimmer",
+        "ist irgendein Fenster im Schlafzimmer offen",
       ]
     slots: { device_class: "window", state: "open", area: "Schlafzimmer" }
     response: "Ja, Schlafzimmerfenster"
@@ -46,6 +47,7 @@ tests:
       [
         "welche Fenster im Schlafzimmer sind offen",
         "welche Fenster sind offen im Schlafzimmer",
+        "welche Fenster sind im Schlafzimmer offen",
       ]
     slots: { device_class: "window", state: "open", area: "Schlafzimmer" }
     response: "Schlafzimmerfenster"
@@ -53,6 +55,7 @@ tests:
       [
         "wie viele Fenster im Schlafzimmer sind offen",
         "wie viele Fenster sind offen im Schlafzimmer",
+        "wie viele Fenster sind im Schlafzimmer offen",
       ]
     slots: { device_class: "window", state: "open", area: "Schlafzimmer" }
     response: "1"

--- a/tests/de/HassGetState/device_class_state_floor.yaml
+++ b/tests/de/HassGetState/device_class_state_floor.yaml
@@ -37,6 +37,7 @@ tests:
       [
         "sind im Obergeschoss Fenster offen",
         "ist irgendein Fenster offen im Obergeschoss",
+        "ist irgendein Fenster im Obergeschoss offen",
       ]
     slots: { device_class: "window", state: "open", floor: "Obergeschoss" }
     response: "Ja, Schlafzimmerfenster"
@@ -51,6 +52,7 @@ tests:
       [
         "welche Fenster im Obergeschoss sind offen",
         "welche Fenster sind offen im Obergeschoss",
+        "welche Fenster sind im Obergeschoss offen",
       ]
     slots: { device_class: "window", state: "open", floor: "Obergeschoss" }
     response: "Schlafzimmerfenster"
@@ -58,6 +60,7 @@ tests:
       [
         "wie viele Fenster im Obergeschoss sind offen",
         "wie viele Fenster sind offen im Obergeschoss",
+        "wie viele Fenster sind im Obergeschoss offen",
       ]
     slots: { device_class: "window", state: "open", floor: "Obergeschoss" }
     response: "1"

--- a/tests/de/HassGetState/name_state.yaml
+++ b/tests/de/HassGetState/name_state.yaml
@@ -18,7 +18,13 @@ entities:
   - name: "Terrassentür"
     domain: "binary_sensor"
     state: "on"
+  - name: "Fenster"
+    domain: "binary_sensor"
+    state: "on"
   - name: "Bürosensor"
+    domain: "binary_sensor"
+    state: "on"
+  - name: "Büro"
     domain: "binary_sensor"
     state: "on"
 
@@ -63,10 +69,24 @@ tests:
       state: "on"
     response: "Ja"
 
+  - sentences:
+      - "ist das Fenster offen"
+    slots:
+      name: "Fenster"
+      state: "on"
+    response: "Ja"
+
   # binary sensors - Belegung
   - sentences:
       - "ist der Bürosensor belegt"
     slots:
       name: "Bürosensor"
+      state: "on"
+    response: "Ja"
+
+  - sentences:
+      - "ist das Büro belegt"
+    slots:
+      name: "Büro"
       state: "on"
     response: "Ja"

--- a/tests/de/HassGetState/name_state_area.yaml
+++ b/tests/de/HassGetState/name_state_area.yaml
@@ -21,6 +21,10 @@ entities:
     domain: "binary_sensor"
     state: "on"
     area: "Schlafzimmer"
+  - name: "Fenster"
+    domain: "binary_sensor"
+    state: "on"
+    area: "Schlafzimmer"
   - name: "Bewegungsmelder"
     domain: "binary_sensor"
     state: "on"
@@ -31,6 +35,7 @@ tests:
   - sentences:
       - "ist das Garagentor offen in der Garage"
       - "ist in der Garage das Garagentor offen"
+      - "ist das Garagentor in der Garage offen"
     slots:
       name: "Garagentor"
       state: "open"
@@ -41,6 +46,7 @@ tests:
   - sentences:
       - "ist die Haustür abgeschlossen im Eingang"
       - "ist im Eingang die Haustür abgeschlossen"
+      - "ist die Haustür im Eingang abgeschlossen"
     slots:
       name: "Haustür"
       state: "locked"
@@ -57,10 +63,19 @@ tests:
       area: "Schlafzimmer"
     response: "Ja"
 
+  - sentences:
+      - "ist das Fenster im Schlafzimmer offen"
+    slots:
+      name: "Fenster"
+      state: "on"
+      area: "Schlafzimmer"
+    response: "Ja"
+
   # binary sensors - Belegung
   - sentences:
       - "ist der Bewegungsmelder belegt im Büro"
       - "ist im Büro der Bewegungsmelder belegt"
+      - "ist der Bewegungsmelder im Büro belegt"
     slots:
       name: "Bewegungsmelder"
       state: "on"

--- a/tests/de/HassGetState/name_state_floor.yaml
+++ b/tests/de/HassGetState/name_state_floor.yaml
@@ -29,6 +29,10 @@ entities:
     domain: "binary_sensor"
     state: "on"
     area: "Schlafzimmer"
+  - name: "Schlafzimmerfenster"
+    domain: "binary_sensor"
+    state: "on"
+    area: "Schlafzimmer"
   - name: "Bewegungsmelder"
     domain: "binary_sensor"
     state: "on"
@@ -39,6 +43,7 @@ tests:
   - sentences:
       - "ist das Garagentor offen im Erdgeschoss"
       - "ist im Erdgeschoss das Garagentor offen"
+      - "ist das Garagentor im Erdgeschoss offen"
     slots:
       name: "Garagentor"
       state: "open"
@@ -49,6 +54,7 @@ tests:
   - sentences:
       - "ist die Haustür abgeschlossen im Erdgeschoss"
       - "ist im Erdgeschoss die Haustür abgeschlossen"
+      - "ist die Haustür im Erdgeschoss abgeschlossen"
     slots:
       name: "Haustür"
       state: "locked"
@@ -65,10 +71,19 @@ tests:
       floor: "Obergeschoss"
     response: "Ja"
 
+  - sentences:
+      - "ist das Schlafzimmerfenster im Obergeschoss offen"
+    slots:
+      name: "Schlafzimmerfenster"
+      state: "on"
+      floor: "Obergeschoss"
+    response: "Ja"
+
   # binary sensors - Belegung
   - sentences:
       - "ist der Bewegungsmelder belegt im Obergeschoss"
       - "ist im Obergeschoss der Bewegungsmelder belegt"
+      - "ist der Bewegungsmelder im Obergeschoss belegt"
     slots:
       name: "Bewegungsmelder"
       state: "on"


### PR DESCRIPTION
The unparsed-examples report for German currently lists 16 documented examples from the HassGetState slot combinations device_class_state_area, device_class_state_floor, name_state, name_state_area and name_state_floor as not recognizable. They fall into two groups.

The first group is a word order gap. Questions like "ist irgendein Fenster im Schlafzimmer offen", "welche Fenster sind im Obergeschoss offen" or "ist das Garagentor in der Garage offen" put the area or floor between the subject and the state, which is the most natural way to ask this in German. The templates only covered "sind im Schlafzimmer Fenster offen" and "ist irgendein Fenster offen im Schlafzimmer". This change adds the missing alternative to the affected blocks, reusing the existing area, floor, are_any, which and how_many expansion rules. No rules or lists were changed.

The second group is a fixture mismatch. The examples "ist das Fenster offen", "ist das Büro belegt", "ist das Fenster im Schlafzimmer offen" and "ist das Schlafzimmerfenster im Obergeschoss offen" use names that had no matching entity in the combination's test fixtures, so the example could never resolve. The English fixtures back every example name with a test entity, so the German test files now do the same: binary_sensor entities named Fenster, Büro and Schlafzimmerfenster were added, existing entities and tests were left untouched.

Every one of the 16 examples is now also a test sentence, added before the fix and observed failing with "Sentence was not recognized", then passing after the change.

Verification: intentfest validate for de ends with "All good!" and no new warnings, the full German pytest run passes (324 tests), check_overmatch reports 0 cross-intent over-matches and 0 no-match sentences, prune reports no dead rules or lists, and report_unparsed_examples for de drops from 48 to 32 no-match entries with no new entries. The remaining 32 belong to other slot combinations.
