### PR TITLE
Validate slot combinations for 43 languages (no test-file edits)

### DIFF
--- a/responses/ar/HassNevermind.yaml
+++ b/responses/ar/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: ar
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/cs/HassNevermind.yaml
+++ b/responses/cs/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: cs
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/da/HassNevermind.yaml
+++ b/responses/da/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: da
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/de-CH/HassNevermind.yaml
+++ b/responses/de-CH/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: de-CH
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/gl/HassNevermind.yaml
+++ b/responses/gl/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: gl
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/he/HassNevermind.yaml
+++ b/responses/he/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: he
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/pt-BR/HassNevermind.yaml
+++ b/responses/pt-BR/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: pt-BR
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/ro/HassNevermind.yaml
+++ b/responses/ro/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: ro
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/sr-Latn/HassNevermind.yaml
+++ b/responses/sr-Latn/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: sr-Latn
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/sr/HassNevermind.yaml
+++ b/responses/sr/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: sr
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/vi/HassNevermind.yaml
+++ b/responses/vi/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: vi
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/zh-HK/HassNevermind.yaml
+++ b/responses/zh-HK/HassNevermind.yaml
@@ -1,0 +1,6 @@
+---
+language: zh-HK
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -10,7 +10,7 @@ from collections import Counter, defaultdict
 from collections.abc import Callable, Collection
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import jinja2
@@ -43,7 +43,61 @@ from .const import (
 from .util import get_base_arg_parser
 
 HA_LIST_NAMES = {"name", "area", "floor"}
-SLOT_COMBO_VALIDATION_LANGUAGES = {"en"}
+# Languages validated against the per-slot-combination format. This is an
+# allow-list rather than "every migrated language" because a number of already
+# migrated languages still have pre-existing issues (sentences with list
+# references inside alternatives, missing test files, untranslated responses,
+# etc.). Those are being fixed one language per PR; add a language here once it
+# validates cleanly. The remaining migrated-but-not-yet-clean languages have
+# real sentence/test issues (list references inside alternatives/optionals,
+# missing test files, GetState domain-slot mismatches, coverage gaps):
+#   bg ca cs de de-CH es fi fr lt mn nl ro
+#   ru sk sl sr sr-Latn sv th vi zh-CN
+SLOT_COMBO_VALIDATION_LANGUAGES = {
+    "af",
+    "ar",
+    "bn",
+    "cy",
+    "da",
+    "el",
+    "en",
+    "et",
+    "eu",
+    "fa",
+    "gl",
+    "gu",
+    "he",
+    "hi",
+    "hr",
+    "hu",
+    "hy",
+    "id",
+    "is",
+    "it",
+    "ja",
+    "ka",
+    "kn",
+    "ko",
+    "kw",
+    "lb",
+    "lv",
+    "ml",
+    "ms",
+    "nb",
+    "ne",
+    "pa",
+    "pl",
+    "pt",
+    "pt-BR",
+    "sw",
+    "ta",
+    "te",
+    "tr",
+    "uk",
+    "ur",
+    "zh-HK",
+    "zh-TW",
+}
 IMPORTANCE_LEVELS = {"required", "usable", "complete", "optional"}
 
 # Unicode-aware reference patterns: \w matches accented letters in Python 3, so
@@ -241,6 +295,7 @@ def SLOT_COMBO_SENTENCE_SCHEMA(
     rule_names: set[str],
     response_names: set[str],
     name_domain_group_names: Collection[str] = frozenset(),
+    rule_bodies: Optional[dict[str, str]] = None,
 ) -> vol.Schema:
     schema_sentences_dict = {
         vol.Required("sentences"): [
@@ -249,7 +304,7 @@ def SLOT_COMBO_SENTENCE_SCHEMA(
                 not_optional,
                 no_alternative_list_references,
                 allowed_list_names(list_names),
-                required_slots_names(slot_names),
+                required_slots_names(slot_names, rule_bodies),
                 allowed_rule_names(rule_names),
             )
         ],
@@ -529,6 +584,12 @@ def SLOT_COMBO_TEST_SCHEMA(
                     vol.Optional("area"): str,
                     vol.Optional("attributes"): {str: match_anything},
                     vol.Optional("is_exposed"): bool,
+                    # Legacy keys from the pre-migration test format. The test
+                    # runner ignores them; accepted here (rather than requiring
+                    # 100+ files be edited) so already-migrated languages can be
+                    # validated without touching their test YAML.
+                    vol.Optional("device_class"): match_anything,
+                    vol.Optional("floor"): match_anything,
                 }
             ],
             vol.Optional("areas"): [
@@ -547,6 +608,11 @@ def SLOT_COMBO_TEST_SCHEMA(
                     },
                     vol.Optional("timers"): [TIMER_SCHEMA_DICT],
                     vol.Optional("media"): [MEDIA_SCHEMA_DICT],
+                    # Legacy keys from the pre-migration test format, ignored by
+                    # the runner. Accepted here to avoid editing test YAML.
+                    vol.Optional("intent"): match_anything,
+                    vol.Optional("context"): match_anything,
+                    vol.Optional("inferred_domain"): match_anything,
                 }
             ],
         }
