### PR TITLE
Migrate entity device_class into attributes (single canonical form)

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -584,13 +584,11 @@ def SLOT_COMBO_TEST_SCHEMA(
                     vol.Optional("area"): str,
                     vol.Optional("attributes"): {str: match_anything},
                     vol.Optional("is_exposed"): bool,
-                    # Consumed by the test runner: folded into the entity's
-                    # attributes so get_matched_states() can filter on it (the
-                    # nested attributes.device_class form works too).
-                    vol.Optional("device_class"): str,
                     # Legacy key the runner ignores (an entity's floor is derived
                     # from its area). Accepted so already-migrated test YAML need
-                    # not be edited.
+                    # not be edited. device_class is intentionally NOT accepted
+                    # here: it must be given under `attributes` (that is how Home
+                    # Assistant exposes it and how get_matched_states() reads it).
                     vol.Optional("floor"): match_anything,
                 }
             ],

--- a/tests/ar/HassGetState/name_state.yaml
+++ b/tests/ar/HassGetState/name_state.yaml
@@ -9,7 +9,8 @@ entities:
   - name: باب الجراج
     domain: cover
     state: open
-    device_class: garage
+    attributes:
+      device_class: garage
   - name: الباب الأمامي
     domain: lock
     state: locked

--- a/tests/ar/HassGetState/name_state_area.yaml
+++ b/tests/ar/HassGetState/name_state_area.yaml
@@ -9,7 +9,8 @@ entities:
   - name: الستارة اليسرى
     domain: cover
     state: open
-    device_class: curtain
+    attributes:
+      device_class: curtain
     area: غرفة المعيشة
   - name: الباب الأمامي
     domain: lock

--- a/tests/ar/HassTurnOff/name_area.yaml
+++ b/tests/ar/HassTurnOff/name_area.yaml
@@ -11,7 +11,8 @@ entities:
     area: المطبخ
   - name: الستارة اليسرى
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
     area: غرفة المعيشة
   - name: الباب الأمامي
     domain: lock

--- a/tests/ar/HassTurnOff/name_floor.yaml
+++ b/tests/ar/HassTurnOff/name_floor.yaml
@@ -9,7 +9,8 @@ entities:
     domain: light
   - name: الستارة اليسرى
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
   - name: الصمام الرئيسي
     domain: valve
 tests:

--- a/tests/ar/HassTurnOff/name_only.yaml
+++ b/tests/ar/HassTurnOff/name_only.yaml
@@ -9,7 +9,8 @@ entities:
     domain: light
   - name: الستارة اليسرى
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
   - name: الصمام الرئيسي
     domain: valve
   - name: الباب الأمامي

--- a/tests/ar/HassTurnOn/name_area.yaml
+++ b/tests/ar/HassTurnOn/name_area.yaml
@@ -11,7 +11,8 @@ entities:
     area: المطبخ
   - name: الستارة اليسرى
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
     area: غرفة المعيشة
   - name: الباب الأمامي
     domain: lock

--- a/tests/ar/HassTurnOn/name_floor.yaml
+++ b/tests/ar/HassTurnOn/name_floor.yaml
@@ -9,7 +9,8 @@ entities:
     domain: light
   - name: الستارة اليسرى
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
   - name: الصمام الرئيسي
     domain: valve
 tests:

--- a/tests/ar/HassTurnOn/name_only.yaml
+++ b/tests/ar/HassTurnOn/name_only.yaml
@@ -9,7 +9,8 @@ entities:
     domain: light
   - name: الستارة اليسرى
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
   - name: الصمام الرئيسي
     domain: valve
   - name: الباب الأمامي

--- a/tests/da/HassGetState/name_state.yaml
+++ b/tests/da/HassGetState/name_state.yaml
@@ -14,11 +14,13 @@ entities:
     state: locked
   - name: Terrassedør
     domain: binary_sensor
-    device_class: door
+    attributes:
+      device_class: door
     state: "on"
   - name: Kontorsensor
     domain: binary_sensor
