### PR TITLE
Fix intentfest scripts broken by the slot-combination migration

### DIFF
--- a/script/intentfest/add_language.py
+++ b/script/intentfest/add_language.py
@@ -4,14 +4,7 @@ import argparse
 
 import yaml
 
-from .const import (
-    INTENTS_FILE,
-    LANGUAGES_FILE,
-    RESPONSE_DIR,
-    ROOT,
-    SENTENCE_DIR,
-    TESTS_DIR,
-)
+from .const import LANGUAGES_FILE, RESPONSE_DIR, ROOT, SENTENCE_DIR, TESTS_DIR
 from .util import YamlDumper, get_base_arg_parser
 
 
@@ -45,8 +38,6 @@ def run() -> int:
         """Dump YAML for `obj` with consistent options and return a string."""
         return yaml.dump(obj, sort_keys=False, allow_unicode=True, Dumper=YamlDumper)
 
-    intent_schemas = yaml.safe_load(INTENTS_FILE.read_text(encoding="utf-8"))
-
     # Create language directory
     sentence_dir = SENTENCE_DIR / language
     tests_dir = TESTS_DIR / language
@@ -60,38 +51,24 @@ def run() -> int:
         print(f"Language '{language}' already exists")
         return 1
 
-    # Create sentence files based off English
+    # Create sentence files based off English. Sentences live in the
+    # per-slot-combination format: sentences/<lang>/<Intent>/<combo>.yaml. Each
+    # English combo file is copied with its sentence lists emptied — the
+    # language-independent scaffolding (slots, name/inferred domains, response
+    # keys, and the example hint) is kept for the translator to work from.
     english_sentences = SENTENCE_DIR / "en"
 
-    for english_filename in english_sentences.glob("*.yaml"):
-        if english_filename.name == "_common.yaml":
-            continue
+    for intent_dir in sorted(p for p in english_sentences.iterdir() if p.is_dir()):
+        target_intent_dir = sentence_dir / intent_dir.name
+        target_intent_dir.mkdir(parents=True, exist_ok=True)
 
-        domain, intent = english_filename.stem.rsplit("_", maxsplit=1)
+        for combo_file in sorted(intent_dir.glob("*.yaml")):
+            combo = yaml.safe_load(combo_file.read_text(encoding="utf-8")) or {}
+            combo["language"] = language
+            for sentence_info in combo.get("data", []):
+                sentence_info["sentences"] = []
 
-        sentence_info: dict = {
-            "sentences": [],
-        }
-        if domain != intent_schemas[intent]["domain"]:
-            sentence_info["slots"] = {
-                "domain": domain,
-                "name": "all",
-            }
-
-        (sentence_dir / english_filename.name).write_text(
-            yaml_dump(
-                {
-                    "language": language,
-                    "intents": {
-                        intent: {
-                            "data": [
-                                sentence_info,
-                            ],
-                        },
-                    },
-                },
-            )
-        )
+            (target_intent_dir / combo_file.name).write_text(yaml_dump(combo))
 
     (sentence_dir / "_common.yaml").write_text(
         yaml_dump(
@@ -143,73 +120,36 @@ def run() -> int:
         )
     )
 
-    # Create tests files based off English
+    # Create tests files based off English. Tests mirror the sentence layout:
+    # tests/<lang>/<Intent>/<combo>.yaml. Each English test file is copied with
+    # its test sentences emptied — the entities/areas/floors fixtures, expected
+    # slots and rendered responses stay as a reference for the translator to
+    # localize.
     english_tests = TESTS_DIR / "en"
 
-    for english_filename in english_tests.glob("*.yaml"):
-        if english_filename.name == "_fixtures.yaml":
-            continue
+    for intent_dir in sorted(p for p in english_tests.iterdir() if p.is_dir()):
+        target_intent_dir = tests_dir / intent_dir.name
+        target_intent_dir.mkdir(parents=True, exist_ok=True)
 
-        domain, intent = english_filename.stem.rsplit("_", maxsplit=1)
+        for combo_file in sorted(intent_dir.glob("*.yaml")):
+            combo = yaml.safe_load(combo_file.read_text(encoding="utf-8")) or {}
+            combo["language"] = language
+            for test_group in combo.get("tests", []):
+                test_group["sentences"] = []
 