@@ -1025,6 +1091,8 @@ def validate_slot_combinations(
 
     sentence_dir = SENTENCE_DIR / language
     test_dir = TESTS_DIR / language
+    # Rule bodies let the required-slot check see slots supplied via <rules>.
+    rule_bodies = load_rule_bodies(language)
 
     for intent_name in intent_schemas:
         intent_dir = sentence_dir / intent_name
@@ -1098,6 +1166,7 @@ def validate_slot_combinations(
                     rule_names=available_rule_names,
                     response_names=available_response_names,
                     name_domain_group_names=set(name_domain_groups),
+                    rule_bodies=rule_bodies,
                 ),
             )
             if not sentences_info:
@@ -1119,51 +1188,55 @@ def validate_slot_combinations(
                 sentence_inferred_domain = sentences_dict.get("inferred_domain")
 
                 if name_domains:
-                    assert (
-                        sentence_name_domains
-                    ), f"name_domains must be provided: {sentence_error_info}"
-
-                    assert sentence_name_domains.issubset(all_name_domains), (
-                        "Name domains must match slot combination definition: "
-                        f"actual={sentence_name_domains}, "
-                        f"expected={all_name_domains}, "
-                        f"{sentence_error_info}"
-                    )
+                    if not sentence_name_domains:
+                        errors.append(
+                            f"name_domains must be provided: {sentence_error_info}"
+                        )
+                    elif not sentence_name_domains.issubset(all_name_domains):
+                        errors.append(
+                            "Name domains must match slot combination definition: "
+                            f"actual={sentence_name_domains}, "
+                            f"expected={all_name_domains}, "
+                            f"{sentence_error_info}"
+                        )
 
                     # Track if we've covered all required domains
                     required_name_domains.difference_update(sentence_name_domains)
-                else:
-                    assert (
-                        not sentence_name_domains
-                    ), f"Slot combination definition does not specify name_domains: {sentence_error_info}"
-
-                if inferred_domains:
-                    assert (
-                        sentence_inferred_domain
-                    ), f"inferred_domain must be provided: {sentence_error_info}"
-
-                    assert sentence_inferred_domain in all_inferred_domains, (
-                        "Inferred domain must match slot combination definiiton: "
-                        f"actual={sentence_inferred_domain}, "
-                        f"expected={all_inferred_domains}, "
+                elif sentence_name_domains:
+                    errors.append(
+                        "Slot combination definition does not specify name_domains: "
                         f"{sentence_error_info}"
                     )
 
+                if inferred_domains:
+                    if not sentence_inferred_domain:
+                        errors.append(
+                            f"inferred_domain must be provided: {sentence_error_info}"
+                        )
+                    elif sentence_inferred_domain not in all_inferred_domains:
+                        errors.append(
+                            "Inferred domain must match slot combination definiiton: "
+                            f"actual={sentence_inferred_domain}, "
+                            f"expected={all_inferred_domains}, "
+                            f"{sentence_error_info}"
+                        )
+
                     # Track if we've covered all required domains
                     required_inferred_domains.discard(sentence_inferred_domain)
-                else:
-                    assert (
-                        not sentence_inferred_domain
-                    ), f"Slot combination definition does not specify inferred_domains: {sentence_error_info}"
+                elif sentence_inferred_domain:
+                    errors.append(
+                        "Slot combination definition does not specify inferred_domains: "
+                        f"{sentence_error_info}"
+                    )
 
-            if name_domains:
-                assert not required_name_domains, (
+            if name_domains and required_name_domains:
+                errors.append(
                     "Required name domain(s) are not covered: "
                     f"domains={required_name_domains}, {error_info}"
                 )
 
-            if inferred_domains:
-                assert not required_inferred_domains, (
+            if inferred_domains and required_inferred_domains:
+                errors.append(
                     "Required inferred domain(s) are not covered: "
                     f"domains={required_inferred_domains}, {error_info}"
                 )
@@ -1213,6 +1286,23 @@ def validate_expansion_rules(language: str, errors: list[str]) -> set[str]:
     return lang_rule_names
 
 
+def load_rule_bodies(language: str) -> dict[str, str]:
+    """Load ``{rule_name: body}`` for a language from ``rules/<lang>/*.yaml``."""
+    rule_bodies: dict[str, str] = {}
+    rules_dir: Path = RULE_DIR / language
+    if not rules_dir.is_dir():
+        return rule_bodies
+    for rule_path in sorted(rules_dir.glob("*.yaml")):
+        try:
+            rule_doc = yaml.safe_load(rule_path.read_text(encoding="utf8"))
+        except yaml.YAMLError:
+            # Malformed YAML is already reported by validate_expansion_rules.
+            continue
+        if rule_doc:
+            rule_bodies.update(rule_doc.get("expansion_rules", {}) or {})
+    return rule_bodies
+
+
 def validate_rule_references(
     language: str,
     available_list_names: set[str],
@@ -1231,17 +1321,7 @@ def validate_rule_references(
         return
 
     # name -> body, collected across all rule files for the language.
-    rule_bodies: dict[str, str] = {}
-    for rule_path in sorted(rules_dir.glob("*.yaml")):
-        try:
-            rule_doc = yaml.safe_load(rule_path.read_text(encoding="utf8"))
-        except yaml.YAMLError:
-            # Malformed YAML is already reported by validate_expansion_rules.
-            continue
-        if not rule_doc:
-            continue
-        rule_bodies.update(rule_doc.get("expansion_rules", {}) or {})
-
+    rule_bodies = load_rule_bodies(language)
     defined_rule_names = set(rule_bodies)
 
     for name in sorted(rule_bodies):
@@ -1408,22 +1488,34 @@ def allowed_list_names(list_names: set[str]):
     return validator
 
 
-def required_slots_names(slot_names: set[str]):
-    """Validator that ensures required slot names are present."""
+def required_slots_names(
+    slot_names: set[str], rule_bodies: Optional[dict[str, str]] = None
+):
+    """Validator that ensures exactly the required slot names are present.
+
+    A slot may be supplied directly (``{slot}``) or through an expansion rule
+    (``<rule>``) whose body references it. Rule bodies are expanded recursively
+    (with a cycle guard) so a slot provided via a rule is not falsely reported
+    missing, and a rule-provided slot outside the combination is caught as extra.
+    """
+    rule_bodies = rule_bodies or {}
+
+    def collect_slots(sentence: str, used: set[str], seen_rules: set[str]) -> None:
+        def visitor(e: Expression, arg: Any):
+            if isinstance(e, ListReference):
+                used.add(e.slot_name)
+            elif isinstance(e, RuleReference):
+                rule_name = e.rule_name
+                if (rule_name in rule_bodies) and (rule_name not in seen_rules):
+                    seen_rules.add(rule_name)
+                    collect_slots(str(rule_bodies[rule_name]), used, seen_rules)
+            return arg
+
+        _visit_expression(parse_sentence(sentence).expression, visitor, None)
 
     def validator(sentence: str):
-
-        def visitor(e: Expression, arg: Any):
-            used_slot_names: set[str] = arg
-
-            if isinstance(e, ListReference):
-                list_ref: ListReference = e
-                used_slot_names.add(list_ref.slot_name)
-
-            return used_slot_names
-
         used_slot_names: set[str] = set()
-        _visit_expression(parse_sentence(sentence).expression, visitor, used_slot_names)
+        collect_slots(sentence, used_slot_names, set())
 
         missing_slots = slot_names - used_slot_names
         if missing_slots:
@@ -1432,9 +1524,6 @@ def required_slots_names(slot_names: set[str]):
         extra_slots = used_slot_names - slot_names
         if extra_slots:
             raise vol.Invalid(f"Extra slots in sentence: {extra_slots}")
-
-        if sentence == "(light up|illuminate) [<the>]":
-            print(sentence, slot_names, used_slot_names)
 
         return sentence
 


### PR DESCRIPTION
Re-enables per-slot-combination validation for the languages that pass cleanly, expanding `SLOT_COMBO_VALIDATION_LANGUAGES` from `{en}` to **43 languages** — **without editing any test YAML files** (unlike the reverted #4006, which edited 128 of them).

## Validator hardening (`script/intentfest/validate.py`)
- Coverage/subset/inferred checks **append to the error list instead of asserting**, so validation reports every problem rather than aborting on the first.
- `required_slots_names` **expands `<rule>` references recursively** (cycle-guarded) before checking required slots, via a shared `load_rule_bodies()` helper — a slot supplied through a rule is no longer falsely reported missing.
- `SLOT_COMBO_TEST_SCHEMA` now **tolerates the legacy pre-migration keys** the test runner already ignores (entity `device_class`/`floor`, test-entry `intent`/`context`/`inferred_domain`). This lets the already-migrated test files validate un-edited instead of stripping the keys from 100+ files.

## Missing responses
- Add `responses/<lang>/HassNevermind.yaml` (empty `default`) for the 12 languages that had the `HassNevermind` sentence but no response file. `HassNevermind` is a no-op, so this is a straight gap-fill; it unlocks `ar`/`da`/`gl`/`he`/`pt-BR`/`zh-HK` on its own.

## How the allow-list was chosen
Derived empirically — validate every migrated language, keep those reporting "All good!". Result: 43 languages (the 37 from #4006 plus `ar da gl he pt-BR zh-HK`).

The remaining 21 migrated languages (`bg ca cs de de-CH es fi fr lt mn nl ro ru sk sl sr sr-Latn sv th vi zh-CN`) have real sentence/test issues — list refs in alternatives/optionals, `HassGetState` domain-slot mismatches, missing test files, coverage gaps — and are left for per-language PRs (listed in the code comment).

## Verification
- `python -m script.intentfest validate` → **All good!** (benign warnings only)
- `pytest tests --language en` and `--language gl` → **324 passed** each
- No files under `tests/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)