-    device_class: occupancy
+    attributes:
+      device_class: occupancy
     state: "on"
 tests:
   - sentences:

--- a/tests/da/HassGetState/name_state_area.yaml
+++ b/tests/da/HassGetState/name_state_area.yaml
@@ -18,12 +18,14 @@ entities:
     area: Entré
   - name: Ovenlysvindue
     domain: binary_sensor
-    device_class: window
+    attributes:
+      device_class: window
     state: "on"
     area: Soveværelse
   - name: Bevægelsessensor
     domain: binary_sensor
-    device_class: occupancy
+    attributes:
+      device_class: occupancy
     state: "on"
     area: Kontor
 tests:

--- a/tests/da/HassGetState/name_state_floor.yaml
+++ b/tests/da/HassGetState/name_state_floor.yaml
@@ -15,12 +15,14 @@ entities:
     floor: Første sal
   - name: Ovenlysvindue
     domain: binary_sensor
-    device_class: window
+    attributes:
+      device_class: window
     state: "on"
     floor: Første sal
   - name: Bevægelsessensor
     domain: binary_sensor
-    device_class: occupancy
+    attributes:
+      device_class: occupancy
     state: "on"
     floor: Første sal
 tests:

--- a/tests/da/HassSetPosition/name_only.yaml
+++ b/tests/da/HassSetPosition/name_only.yaml
@@ -5,7 +5,8 @@ language: da
 entities:
   - name: Badeværelsespersienne
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
   - name: Hovedhane
     domain: valve
 tests:

--- a/tests/fi/HassTurnOff/area_device_class_cover.yaml
+++ b/tests/fi/HassTurnOff/area_device_class_cover.yaml
@@ -7,11 +7,13 @@ areas:
 entities:
   - name: "Olohuoneen verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "Olohuone"
   - name: "Yläkerran verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "Yläkerta"
 
 tests:

--- a/tests/fi/HassTurnOff/device_class_cover.yaml
+++ b/tests/fi/HassTurnOff/device_class_cover.yaml
@@ -3,7 +3,8 @@ language: "fi"
 entities:
   - name: "Olohuoneen verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
 
 tests:
   - sentences:

--- a/tests/fi/HassTurnOff/floor_device_class_cover.yaml
+++ b/tests/fi/HassTurnOff/floor_device_class_cover.yaml
@@ -10,7 +10,8 @@ areas:
 entities:
   - name: "Olohuoneen verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "Olohuone"
 
 tests:

--- a/tests/fi/HassTurnOn/area_device_class_cover.yaml
+++ b/tests/fi/HassTurnOn/area_device_class_cover.yaml
@@ -7,11 +7,13 @@ areas:
 entities:
   - name: "Olohuoneen verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "Olohuone"
   - name: "Yläkerran verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "Yläkerta"
 
 tests:

--- a/tests/fi/HassTurnOn/device_class_cover.yaml
+++ b/tests/fi/HassTurnOn/device_class_cover.yaml
@@ -3,7 +3,8 @@ language: "fi"
 entities:
   - name: "Olohuoneen verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
 
 tests:
   - sentences:

--- a/tests/fi/HassTurnOn/floor_device_class_cover.yaml
+++ b/tests/fi/HassTurnOn/floor_device_class_cover.yaml
@@ -10,7 +10,8 @@ areas:
 entities:
   - name: "Olohuoneen verho"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "Olohuone"
 
 tests:

--- a/tests/he/HassTurnOff/area_device_class_cover.yaml
+++ b/tests/he/HassTurnOff/area_device_class_cover.yaml
@@ -8,7 +8,8 @@ areas:
 entities:
   - name: "וילון סלון"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "סלון"
 
 tests:

--- a/tests/he/HassTurnOn/area_device_class_cover.yaml
+++ b/tests/he/HassTurnOn/area_device_class_cover.yaml
@@ -8,7 +8,8 @@ areas:
 entities:
   - name: "וילון סלון"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "סלון"
 
 tests:

--- a/tests/hr/HassTurnOff/area_device_class_cover.yaml
+++ b/tests/hr/HassTurnOff/area_device_class_cover.yaml
@@ -6,7 +6,8 @@ language: "hr"
 entities:
   - name: "zavjesa"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "dnevna soba"
 
 areas:

--- a/tests/hr/HassTurnOff/device_class_cover.yaml
+++ b/tests/hr/HassTurnOff/device_class_cover.yaml
@@ -6,7 +6,8 @@ language: "hr"
 entities:
   - name: "zavjesa"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "kuhinja"
 
 areas:

--- a/tests/hr/HassTurnOn/area_device_class_cover.yaml
+++ b/tests/hr/HassTurnOn/area_device_class_cover.yaml
@@ -6,7 +6,8 @@ language: "hr"
 entities:
   - name: "zavjesa"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "dnevna soba"
 
 areas:

--- a/tests/hr/HassTurnOn/device_class_cover.yaml
+++ b/tests/hr/HassTurnOn/device_class_cover.yaml
@@ -6,7 +6,8 @@ language: "hr"
 entities:
   - name: "zavjesa"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "kuhinja"
 
 areas:

--- a/tests/hu/HassSetPosition/name_area.yaml
+++ b/tests/hu/HassSetPosition/name_area.yaml
@@ -3,7 +3,8 @@ language: hu
 entities:
   - name: középső függöny
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
 areas:
   - name: nappali
 tests:

--- a/tests/hu/HassSetPosition/name_only.yaml
+++ b/tests/hu/HassSetPosition/name_only.yaml
@@ -3,7 +3,8 @@ language: hu
 entities:
   - name: háló függöny
     domain: cover
-    device_class: curtain
+    attributes:
+      device_class: curtain
   - name: radiátor szelep
     domain: valve
 tests:

--- a/tests/it/HassSetPosition/device_class.yaml
+++ b/tests/it/HassSetPosition/device_class.yaml
@@ -8,7 +8,8 @@ areas:
 entities:
   - name: Tapparella Camera
     domain: cover
-    device_class: shutter
+    attributes:
+      device_class: shutter
     state: closed
     area: Camera da Letto
 tests:

--- a/tests/ko/HassGetState/name_state.yaml
+++ b/tests/ko/HassGetState/name_state.yaml
@@ -15,31 +15,38 @@ entities:
   # binary sensors (one per predicate group)
   - name: "휴대폰"
     domain: "binary_sensor"
-    device_class: "battery_charging"
+    attributes:
+      device_class: "battery_charging"
     state: "on"
   - name: "주방 모션 센서"
     domain: "binary_sensor"
-    device_class: "motion"
+    attributes:
+      device_class: "motion"
     state: "on"
   - name: "수도관"
     domain: "binary_sensor"
-    device_class: "cold"
+    attributes:
+      device_class: "cold"
     state: "on"
   - name: "창고 창문"
     domain: "binary_sensor"
-    device_class: "window"
+    attributes:
+      device_class: "window"
     state: "on"
   - name: "표시등"
     domain: "binary_sensor"
-    device_class: "light"
+    attributes:
+      device_class: "light"
     state: "on"
   - name: "길"
     domain: "binary_sensor"
-    device_class: "safety"
+    attributes:
+      device_class: "safety"
     state: "on"
   - name: "노트북"
     domain: "binary_sensor"
-    device_class: "update"
+    attributes:
+      device_class: "update"
     state: "on"
 
 tests:

--- a/tests/ko/HassTurnOff/area_device_class_cover.yaml
+++ b/tests/ko/HassTurnOff/area_device_class_cover.yaml
@@ -9,11 +9,13 @@ areas:
 entities:
   - name: "주방 가리개"
     domain: "cover"
-    device_class: "window"
+    attributes:
+      device_class: "window"
     area: "주방"
   - name: "침실 차양"
     domain: "cover"
-    device_class: "blind"
+    attributes:
+      device_class: "blind"
     area: "침실"
 
 tests:

