### PR TITLE
[DE] Fix unparsed volume control examples

### DIFF
--- a/tests/de/HassSetVolume/name_only.yaml
+++ b/tests/de/HassSetVolume/name_only.yaml
@@ -5,6 +5,8 @@ language: de
 entities:
   - name: TV
     domain: media_player
+  - name: Fernseher
+    domain: media_player
 tests:
   - sentences:
       - Stelle TV auf maximum
@@ -102,4 +104,20 @@ tests:
     slots:
       name: TV
       volume_level: 10
+    response: Lautstärke festgelegt
+  - sentences:
+      - Stelle die Lautstärke von dem Fernseher auf 50 Prozent
+      - Setze die Lautstärke von dem Fernseher auf 50
+      - die Lautstärke von dem Fernseher auf 50 Prozent stellen
+    slots:
+      name: Fernseher
+      volume_level: 50
+    response: Lautstärke festgelegt
+  - sentences:
+      - Stelle den Fernseher auf maximale Lautstärke
+      - Stelle den Fernseher auf die höchste Stufe ein
+      - den Fernseher auf maximale Lautstärke stellen
+    slots:
+      name: Fernseher
+      volume_level: 100
     response: Lautstärke festgelegt

--- a/tests/de/HassSetVolumeRelative/floor_only.yaml
+++ b/tests/de/HassSetVolumeRelative/floor_only.yaml
@@ -4,6 +4,7 @@
 language: de
 floors:
   - name: Obergeschoss
+  - name: Erdgeschoss
 
 tests:
   # relative up
@@ -58,5 +59,30 @@ tests:
       - die Musik um 20 Prozent leiser im Obergeschoss
     slots:
       floor: Obergeschoss
+      volume_step: -20
+    response: Lautstärke festgelegt
+  # relative down (Erdgeschoss)
+  - sentences:
+      - die Lautstärke im Erdgeschoss leiser
+      - mach die Lautstärke im Erdgeschoss leiser
+      - Erdgeschoss leiser
+    slots:
+      floor: Erdgeschoss
+      volume_step: down
+    response: Lautstärke festgelegt
+  # percentage up (Erdgeschoss)
+  - sentences:
+      - die Lautstärke im Erdgeschoss um 20 Prozent lauter
+      - erhöhe die Lautstärke im Erdgeschoss um 20 Prozent
+    slots:
+      floor: Erdgeschoss
+      volume_step: 20
+    response: Lautstärke festgelegt
+  # percentage down (Erdgeschoss)
+  - sentences:
+      - die Lautstärke im Erdgeschoss um 20 Prozent leiser
+      - verringere die Lautstärke im Erdgeschoss um 20 Prozent
+    slots:
+      floor: Erdgeschoss
       volume_step: -20
     response: Lautstärke festgelegt

--- a/tests/de/HassSetVolumeRelative/name_only.yaml
+++ b/tests/de/HassSetVolumeRelative/name_only.yaml
@@ -5,6 +5,8 @@ language: de
 entities:
   - name: TV
     domain: media_player
+  - name: Fernseher
+    domain: media_player
 
 tests:
   # relative up
@@ -51,5 +53,30 @@ tests:
       - dreh die Lautstärke von dem TV um 20 Prozent runter
     slots:
       name: TV
+      volume_step: -20
+    response: Lautstärke festgelegt
+  # relative down (Fernseher)
+  - sentences:
+      - den Fernseher leiser
+      - mach die Lautstärke vom Fernseher leiser
+      - den Ton vom Fernseher leiser einstellen
+    slots:
+      name: Fernseher
+      volume_step: down
+    response: Lautstärke festgelegt
+  # percentage up (Fernseher)
+  - sentences:
+      - Fernseher um 20 Prozent lauter
+      - erhöhe die Lautstärke vom Fernseher um 20 Prozent
+    slots:
+      name: Fernseher
+      volume_step: 20
+    response: Lautstärke festgelegt
+  # percentage down (Fernseher)
+  - sentences:
+      - Fernseher um 20 Prozent leiser
+      - reduziere die Lautstärke vom Fernseher um 20 Prozent
+    slots:
+      name: Fernseher
       volume_step: -20
     response: Lautstärke festgelegt


### PR DESCRIPTION
The unparsed examples report listed eight German volume control examples as no-match:

- HassSetVolume/name_only: "Stelle die Lautstärke von dem Fernseher auf 50 Prozent", "Stelle den Fernseher auf maximale Lautstärke"
- HassSetVolumeRelative/name_only: "den Fernseher leiser", "Fernseher um 20 Prozent lauter", "Fernseher um 20 Prozent leiser"
- HassSetVolumeRelative/floor_only: "die Lautstärke im Erdgeschoss leiser", "die Lautstärke im Erdgeschoss um 20 Prozent lauter", "die Lautstärke im Erdgeschoss um 20 Prozent leiser"

The grammar already covers all eight sentences. The problem was in the test fixtures: example recognition resolves name and floor slots from the slot combination's own test file, and those fixtures only contained a media_player named "TV" and a floor named "Obergeschoss", while the examples use "Fernseher" and "Erdgeschoss".

This PR adds a "Fernseher" media_player entity and an "Erdgeschoss" floor to the fixtures of the three affected test files and adds test blocks that cover the example sentences plus a few close variants. No sentence templates were changed and no existing tests were modified, the diff is insertions only. This follows the English files, where examples use the exact fixture names and these combos have zero problems.

Verification, all run for language de: intentfest validate passes with no new warnings, the full test suite passes (324 passed), check_overmatch reports 0 cross-intent over-matches and 0 no-match sentences, prune reports no dead rules or lists, and report_unparsed_examples drops from 48 to 40 no-match with exactly these eight entries gone and no new ones.