-        slots = {}
+            (target_intent_dir / combo_file.name).write_text(yaml_dump(combo))
 
-        if domain != intent_schemas[intent]["domain"]:
-            slots = {"domain": domain, "name": "all"}
-
-        (tests_dir / english_filename.name).write_text(
-            yaml_dump(
-                {
-                    "language": language,
-                    "tests": [
-                        {
-                            "sentences": [],
-                            "intent": {
-                                "name": intent,
-                                "slots": slots,
-                            },
-                        },
-                    ],
-                },
-            )
-        )
-
-    (tests_dir / "_fixtures.yaml").write_text(
-        yaml_dump(
-            {
-                "language": language,
-                "areas": [
-                    {"name": "Kitchen", "id": "kitchen"},
-                    {"name": "Living Room", "id": "living_room"},
-                    {"name": "Bedroom", "id": "bedroom"},
-                    {"name": "Garage", "id": "garage"},
-                ],
-                "entities": [
-                    {
-                        "name": "Bedroom Lamp",
-                        "id": "light.bedroom_lamp",
-                        "area": "bedroom",
-                    },
-                    {
-                        "name": "Kitchen Switch",
-                        "id": "switch.kitchen",
-                        "area": "kitchen",
-                    },
-                    {
-                        "name": "Ceiling Fan",
-                        "id": "fan.ceiling",
-                        "area": "living_room",
-                    },
-                ],
-            },
-        )
+    # Copy the fixtures (areas/floors/entities) as a starting point.
+    fixtures = yaml.safe_load(
+        (english_tests / "_fixtures.yaml").read_text(encoding="utf-8")
     )
+    fixtures["language"] = language
+    (tests_dir / "_fixtures.yaml").write_text(yaml_dump(fixtures))
 
     # Create response files based off English
     english_responses = RESPONSE_DIR / "en"
 
     for english_filename in english_responses.glob("*.yaml"):
-        intent = english_filename.stem
         with open(english_filename, "r", encoding="utf-8") as english_file:
             responses = yaml.safe_load(english_file)["responses"]
 
@@ -266,13 +206,13 @@ def run() -> int:
     )
     print()
     print(
-        f"{rel_sentence_dir / 'homeassistant_HassTurnOn.yaml'} - Add some basic sentences"
+        f"{rel_sentence_dir / 'HassTurnOn' / 'name_only.yaml'} - Add some basic sentences"
     )
     print(
-        f"{rel_sentence_dir / 'homeassistant_HassTurnOff.yaml'} - Add some basic sentences"
+        f"{rel_sentence_dir / 'HassTurnOff' / 'name_only.yaml'} - Add some basic sentences"
     )
     print()
-    print(f"{rel_test_dir / 'homeassistant_HassTurnOn.yaml'} - Add test sentences")
-    print(f"{rel_test_dir / 'homeassistant_HassTurnOff.yaml'} - Add test sentences")
+    print(f"{rel_test_dir / 'HassTurnOn' / 'name_only.yaml'} - Add test sentences")
+    print(f"{rel_test_dir / 'HassTurnOff' / 'name_only.yaml'} - Add test sentences")
 
     return 0

--- a/script/intentfest/check_slot_combinations.py
+++ b/script/intentfest/check_slot_combinations.py
@@ -28,8 +28,8 @@ from hassil import (
     Sequence,
 )
 
-from .const import INTENTS_FILE, LANGUAGES, SENTENCE_DIR
-from .util import get_base_arg_parser
+from .const import INTENTS_FILE, LANGUAGES
+from .util import get_base_arg_parser, load_intents_dict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ def run() -> int:
 
 
 def _get_support(language: str, intents: Dict[str, Any], args: argparse.Namespace):
-    lang_intents = Intents.from_files((SENTENCE_DIR / language).glob("*.yaml"))
+    lang_intents = Intents.from_dict(load_intents_dict(language))
     lang_supports: List[LanguageIntentSupport] = []
     rule_slot_cache: Dict[Tuple[str, bool], Any] = {}
 