--- a/tests/ko/HassTurnOff/device_class_cover.yaml
+++ b/tests/ko/HassTurnOff/device_class_cover.yaml
@@ -5,10 +5,12 @@ language: "ko"
 entities:
   - name: "차고 셔터"
     domain: "cover"
-    device_class: "garage"
+    attributes:
+      device_class: "garage"
   - name: "거실 가리개"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
 
 tests:
   - sentences:

--- a/tests/ko/HassTurnOn/area_device_class_cover.yaml
+++ b/tests/ko/HassTurnOn/area_device_class_cover.yaml
@@ -9,11 +9,13 @@ areas:
 entities:
   - name: "주방 가리개"
     domain: "cover"
-    device_class: "window"
+    attributes:
+      device_class: "window"
     area: "주방"
   - name: "침실 차양"
     domain: "cover"
-    device_class: "blind"
+    attributes:
+      device_class: "blind"
     area: "침실"
 
 tests:

--- a/tests/ko/HassTurnOn/device_class_cover.yaml
+++ b/tests/ko/HassTurnOn/device_class_cover.yaml
@@ -5,10 +5,12 @@ language: "ko"
 entities:
   - name: "차고 셔터"
     domain: "cover"
-    device_class: "garage"
+    attributes:
+      device_class: "garage"
   - name: "거실 가리개"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
 
 tests:
   - sentences:

--- a/tests/pa/HassTurnOff/area_device_class_cover.yaml
+++ b/tests/pa/HassTurnOff/area_device_class_cover.yaml
@@ -6,7 +6,8 @@ areas:
 entities:
   - name: "ਪਰਦਾ ੧"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "ਲਿਵਿੰਗ ਰੂਮ"
 tests:
   - sentences:

--- a/tests/pa/HassTurnOff/device_class_cover.yaml
+++ b/tests/pa/HassTurnOff/device_class_cover.yaml
@@ -4,7 +4,8 @@ language: "pa"
 entities:
   - name: "ਪਰਦਾ ੧"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
 tests:
   - sentences:
       - "ਇੱਥੇ ਪਰਦੇ ਬੰਦ ਕਰੋ"

--- a/tests/pa/HassTurnOff/floor_device_class_cover.yaml
+++ b/tests/pa/HassTurnOff/floor_device_class_cover.yaml
@@ -6,7 +6,8 @@ floors:
 entities:
   - name: "ਪਰਦਾ ੧"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     floor: "ਪਹਿਲੀ"
 tests:
   - sentences:

--- a/tests/pa/HassTurnOn/area_device_class_cover.yaml
+++ b/tests/pa/HassTurnOn/area_device_class_cover.yaml
@@ -6,7 +6,8 @@ areas:
 entities:
   - name: "ਪਰਦਾ ੧"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     area: "ਲਿਵਿੰਗ ਰੂਮ"
 
 tests:

--- a/tests/pa/HassTurnOn/device_class_cover.yaml
+++ b/tests/pa/HassTurnOn/device_class_cover.yaml
@@ -4,7 +4,8 @@ language: "pa"
 entities:
   - name: "ਪਰਦਾ ੧"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
 
 tests:
   - sentences:

--- a/tests/pa/HassTurnOn/floor_device_class_cover.yaml
+++ b/tests/pa/HassTurnOn/floor_device_class_cover.yaml
@@ -6,7 +6,8 @@ floors:
 entities:
   - name: "ਪਰਦਾ ੧"
     domain: "cover"
-    device_class: "curtain"
+    attributes:
+      device_class: "curtain"
     floor: "ਪਹਿਲੀ"
 
 tests:

--- a/tests/pt-BR/HassSetPosition/area_device_class.yaml
+++ b/tests/pt-BR/HassSetPosition/area_device_class.yaml
@@ -4,7 +4,8 @@ areas:
 entities:
   - name: Persiana
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
     area: Cozinha
 tests:
   - sentences:

