### PR TITLE
[DE] Speak German state names in HassGetState responses

### DIFF
--- a/responses/de/HassGetState.yaml
+++ b/responses/de/HassGetState.yaml
@@ -13,10 +13,22 @@ responses:
         {% endif %}
 
       one_yesno: |
+        {% set state_names = {
+          'on': 'an',
+          'off': 'aus',
+          'open': 'offen',
+          'closed': 'geschlossen',
+          'opening': 'am Öffnen',
+          'closing': 'am Schließen',
+          'locked': 'abgeschlossen',
+          'unlocked': 'aufgeschlossen',
+          'home': 'zu Hause',
+          'not_home': 'unterwegs'
+        } %}
         {% if query.matched %}
           Ja
         {% else %}
-          Nein, {{ state.state_with_unit }}
+          Nein, {{ state_names.get(state.state_with_unit, state.state_with_unit) }}
         {% endif %}
 
       any: |
@@ -36,18 +48,30 @@ responses:
         {% endif %}
 
       all: |
+        {% set state_names = {
+          'on': 'an',
+          'off': 'aus',
+          'open': 'offen',
+          'closed': 'geschlossen',
+          'opening': 'am Öffnen',
+          'closing': 'am Schließen',
+          'locked': 'abgeschlossen',
+          'unlocked': 'aufgeschlossen',
+          'home': 'zu Hause',
+          'not_home': 'unterwegs'
+        } %}
         {% if not query.unmatched: %}
           Ja
         {% else %}
           {% set no_match = query.unmatched | map(attribute="name") | sort | list %}
           {% if no_match | length > 4 %}
-            Nein, {{ no_match[:3] | join(", ") }} und {{ (no_match | length - 3) }} weitere sind nicht {{ slots.state }}
+            Nein, {{ no_match[:3] | join(", ") }} und {{ (no_match | length - 3) }} weitere sind nicht {{ state_names.get(slots.state, slots.state) }}
           {%- else -%}
             Nein,
             {% for name in no_match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} und {% endif -%}
               {{ name }}
-            {%- endfor %} {% if no_match | length > 1 %}sind{% else %}ist{% endif %} nicht {{ slots.state }}
+            {%- endfor %} {% if no_match | length > 1 %}sind{% else %}ist{% endif %} nicht {{ state_names.get(slots.state, slots.state) }}
           {% endif %}
         {% endif %}
 

--- a/tests/de/HassGetState/device_class_state.yaml
+++ b/tests/de/HassGetState/device_class_state.yaml
@@ -20,7 +20,7 @@ tests:
     response: "Ja, Wohnzimmerfenster"
   - sentences: ["sind alle Fenster geschlossen"]
     slots: { device_class: "window", state: "closed" }
-    response: "Nein, Wohnzimmerfenster ist nicht closed"
+    response: "Nein, Wohnzimmerfenster ist nicht geschlossen"
   - sentences: ["welche Fenster sind offen"]
     slots: { device_class: "window", state: "open" }
     response: "Wohnzimmerfenster"

--- a/tests/de/HassGetState/device_class_state_area.yaml
+++ b/tests/de/HassGetState/device_class_state_area.yaml
@@ -41,7 +41,7 @@ tests:
         "sind alle Fenster geschlossen im Schlafzimmer",
       ]
     slots: { device_class: "window", state: "closed", area: "Schlafzimmer" }
-    response: "Nein, Schlafzimmerfenster ist nicht closed"
+    response: "Nein, Schlafzimmerfenster ist nicht geschlossen"
   - sentences:
       [
         "welche Fenster im Schlafzimmer sind offen",

--- a/tests/de/HassGetState/device_class_state_floor.yaml
+++ b/tests/de/HassGetState/device_class_state_floor.yaml
@@ -46,7 +46,7 @@ tests:
         "sind alle Fenster geschlossen im Obergeschoss",
       ]
     slots: { device_class: "window", state: "closed", floor: "Obergeschoss" }
-    response: "Nein, Schlafzimmerfenster ist nicht closed"
+    response: "Nein, Schlafzimmerfenster ist nicht geschlossen"
   - sentences:
       [
         "welche Fenster im Obergeschoss sind offen",

--- a/tests/de/HassGetState/domain_state.yaml
+++ b/tests/de/HassGetState/domain_state.yaml
@@ -61,7 +61,7 @@ tests:
     response: "Ja, Licht A, Licht B, Licht C und 2 weitere"
   - sentences: ["sind alle Lichter aus"]
     slots: { state: "off" }
-    response: "Nein, Licht A, Licht B, Licht C und 2 weitere sind nicht off"
+    response: "Nein, Licht A, Licht B, Licht C und 2 weitere sind nicht aus"
   - sentences: ["welche Lichter sind an"]
     slots: { state: "on" }
     response: "Licht A, Licht B, Licht C und 2 weitere"
@@ -75,7 +75,7 @@ tests:
     response: "Ja, Dachventilator und Deckenventilator"
   - sentences: ["sind alle Ventilatoren aus"]
     slots: { state: "off" }
-    response: "Nein, Dachventilator und Deckenventilator sind nicht off"
+    response: "Nein, Dachventilator und Deckenventilator sind nicht aus"
   - sentences: ["welche Ventilatoren sind an"]
     slots: { state: "on" }
     response: "Dachventilator und Deckenventilator"
@@ -89,7 +89,7 @@ tests:
     response: "Ja, Steckdosenschalter"
   - sentences: ["sind alle Schalter aus"]
     slots: { state: "off" }
-    response: "Nein, Steckdosenschalter ist nicht off"
+    response: "Nein, Steckdosenschalter ist nicht aus"
   - sentences: ["welche Schalter sind an"]
     slots: { state: "on" }
     response: "Steckdosenschalter"
@@ -103,7 +103,7 @@ tests:
     response: "Ja, Hintertür"
   - sentences: ["sind alle Türen abgeschlossen"]
     slots: { state: "locked" }
-    response: "Nein, Hintertür ist nicht locked"
+    response: "Nein, Hintertür ist nicht abgeschlossen"
   - sentences: ["welche Türen sind aufgeschlossen"]
     slots: { state: "unlocked" }
     response: "Hintertür"

--- a/tests/de/HassGetState/domain_state_area.yaml
+++ b/tests/de/HassGetState/domain_state_area.yaml
@@ -58,7 +58,7 @@ tests:
         "sind alle Lichter aus in der Küche",
       ]
     slots: { state: "off", area: "Küche" }