@@ -171,18 +171,21 @@ def _get_support(language: str, intents: Dict[str, Any], args: argparse.Namespac
             # Language does not have intent at all
             continue
 
+        # `slot_combinations` is a mapping of combo name -> combo info, where
+        # each combo info carries its `slots` (a list, or a bare string) and an
+        # optional `context_area` flag.
         expected_slot_combos: Set[Tuple[str, ...]] = set()
-        for combo in slot_combinations:
+        for combo in slot_combinations.values():
             combo_slots = combo["slots"]
             if isinstance(combo_slots, str):
                 combo_slots = [combo_slots]
+            else:
+                combo_slots = list(combo_slots)
 
             if combo.get("context_area", False):
                 combo_slots.append(CONTEXT_AREA_SLOT)
 
-            expected_slot_combos.update(
-                tuple(sorted(combo_slots)) for combo in slot_combinations
-            )
+            expected_slot_combos.add(tuple(sorted(combo_slots)))
 
         actual_slot_combos: Set[Tuple[str, ...]] = set()
         combo_sentences = defaultdict(set)

--- a/script/intentfest/count_sentences.py
+++ b/script/intentfest/count_sentences.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import argparse
 import math
 from functools import reduce
-from typing import Any, Dict, Optional
+from typing import Optional
 
-import yaml
 from hassil import (
     Alternative,
     Expression,
@@ -22,12 +21,11 @@ from hassil import (
     Sequence,
     SlotList,
     TextSlotList,
-    merge_dict,
     parse_sentence,
 )
 
-from .const import LANGUAGES, SENTENCE_DIR
-from .util import get_base_arg_parser
+from .const import LANGUAGES
+from .util import get_base_arg_parser, load_intents_dict
 
 
 def get_arguments() -> argparse.Namespace:
@@ -134,15 +132,10 @@ def run() -> int:
         user_sentence = parse_sentence(args.sentence, keep_text=True)
 
     for language in sorted(languages):
-        language_dir = SENTENCE_DIR / language
+        # Load intents (legacy flat + per-slot-combination format)
+        intents_dict = load_intents_dict(language)
 
-        # Load intents
-        intents_dict: Dict[str, Any] = {}
-        for intent_path in language_dir.glob("*.yaml"):
-            with open(intent_path, "r", encoding="utf-8") as intent_file:
-                merge_dict(intents_dict, yaml.safe_load(intent_file))
-
-        assert intents_dict, "No intent YAML files loaded"
+        assert intents_dict["intents"], "No intents loaded"
         intents = Intents.from_dict(intents_dict)
 
         counts = []

--- a/script/intentfest/llm_template.py
+++ b/script/intentfest/llm_template.py
@@ -48,12 +48,23 @@ def run() -> int:
         RESPONSE_DIR / f"en/{args.intent}.yaml",
     ]
 
-    # Find sentences
+    # Find sentences. In the per-slot-combination format each intent's sentences
+    # live in sentences/en/<intent>/<combo>.yaml, with tests alongside in
+    # tests/en/<intent>/<combo>.yaml.
+    intent_sentence_dir = SENTENCE_DIR / "en" / args.intent
+    if intent_sentence_dir.is_dir():
+        for sentence_file in sorted(intent_sentence_dir.glob("*.yaml")):
+            to_collect.append(sentence_file)
+            test_file = TESTS_DIR / "en" / args.intent / sentence_file.name
+            if test_file.exists():
+                to_collect.append(test_file)
+
+    # Legacy flat format (languages/intents not yet migrated).
     for sentence_file in sorted((SENTENCE_DIR / "en").glob("*.yaml")):
         if sentence_file.name == "_common.yaml":
             continue
-        content = yaml.safe_load(sentence_file.read_text())
-        if args.intent not in content["intents"]:
+        content = yaml.safe_load(sentence_file.read_text()) or {}
+        if args.intent not in content.get("intents", {}):
             continue
 
         to_collect.append(sentence_file)

--- a/script/intentfest/merged_output.py
+++ b/script/intentfest/merged_output.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import yaml
 from hassil import merge_dict
 
-from .const import INTENTS_FILE, LANGUAGES, RESPONSE_DIR, SENTENCE_DIR
-from .util import get_base_arg_parser
+from .const import INTENTS_FILE, LANGUAGES, RESPONSE_DIR
+from .util import get_base_arg_parser, load_intents_dict
 
 
 def get_arguments() -> argparse.Namespace:
@@ -33,9 +33,9 @@ def run() -> int:
         (target / domain).mkdir(parents=True, exist_ok=True)
 
     for language in LANGUAGES:
-        merged_sentences: dict = {}
-        for sentence_file in (SENTENCE_DIR / language).glob("*.yaml"):
-            merge_dict(merged_sentences, yaml.safe_load(sentence_file.read_text()))
+        # Assemble the full intents dict (legacy flat + per-slot-combination
+        # format), including lists/expansion_rules/skip_words for the merged file.
+        merged_sentences = load_intents_dict(language)
 
         merged_responses: dict = {}
         for response_file in (RESPONSE_DIR / language).glob("*.yaml"):

--- a/script/intentfest/parse.py
+++ b/script/intentfest/parse.py
@@ -6,13 +6,11 @@ import argparse
 import json
 import sys
 from collections.abc import Iterable
-from typing import Any, Dict, Optional
+from typing import Optional
 
-import yaml
 from hassil import (
     Intents,
     RecognizeResult,
-    merge_dict,
     normalize_whitespace,
     recognize_all,
     recognize_best,
@@ -27,8 +25,13 @@ from shared import (
     render_response,
 )
 
-from .const import INTENTS_FILE, LANGUAGES, LIST_DIR, RULE_DIR, SENTENCE_DIR, TESTS_DIR
-from .util import get_base_arg_parser, load_merged_responses
+from .const import LANGUAGES
+from .util import (
+    get_base_arg_parser,
+    load_fixtures,
+    load_intents_dict,
+    load_merged_responses,
+)
 
 
 def get_arguments() -> argparse.Namespace:
@@ -67,11 +70,9 @@ def get_arguments() -> argparse.Namespace:
 def run() -> int:
     args = get_arguments()
 
-    language_dir = SENTENCE_DIR / args.language
-    tests_dir = TESTS_DIR / args.language
-
-    # Load test areas and entities for language
-    fixtures = yaml.safe_load((tests_dir / "_fixtures.yaml").read_text())
+    # Load test areas and entities for language (from _fixtures.yaml when
+    # present, else aggregated from the per-slot-combination test files).
+    fixtures = load_fixtures(args.language)
     slot_lists = get_slot_lists(fixtures)
     states = get_states(fixtures)
     areas = get_areas(fixtures)
@@ -79,65 +80,8 @@ def run() -> int:
 
     # Load intents. This supports both the legacy flat format
     # (sentences/<lang>/<domain>_<Intent>.yaml) and the per-slot-combination
-    # format (sentences/<lang>/<Intent>/<combo>.yaml). A fully migrated language
-    # has only the latter, so we also load lists/rules from their new homes.
-    intents_dict: Dict[str, Any] = {"language": args.language, "intents": {}}
-
-    # Legacy flat sentence files (also provides skip_words via _common.yaml)
-    for intent_path in language_dir.glob("*.yaml"):
-        with open(intent_path, "r", encoding="utf-8") as intent_file:
-            merge_dict(intents_dict, yaml.safe_load(intent_file))
-
-    intents_dict.setdefault("intents", {})
-
-    # Lists: shared (lists/*.yaml) + language-specific (lists/<lang>/*.yaml)
-    lists_dict: Dict[str, Any] = intents_dict.setdefault("lists", {})
-    for list_path in (
-        *LIST_DIR.glob("*.yaml"),
-        *(LIST_DIR / args.language).glob("*.yaml"),
-    ):
-        lists_dict.update(
-            (yaml.safe_load(list_path.read_text()) or {}).get("lists", {})
-        )
-
-    # Expansion rules: language-specific (rules/<lang>/*.yaml)
-    rules_dict: Dict[str, Any] = intents_dict.setdefault("expansion_rules", {})
-    for rule_path in (RULE_DIR / args.language).glob("*.yaml"):
-        rules_dict.update(
-            (yaml.safe_load(rule_path.read_text()) or {}).get("expansion_rules", {})
-        )
-
-    # Per-slot-combination sentence files (new format)
-    intent_info = yaml.safe_load(INTENTS_FILE.read_text())
-    for intent_name, info in intent_info.items():
-        for combo_name, combo_info in (info.get("slot_combinations") or {}).items():
-            combo_path = language_dir / intent_name / f"{combo_name}.yaml"
-            if not combo_path.exists():
-                continue
-
-            combo_dict = yaml.safe_load(combo_path.read_text()) or {}
-            intent_data = intents_dict["intents"].setdefault(intent_name, {"data": []})[
-                "data"
-            ]
-            for data in combo_dict.get("data", []):
-                slots = dict(data.get("slots", {}))
-                requires_context = dict(data.get("requires_context", {}))
-                if name_domains := data.get("name_domains"):
-                    requires_context["domain"] = name_domains
-                elif inferred_domain := data.get("inferred_domain"):
-                    slots["domain"] = inferred_domain
-
-                if combo_info.get("context_area"):
-                    requires_context["area"] = {"slot": True}
-
-                intent_data.append(
-                    {
-                        "sentences": data["sentences"],
-                        "slots": slots,
-                        "requires_context": requires_context,
-                        "response": data["response"],
-                    }
-                )
+    # format (sentences/<lang>/<Intent>/<combo>.yaml).
+    intents_dict = load_intents_dict(args.language)
 
     assert intents_dict["intents"], "No intents loaded"
     intents = Intents.from_dict(intents_dict)

--- a/script/intentfest/sample.py
+++ b/script/intentfest/sample.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from typing import Any, Dict
 
-import yaml
-from hassil import Intents, merge_dict, sample_intents
+from hassil import Intents, sample_intents
 
 from shared import get_slot_lists
 
-from .const import LANGUAGES, SENTENCE_DIR, TESTS_DIR
-from .util import get_base_arg_parser
+from .const import LANGUAGES
+from .util import get_base_arg_parser, load_fixtures, load_intents_dict
 
 
 def get_arguments() -> argparse.Namespace:
@@ -41,20 +39,15 @@ def get_arguments() -> argparse.Namespace:
 def run() -> int:
     args = get_arguments()
 
-    language_dir = SENTENCE_DIR / args.language
-    tests_dir = TESTS_DIR / args.language
-
-    # Load test areas and entities for language
-    test_names = yaml.safe_load((tests_dir / "_fixtures.yaml").read_text())
+    # Load test areas and entities for language (from _fixtures.yaml when
+    # present, else aggregated from the per-slot-combination test files).
+    test_names = load_fixtures(args.language)
     slot_lists = get_slot_lists(test_names)
 
-    # Load intents
-    intents_dict: Dict[str, Any] = {}
-    for intent_path in language_dir.glob("*.yaml"):
-        with open(intent_path, "r", encoding="utf-8") as intent_file:
-            merge_dict(intents_dict, yaml.safe_load(intent_file))
+    # Load intents (legacy flat + per-slot-combination format)
+    intents_dict = load_intents_dict(args.language)
 
-    assert intents_dict, "No intent YAML files loaded"
+    assert intents_dict["intents"], "No intents loaded"
     intents = Intents.from_dict(intents_dict)
 
     # Sample sentences

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -1,11 +1,19 @@
 """Translation utils."""
 
 import argparse
+from typing import Any, Dict
 
 import yaml
 from hassil import merge_dict
 
-from .const import RESPONSE_DIR, SENTENCE_DIR
+from .const import (
+    INTENTS_FILE,
+    LIST_DIR,
+    RESPONSE_DIR,
+    RULE_DIR,
+    SENTENCE_DIR,
+    TESTS_DIR,
+)
 
 
 # pylint:disable=too-many-ancestors
@@ -70,6 +78,156 @@ def load_merged_sentences(language: str) -> dict:
                 )
 
     return merged_sentences
+
+
+def load_intents_dict(language: str) -> Dict[str, Any]:
+    """Assemble a complete, hassil-ready intents dict for a language.
+
+    Handles both the legacy flat format
+    (``sentences/<lang>/<domain>_<Intent>.yaml``) and the per-slot-combination
+    format (``sentences/<lang>/<Intent>/<combo>.yaml``). Lists and expansion
+    rules are pulled from their post-migration homes (``lists/``, ``lists/<lang>/``,
+    ``rules/<lang>/``), and the migration shorthands (``name_domains`` /
+    ``inferred_domain`` / ``context_area``) are translated into hassil's
+    ``slots`` / ``requires_context``. A partially migrated language works too:
+    legacy files and combo files are merged.
+
+    The returned dict is suitable for ``hassil.Intents.from_dict``.
+    """
+    language_dir = SENTENCE_DIR / language
+    intents_dict: Dict[str, Any] = {"language": language, "intents": {}}
+
+    # Legacy flat sentence files (also provides language-level config such as
+    # skip_words / responses.errors via _common.yaml).
+    for intent_path in language_dir.glob("*.yaml"):
+        merge_dict(intents_dict, yaml.safe_load(intent_path.read_text()) or {})
+
+    intents_dict.setdefault("intents", {})
+
+    # Lists: shared (lists/*.yaml) + language-specific (lists/<lang>/*.yaml)
+    lists_dict: Dict[str, Any] = intents_dict.setdefault("lists", {})
+    for list_path in (
+        *LIST_DIR.glob("*.yaml"),
+        *(LIST_DIR / language).glob("*.yaml"),
+    ):
+        lists_dict.update(
+            (yaml.safe_load(list_path.read_text()) or {}).get("lists", {})
+        )
+
+    # Expansion rules: language-specific (rules/<lang>/*.yaml)
+    rules_dict: Dict[str, Any] = intents_dict.setdefault("expansion_rules", {})
+    for rule_path in (RULE_DIR / language).glob("*.yaml"):
+        rules_dict.update(
+            (yaml.safe_load(rule_path.read_text()) or {}).get("expansion_rules", {})
+        )
+
+    # Per-slot-combination sentence files (new format)
+    intent_info = yaml.safe_load(INTENTS_FILE.read_text())
+    for intent_name, info in intent_info.items():
+        for combo_name, combo_info in (info.get("slot_combinations") or {}).items():
+            combo_path = language_dir / intent_name / f"{combo_name}.yaml"
+            if not combo_path.exists():
+                continue
+
+            combo_dict = yaml.safe_load(combo_path.read_text()) or {}
+            intent_data = intents_dict["intents"].setdefault(intent_name, {"data": []})[
+                "data"
+            ]
+            for data in combo_dict.get("data", []):
+                slots = dict(data.get("slots", {}))
+                requires_context = dict(data.get("requires_context", {}))
+                if name_domains := data.get("name_domains"):
+                    requires_context["domain"] = name_domains
+                elif inferred_domain := data.get("inferred_domain"):
+                    slots["domain"] = inferred_domain
+
+                if combo_info.get("context_area"):
+                    requires_context["area"] = {"slot": True}
+
+                intent_data.append(
+                    {
+                        "sentences": data["sentences"],
+                        "slots": slots,
+                        "requires_context": requires_context,
+                        "response": data["response"],
+                    }
+                )
+
+    return intents_dict
+
+
+def _slug(name: str) -> str:
+    """Synthesize an id from a human name (mirrors the test harness)."""
+    return name.strip().casefold().replace(" ", "_")
+
+
+def load_fixtures(language: str) -> Dict[str, Any]:
+    """Load test fixtures (entities/areas/floors/timers/media) for a language.
+
+    Prefers a monolithic ``tests/<lang>/_fixtures.yaml`` when present. Otherwise
+    — the per-slot-combination format, where each test file carries its own
+    inline fixtures — it aggregates the fixtures declared across every
+    ``tests/<lang>/<Intent>/<combo>.yaml`` file, synthesizing the ids the test
+    harness would (mirroring ``tests/test_slot_combinations.py``).
+
+    The returned dict is compatible with ``shared.get_slot_lists`` /
+    ``get_states`` / ``get_areas`` / ``get_floors``.
+    """
+    tests_dir = TESTS_DIR / language
+
+    legacy_fixtures = tests_dir / "_fixtures.yaml"
+    if legacy_fixtures.exists():
+        return yaml.safe_load(legacy_fixtures.read_text()) or {}
+
+    entities: Dict[str, Dict[str, Any]] = {}
+    areas: Dict[str, Dict[str, Any]] = {}
+    floors: Dict[str, Dict[str, Any]] = {}
+    timers: list = []
+    media: list = []
+
+    for combo_file in sorted(tests_dir.glob("*/*.yaml")):
+        test_dict = yaml.safe_load(combo_file.read_text()) or {}
+
+        for floor in test_dict.get("floors", []):
+            floor_id = _slug(floor["name"])
+            floors.setdefault(floor_id, {"id": floor_id, "name": floor["name"]})
+
+        for area in test_dict.get("areas", []):
+            area_id = _slug(area["name"])
+            entry = {"id": area_id, "name": area["name"]}
+            if area.get("floor"):
+                entry["floor"] = _slug(area["floor"])
+            areas.setdefault(area_id, entry)
+
+        for entity in test_dict.get("entities", []):
+            entity_id = f"{entity['domain']}.{_slug(entity['name'])}"
+            if entity_id in entities:
+                continue
+            entry = {"id": entity_id, "name": entity["name"]}
+            if "state" in entity:
+                entry["state"] = entity["state"]
+            elif "state_with_unit" in entity:
+                # No raw state given; use the human state_with_unit for rendering.
+                entry["state"] = entity["state_with_unit"]
+            if entity.get("area"):
+                entry["area"] = _slug(entity["area"])
+            if entity.get("attributes"):
+                entry["attributes"] = entity["attributes"]
+            if "is_exposed" in entity:
+                entry["is_exposed"] = entity["is_exposed"]
+            entities[entity_id] = entry
+
+        timers.extend(test_dict.get("timers", []))
+        media.extend(test_dict.get("media", []))
+
+    return {
+        "language": language,
+        "entities": list(entities.values()),
+        "areas": list(areas.values()),
+        "floors": list(floors.values()),
+        "timers": timers,
+        "media": media,
+    }
 
 
 def load_merged_responses(language: str) -> dict:


### PR DESCRIPTION
## Problem

The slot-combination migration moved sentences from the flat `sentences/<lang>/<domain>_<Intent>.yaml` layout to the per-slot-combination layout `sentences/<lang>/<Intent>/<combo>.yaml` (with lists/rules relocated to `lists/`, `lists/<lang>/`, `rules/<lang>/`, and test fixtures moved inline into each per-combo test file). 64 of 65 languages are now migrated (only `ga` remains flat).

Several `script/intentfest` subcommands still loaded intents the old way — globbing the top-level `*.yaml` files and calling `Intents.from_dict` — which now yields an empty dict and crashes with `KeyError: 'intents'`. Others read the now-deleted `tests/<lang>/_fixtures.yaml` and crashed with `FileNotFoundError`.

## Fix

Two canonical loaders added to `util.py` (single source of truth):

- **`load_intents_dict(language)`** — handles both the legacy flat and per-slot-combination formats, translates the migration shorthands (`name_domains` / `inferred_domain` / `context_area`) into hassil's `slots` / `requires_context`, and pulls lists/rules from their post-migration homes.
- **`load_fixtures(language)`** — prefers `tests/<lang>/_fixtures.yaml` when present, otherwise aggregates the inline per-combo test fixtures, synthesizing ids the way `tests/test_slot_combinations.py` does.

Scripts fixed:

| Script | Change |
|---|---|
| `parse`, `sample`, `count_sentences`, `merged_output` | Use the shared loaders |
| `check_slot_combinations` | Use the shared loader **+** fix `_get_support` to treat `intents.yaml` `slot_combinations` as a dict (it was iterated as a list) |
| `llm_template` | Collect per-combo `sentences/en/<Intent>/*.yaml` plus their tests |
| `add_language` | Scaffold the new per-combo directory layout by copying the English combo files with their sentence lists emptied |

`sample`/`parse` also now work for the migrated languages that no longer have a `_fixtures.yaml` (previously en/ga only).

## Verification

- All **65 languages** load cleanly through `load_intents_dict` → `Intents.from_dict` and `load_fixtures` → the shared fixture helpers.
- Every fixed subcommand runs end-to-end (checked against en, de, and ga).
- `pyflakes` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)