--- a/tests/pt-BR/HassSetPosition/device_class.yaml
+++ b/tests/pt-BR/HassSetPosition/device_class.yaml
@@ -2,7 +2,8 @@ language: pt-BR
 entities:
   - name: Persiana
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
 tests:
   - sentences:
       - abra as persianas a 50%

--- a/tests/pt-BR/HassSetPosition/floor_device_class.yaml
+++ b/tests/pt-BR/HassSetPosition/floor_device_class.yaml
@@ -7,7 +7,8 @@ areas:
 entities:
   - name: Persiana
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
     area: Cozinha
 tests:
   - sentences:

--- a/tests/sk/HassGetState/name_state.yaml
+++ b/tests/sk/HassGetState/name_state.yaml
@@ -11,7 +11,8 @@ entities:
     state: "locked"
   - name: "Okno"
     domain: binary_sensor
-    device_class: opening
+    attributes:
+      device_class: opening
     state: "on"
 tests:
   - sentences:

--- a/tests/sk/HassGetState/name_state_area.yaml
+++ b/tests/sk/HassGetState/name_state_area.yaml
@@ -12,7 +12,8 @@ entities:
     area: "garáž(i|a|e)"
   - name: "Okno"
     domain: binary_sensor
-    device_class: opening
+    attributes:
+      device_class: opening
     state: "on"
     area: "garáž(i|a|e)"
 tests:

--- a/tests/sk/HassGetState/name_state_floor.yaml
+++ b/tests/sk/HassGetState/name_state_floor.yaml
@@ -10,7 +10,8 @@ entities:
     state: "locked"
   - name: "Okno"
     domain: binary_sensor
-    device_class: opening
+    attributes:
+      device_class: opening
     state: "on"
 tests:
   - sentences:

--- a/tests/sk/HassSetPosition/area_device_class.yaml
+++ b/tests/sk/HassSetPosition/area_device_class.yaml
@@ -4,7 +4,8 @@ areas:
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
     area: "spáln(i|e|a|u)"
 tests:
   - sentences:

--- a/tests/sk/HassSetPosition/device_class.yaml
+++ b/tests/sk/HassSetPosition/device_class.yaml
@@ -2,7 +2,8 @@ language: sk
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
 tests:
   - sentences:
       - "nastav tu pozíciu rolety na 40%"

--- a/tests/sk/HassTurnOff/area_device_class_cover.yaml
+++ b/tests/sk/HassTurnOff/area_device_class_cover.yaml
@@ -4,7 +4,8 @@ areas:
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
     area: "kuchyn(i|a|e)"
 tests:
   - sentences:

--- a/tests/sk/HassTurnOff/device_class_cover.yaml
+++ b/tests/sk/HassTurnOff/device_class_cover.yaml
@@ -4,7 +4,8 @@ areas:
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
 tests:
   - sentences:
       - "zatvor rolety"

--- a/tests/sk/HassTurnOff/floor_device_class_cover.yaml
+++ b/tests/sk/HassTurnOff/floor_device_class_cover.yaml
@@ -4,7 +4,8 @@ floors:
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
 tests:
   - sentences:
       - "zatvor rolety na prvom poschodí"

--- a/tests/sk/HassTurnOn/area_device_class_cover.yaml
+++ b/tests/sk/HassTurnOn/area_device_class_cover.yaml
@@ -4,7 +4,8 @@ areas:
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
     area: "kuchyn(i|a|e)"
 tests:
   - sentences:

--- a/tests/sk/HassTurnOn/device_class_cover.yaml
+++ b/tests/sk/HassTurnOn/device_class_cover.yaml
@@ -4,7 +4,8 @@ areas:
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
 tests:
   - sentences:
       - "otvor rolety"

--- a/tests/sk/HassTurnOn/floor_device_class_cover.yaml
+++ b/tests/sk/HassTurnOn/floor_device_class_cover.yaml
@@ -4,7 +4,8 @@ floors:
 entities:
   - name: "Roleta"
     domain: cover
-    device_class: blind
+    attributes:
+      device_class: blind
 tests:
   - sentences:
       - "otvor rolety na prvom poschodí"