-    response: "Nein, Küchenlicht ist nicht off"
+    response: "Nein, Küchenlicht ist nicht aus"
   - sentences:
       [
         "welche Lichter in der Küche sind an",
@@ -88,7 +88,7 @@ tests:
         "sind alle Ventilatoren aus in der Küche",
       ]
     slots: { state: "off", area: "Küche" }
-    response: "Nein, Küchenventilator ist nicht off"
+    response: "Nein, Küchenventilator ist nicht aus"
   - sentences:
       [
         "welche Ventilatoren in der Küche sind an",
@@ -118,7 +118,7 @@ tests:
         "sind alle Schalter aus in der Küche",
       ]
     slots: { state: "off", area: "Küche" }
-    response: "Nein, Thekenschalter ist nicht off"
+    response: "Nein, Thekenschalter ist nicht aus"
   - sentences:
       [
         "welche Schalter in der Küche sind an",
@@ -148,7 +148,7 @@ tests:
         "sind alle Türen abgeschlossen im Flur",
       ]
     slots: { state: "locked", area: "Flur" }
-    response: "Nein, Schrankschloss ist nicht locked"
+    response: "Nein, Schrankschloss ist nicht abgeschlossen"
   - sentences:
       [
         "welche Türen im Flur sind aufgeschlossen",

--- a/tests/de/HassGetState/domain_state_floor.yaml
+++ b/tests/de/HassGetState/domain_state_floor.yaml
@@ -68,7 +68,7 @@ tests:
         "sind alle Lichter aus im Erdgeschoss",
       ]
     slots: { state: "off", floor: "Erdgeschoss" }
-    response: "Nein, Küchenlicht ist nicht off"
+    response: "Nein, Küchenlicht ist nicht aus"
   - sentences:
       [
         "welche Lichter im Erdgeschoss sind an",
@@ -98,7 +98,7 @@ tests:
         "sind alle Ventilatoren aus im Erdgeschoss",
       ]
     slots: { state: "off", floor: "Erdgeschoss" }
-    response: "Nein, Küchenventilator ist nicht off"
+    response: "Nein, Küchenventilator ist nicht aus"
   - sentences:
       [
         "welche Ventilatoren im Erdgeschoss sind an",
@@ -128,7 +128,7 @@ tests:
         "sind alle Schalter aus im Erdgeschoss",
       ]
     slots: { state: "off", floor: "Erdgeschoss" }
-    response: "Nein, Thekenschalter ist nicht off"
+    response: "Nein, Thekenschalter ist nicht aus"
   - sentences:
       [
         "welche Schalter im Erdgeschoss sind an",
@@ -158,7 +158,7 @@ tests:
         "sind alle Türen abgeschlossen im Erdgeschoss",
       ]
     slots: { state: "locked", floor: "Erdgeschoss" }
-    response: "Nein, Schrankschloss ist nicht locked"
+    response: "Nein, Schrankschloss ist nicht abgeschlossen"
   - sentences:
       [
         "welche Türen im Erdgeschoss sind aufgeschlossen",

--- a/tests/de/HassGetState/name_state.yaml
+++ b/tests/de/HassGetState/name_state.yaml
@@ -37,7 +37,7 @@ tests:
     slots:
       name: "Flurlampe"
       state: "on"
-    response: "Nein, off"
+    response: "Nein, aus"
 
   # covers
   - sentences:


### PR DESCRIPTION
The German HassGetState responses mixed English words into spoken German answers. Asking "sind alle Türen abgeschlossen" answered "Nein, Hintertür ist nicht locked", and "ist die Flurlampe an" answered "Nein, off". The "all" response inserted the raw slot state and the "one_yesno" response inserted the raw entity state, so every non-numeric state came out in English.

This change adds a small state name mapping inside the two affected templates in responses/de/HassGetState.yaml, following the pattern already used by the weather condition mapping in responses/de/HassGetWeather.yaml. The mapping covers the closed set of state values reachable through the German sentence lists (on_off_states, cover_states, lock_states, bs_open_states, bs_occupancy_states) plus the person states home and not_home, using the same words the German sentences and the existing "where" response already use: an, aus, offen, geschlossen, am Öffnen, am Schließen, abgeschlossen, aufgeschlossen, zu Hause, unterwegs. Unmapped values, for example zone names or sensor values with units, pass through unchanged. The wording is invariant for singular and plural, so the existing ist/sind handling keeps working.

The 16 test expectations that asserted the mixed language output were updated to the German wording first and failed against the old templates, then passed after the template change. Verified with intentfest validate, the full German pytest suite (324 passed), check_overmatch (0 over-matches, 0 no-match), prune in check mode, and report_unparsed_examples (unchanged at the upstream baseline).
