### PR TITLE
Add shared name domain groups, migrate en

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -84,6 +84,16 @@ HassTurnOn:
           - "lock"
         optional:
           - "valve"
+          - "climate"
+      # Shared groups
+      name_domain_groups:
+        default:
+          - "light"
+          - "switch"
+          - "fan"
+          - "media_player"
+          - "input_boolean"
+          - "climate"
       example:
         - "turn on the overhead light"
         - "open sliding door"
@@ -146,6 +156,16 @@ HassTurnOn:
           - "cover"
           - "lock"
           - "valve"
+          - "climate"
+      # Shared groups
+      name_domain_groups:
+        default:
+          - "light"
+          - "switch"
+          - "fan"
+          - "media_player"
+          - "input_boolean"
+          - "climate"
       example:
         - "turn on the overhead light in the kitchen"
         - "open the sliding door in the kitchen"
@@ -166,6 +186,16 @@ HassTurnOn:
           - "input_boolean"
           - "cover"
           - "valve"
+          - "climate"
+      # Shared groups
+      name_domain_groups:
+        default:
+          - "light"
+          - "switch"
+          - "fan"
+          - "media_player"
+          - "input_boolean"
+          - "climate"
       example:
         - "turn on the overhead light on the first floor"
         - "open the sliding door on the first floor"
@@ -277,6 +307,16 @@ HassTurnOff:
           - "lock"
         optional:
           - "valve"
+          - "climate"
+      # Shared groups
+      name_domain_groups:
+        default:
+          - "light"
+          - "switch"
+          - "fan"
+          - "media_player"
+          - "input_boolean"
+          - "climate"
       example:
         - "turn off the overhead light"
         - "close sliding door"
@@ -339,6 +379,16 @@ HassTurnOff:
           - "cover"
           - "lock"
           - "valve"
+          - "climate"
+      # Shared groups
+      name_domain_groups:
+        default:
+          - "light"
+          - "switch"
+          - "fan"
+          - "media_player"
+          - "input_boolean"
+          - "climate"
       example:
         - "turn off the overhead light in the kitchen"
         - "close the sliding door in the kitchen"
@@ -359,6 +409,16 @@ HassTurnOff:
           - "input_boolean"
           - "cover"
           - "valve"
+          - "climate"
+      # Shared groups
+      name_domain_groups:
+        default:
+          - "light"
+          - "switch"
+          - "fan"
+          - "media_player"
+          - "input_boolean"
+          - "climate"
       example:
         - "turn off the overhead light on the first floor"
         - "close the sliding door on the first floor"

--- a/script/intentfest/check_overmatch.py
+++ b/script/intentfest/check_overmatch.py
@@ -29,7 +29,7 @@ import yaml
 from hassil import Intents, SlotList, TextSlotList, recognize_best
 
 from .const import INTENTS_FILE, LANGUAGES, LIST_DIR, RULE_DIR, SENTENCE_DIR, TESTS_DIR
-from .util import get_base_arg_parser
+from .util import get_base_arg_parser, resolve_domain_context
 
 # Sentinel area injected via intent_context, matching the slot-combination
 # harness (tests/test_slot_combinations.py:CONTEXT_AREA_NAME).
@@ -177,20 +177,10 @@ def _load_merged_intents(language: str, intent_schemas: dict[str, Any]) -> Inten
                 test_data_dict = yaml.safe_load(sentences_file)
 
                 for test_sentences_dict in test_data_dict["data"]:
-                    test_slots = test_sentences_dict.get("slots", {})
-                    test_metadata = test_sentences_dict.get("metadata", {})
-                    test_requires_context = test_sentences_dict.get(
-                        "requires_context", {}
+                    test_slots, test_requires_context = resolve_domain_context(
+                        test_sentences_dict, combo_info
                     )
-
-                    if name_domains := test_sentences_dict.get("name_domains"):
-                        test_requires_context["domain"] = name_domains
-                    elif inferred_domain := test_sentences_dict.get("inferred_domain"):
-                        test_slots["domain"] = inferred_domain
-
-                    # Add context area slot
-                    if combo_info.get("context_area"):
-                        test_requires_context["area"] = {"slot": True}
+                    test_metadata = test_sentences_dict.get("metadata", {})
 
                     # Attach metadata so we can identify the slot combination of
                     # whichever intent ends up winning.

--- a/script/intentfest/example_highlight.py
+++ b/script/intentfest/example_highlight.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional
 import yaml
 
 from .const import INTENTS_FILE, LIST_DIR, RULE_DIR, SENTENCE_DIR, TESTS_DIR
+from .util import resolve_domain_context
 
 # Map each slot name to a colour category. Slots not listed fall back to
 # "number" (numeric/range slots) or "other".
@@ -133,14 +134,7 @@ def _build_language_intents(language: str, intent_info: dict) -> Optional[Any]:
                     continue
                 combo_data = yaml.safe_load(sentences_path.read_text()) or {}
                 for group in combo_data.get("data", []):
-                    slots = dict(group.get("slots", {}))
-                    requires_context = dict(group.get("requires_context", {}))
-                    if name_domains := group.get("name_domains"):
-                        requires_context["domain"] = name_domains
-                    elif inferred_domain := group.get("inferred_domain"):
-                        slots["domain"] = inferred_domain
-                    if combo_info.get("context_area"):
-                        requires_context["area"] = {"slot": True}
+                    slots, requires_context = resolve_domain_context(group, combo_info)
                     data.append(
                         {
                             "sentences": group["sentences"],

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -1,7 +1,7 @@
 """Translation utils."""
 
 import argparse
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import yaml
 from hassil import merge_dict
@@ -134,16 +134,7 @@ def load_intents_dict(language: str) -> Dict[str, Any]:
                 "data"
             ]
             for data in combo_dict.get("data", []):
-                slots = dict(data.get("slots", {}))
-                requires_context = dict(data.get("requires_context", {}))
-                if name_domains := data.get("name_domains"):
-                    requires_context["domain"] = name_domains
-                elif inferred_domain := data.get("inferred_domain"):
-                    slots["domain"] = inferred_domain
-
-                if combo_info.get("context_area"):
-                    requires_context["area"] = {"slot": True}
-
+                slots, requires_context = resolve_domain_context(data, combo_info)
                 intent_data.append(
                     {
                         "sentences": data["sentences"],
@@ -154,6 +145,41 @@ def load_intents_dict(language: str) -> Dict[str, Any]:
                 )
 
     return intents_dict
+
+
+def resolve_domain_context(
+    data: Dict[str, Any], combo_info: Dict[str, Any]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Translate the slot-combination shorthands into hassil fragments.
+
+    Given a sentence ``data`` group and its slot-combination ``combo_info`` (from
+    ``intents.yaml``), return the ``(slots, requires_context)`` that hassil
+    expects. This is the single place the ``name_domains`` / ``inferred_domain``
+    / ``context_area`` shorthands are converted, so every consumer (the loader,
+    the tests, and the intentfest scripts) stays in sync.
+
+    ``name_domains`` may be an explicit list of domains or a string naming a
+    reusable set defined in ``combo_info['name_domain_groups']``; the latter is
+    resolved to its concrete list here.
+    """
+    slots = dict(data.get("slots", {}))
+    requires_context = dict(data.get("requires_context", {}))
+
+    if name_domains := data.get("name_domains"):
+        if isinstance(name_domains, str):
+            # Named group defined in intents.yaml (name_domain_groups)
+            name_domains = combo_info["name_domain_groups"][name_domains]
+        # {name} is restricted to entities with one of these domains
+        requires_context["domain"] = name_domains
+    elif inferred_domain := data.get("inferred_domain"):
+        # Domain is inferred from the words in the sentence
+        slots["domain"] = inferred_domain
+
+    if combo_info.get("context_area"):
+        # Area comes from the voice satellite's context
+        requires_context["area"] = {"slot": True}
+
+    return slots, requires_context
 
 
 def _slug(name: str) -> str:

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -240,7 +240,7 @@ def SLOT_COMBO_SENTENCE_SCHEMA(
     slot_names: set[str],
     rule_names: set[str],
     response_names: set[str],
-    name_domain_group_names: set[str] = frozenset(),
+    name_domain_group_names: Collection[str] = frozenset(),
 ) -> vol.Schema:
     schema_sentences_dict = {
         vol.Required("sentences"): [

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -146,6 +146,10 @@ INTENTS_SCHEMA = vol.Schema(
                         vol.In(IMPORTANCE_LEVELS): [str]
                     },
                     vol.Optional("name_domains"): {vol.In(IMPORTANCE_LEVELS): [str]},
+                    # Named, reusable domain sets that sentence files reference
+                    # by name via `name_domains: <group>` instead of repeating
+                    # the list. Group name -> list of domains.
+                    vol.Optional("name_domain_groups"): {str: [str]},
                     vol.Optional("context_area"): bool,
                     vol.Required("example"): vol.Any(str, [str]),
                     vol.Optional("wildcard_slots"): [str],
@@ -236,6 +240,7 @@ def SLOT_COMBO_SENTENCE_SCHEMA(
     slot_names: set[str],
     rule_names: set[str],
     response_names: set[str],
+    name_domain_group_names: set[str] = frozenset(),
 ) -> vol.Schema:
     schema_sentences_dict = {
         vol.Required("sentences"): [
@@ -253,7 +258,14 @@ def SLOT_COMBO_SENTENCE_SCHEMA(
     }
 
     if name_domains:
-        schema_sentences_dict[vol.Required("name_domains")] = [vol.In(name_domains)]
+        # Accept either a named group (resolved from name_domain_groups) or an
+        # explicit list of domains (the pre-existing form).
+        name_domains_options: list = [[vol.In(name_domains)]]
+        if name_domain_group_names:
+            name_domains_options.insert(0, vol.In(name_domain_group_names))
+        schema_sentences_dict[vol.Required("name_domains")] = vol.Any(
+            *name_domains_options
+        )
 
     if inferred_domains:
         schema_sentences_dict[vol.Required("inferred_domain")] = vol.In(
@@ -1034,6 +1046,9 @@ def validate_slot_combinations(
             error_info = f"intent_name={intent_name}, combo_name={combo_name}, file={combo_sentence_path}"
 
             name_domains: dict[str, list[str]] = combo_info.get("name_domains", {})
+            name_domain_groups: dict[str, list[str]] = combo_info.get(
+                "name_domain_groups", {}
+            )
             inferred_domains: dict[str, list[str]] = combo_info.get(
                 "inferred_domains", {}
             )
@@ -1082,6 +1097,7 @@ def validate_slot_combinations(
                     slot_names=available_sentence_slot_names,
                     rule_names=available_rule_names,
                     response_names=available_response_names,
+                    name_domain_group_names=set(name_domain_groups),
                 ),
             )
             if not sentences_info:
@@ -1092,7 +1108,14 @@ def validate_slot_combinations(
 
             for sentences_dict in sentences_info["data"]:
                 sentence_error_info = f"{error_info}, sentences={sentences_dict}"
-                sentence_name_domains = set(sentences_dict.get("name_domains", []))
+                raw_name_domains = sentences_dict.get("name_domains")
+                if isinstance(raw_name_domains, str):
+                    # A named group; resolve it to the concrete domain list.
+                    sentence_name_domains = set(
+                        name_domain_groups.get(raw_name_domains, [])
+                    )
+                else:
+                    sentence_name_domains = set(raw_name_domains or [])
                 sentence_inferred_domain = sentences_dict.get("inferred_domain")
 
                 if name_domains:

--- a/sentences/en/HassTurnOff/name_area.yaml
+++ b/sentences/en/HassTurnOff/name_area.yaml
@@ -16,12 +16,7 @@ data:
       - "deactivate [<the>] {area} [<the>] {name}"
       - "deactivate [<the>] {name} <in> [<the>] {area}"
     example: "turn off the overhead light in the kitchen"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/en/HassTurnOff/name_floor.yaml
+++ b/sentences/en/HassTurnOff/name_floor.yaml
@@ -13,12 +13,7 @@ data:
       - "[<turn>] [<the>] {name} <in> [<the>] {floor} [floor] [to] off"
       - "deactivate [<the>] {name} <in> [<the>] {floor} [floor]"
     example: "turn off the overhead light on the first floor"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/en/HassTurnOff/name_only.yaml
+++ b/sentences/en/HassTurnOff/name_only.yaml
@@ -12,12 +12,7 @@ data:
       - "[<turn>] [<the>] {name} [to] off"
       - "deactivate [<the>] {name}"
     example: "turn off the overhead light"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/en/HassTurnOn/name_area.yaml
+++ b/sentences/en/HassTurnOn/name_area.yaml
@@ -16,12 +16,7 @@ data:
       - "activate [<the>] {area} [<the>] {name}"
       - "activate [<the>] {name} <in> [<the>] {area}"
     example: "turn on the overhead light in the kitchen"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/en/HassTurnOn/name_floor.yaml
+++ b/sentences/en/HassTurnOn/name_floor.yaml
@@ -13,12 +13,7 @@ data:
       - "[<turn>] [<the>] {name} <in> [<the>] {floor} [floor] [to] on"
       - "activate [<the>] {name} <in> [<the>] {floor} [floor]"
     example: "turn on the overhead light on the first floor"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/en/HassTurnOn/name_only.yaml
+++ b/sentences/en/HassTurnOn/name_only.yaml
@@ -12,12 +12,7 @@ data:
       - "activate [<the>] {name}"
       - "[<the>] {name}"
     example: "turn on the overhead light"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/tests/test_slot_combinations.py
+++ b/tests/test_slot_combinations.py
@@ -1,5 +1,6 @@
 """Slot combination tests."""
 
+import importlib
 import itertools
 import sys
 from collections import defaultdict
@@ -20,7 +21,6 @@ from hassil import (
 )
 from jinja2 import BaseLoader, Environment, StrictUndefined
 
-from script.intentfest.util import resolve_domain_context
 from shared import get_areas, get_floors, get_matched_states, get_states, state_attr
 
 from . import (
@@ -32,6 +32,12 @@ from . import (
     SENTENCES_DIR,
     TESTS_DIR,
 )
+
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+_util: Any = importlib.import_module("script.intentfest.util")
+resolve_domain_context = _util.resolve_domain_context
 
 
 def _slug(name: str) -> str:

--- a/tests/test_slot_combinations.py
+++ b/tests/test_slot_combinations.py
@@ -20,6 +20,7 @@ from hassil import (
 )
 from jinja2 import BaseLoader, Environment, StrictUndefined
 
+from script.intentfest.util import resolve_domain_context
 from shared import get_areas, get_floors, get_matched_states, get_states, state_attr
 
 from . import (
@@ -192,20 +193,10 @@ def lang_resources_fixture(language: str, intent_schemas: dict[str, Any]):
                 ]
 
                 for test_sentences_dict in test_data_dict["data"]:
-                    test_slots = test_sentences_dict.get("slots", {})
-                    test_metadata = test_sentences_dict.get("metadata", {})
-                    test_requires_context = test_sentences_dict.get(
-                        "requires_context", {}
+                    test_slots, test_requires_context = resolve_domain_context(
+                        test_sentences_dict, combo_info
                     )
-
-                    if name_domains := test_sentences_dict.get("name_domains"):
-                        test_requires_context["domain"] = name_domains
-                    elif inferred_domain := test_sentences_dict.get("inferred_domain"):
-                        test_slots["domain"] = inferred_domain
-
-                    # Add context area slot
-                    if combo_info.get("context_area"):
-                        test_requires_context["area"] = {"slot": True}
+                    test_metadata = test_sentences_dict.get("metadata", {})
 
                     # Attach metadata so we can check the slot combination later
                     test_metadata["slot_combination"] = combo_name


### PR DESCRIPTION
Make it so `name_domains` can be a string, which refers to a `name_domain_groups` key from `intents.yaml`
This will allow for a centralized list of domains that can be turned on/off, etc.

Migrate en only for now. Other languages to follow.