--- a/tests/test_slot_combinations.py
+++ b/tests/test_slot_combinations.py
@@ -72,14 +72,8 @@ def _build_fixtures(test_dict: dict[str, Any]) -> dict[str, Any]:
             entity["state"] = e["state_with_unit"]
         if e.get("area"):
             entity["area"] = _slug(e["area"])
-        attributes = dict(e.get("attributes") or {})
-        if e.get("device_class"):
-            # device_class may be given as a top-level entity key (mirroring how
-            # Home Assistant exposes it) or nested under attributes. Fold the
-            # top-level form in so get_matched_states() can filter on it.
-            attributes.setdefault("device_class", e["device_class"])
-        if attributes:
-            entity["attributes"] = attributes
+        if e.get("attributes"):
+            entity["attributes"] = e["attributes"]
         if "is_exposed" in e:
             entity["is_exposed"] = e["is_exposed"]
         entities.append(entity)

--- a/tests/uk/HassTurnOff/area_device_class_cover.yaml
+++ b/tests/uk/HassTurnOff/area_device_class_cover.yaml
@@ -2,7 +2,8 @@ language: uk
 entities:
   - name: Вікно вітальні
     domain: cover
-    device_class: window
+    attributes:
+      device_class: window
 areas:
   - name: Кухня
 tests:

--- a/tests/uk/HassTurnOff/device_class_cover.yaml
+++ b/tests/uk/HassTurnOff/device_class_cover.yaml
@@ -2,10 +2,12 @@ language: uk
 entities:
   - name: Гаражні ворота
     domain: cover
-    device_class: garage
+    attributes:
+      device_class: garage
   - name: Вікно вітальні
     domain: cover
-    device_class: window
+    attributes:
+      device_class: window
 tests:
   - sentences:
       - закрий двері у гаражі

--- a/tests/uk/HassTurnOn/area_device_class_cover.yaml
+++ b/tests/uk/HassTurnOn/area_device_class_cover.yaml
@@ -2,7 +2,8 @@ language: uk
 entities:
   - name: Вікно вітальні
     domain: cover
-    device_class: window
+    attributes:
+      device_class: window
 areas:
   - name: Кухня
 tests:

--- a/tests/uk/HassTurnOn/device_class_cover.yaml
+++ b/tests/uk/HassTurnOn/device_class_cover.yaml
@@ -2,10 +2,12 @@ language: uk
 entities:
   - name: Гаражні ворота
     domain: cover
-    device_class: garage
+    attributes:
+      device_class: garage
   - name: Вікно вітальні
     domain: cover
-    device_class: window
+    attributes:
+      device_class: window
 tests:
   - sentences:
       - відкрий двері у гаражі


### PR DESCRIPTION
`device_class` is a Home Assistant **state attribute** — `get_matched_states()` reads it from `state.attributes["device_class"]` ([shared/__init__.py:214](../blob/main/shared/__init__.py#L214)). The slot-combination test fixtures had drifted into **two forms**:

- nested `attributes.device_class` — 393 entities (the standard), and
- a top-level `device_class:` entity key — 73 entities.

The top-level form was a footgun: `_build_fixtures` dropped it, so it only appeared to work in combos that render `slots.device_class` directly (`*device_class_cover`, SetPosition) or match by entity name (`name_*`). In a `device_class_state` test it would have **silently failed to filter** and passed anyway.

## Changes
- **Move all 73 top-level occurrences into `attributes.device_class`** (56 test files). Mechanical and conflict-free — no entity had both forms or competing attributes; each file was checked to confirm the parsed `device_class` is unchanged. 0 residual top-level entities.
- **Remove the top-level folding shim** from `_build_fixtures` (it was added as a safe intermediate in the preceding commit and is now dead code).
- **Drop `device_class` from the entity test schema**, so a top-level `device_class:` is now *rejected* — leaving one canonical, HA-faithful representation.

## Verification
- Full suite: **20420 passed**
- `python -m script.intentfest validate`: **All good!**
- prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)