### PR TITLE
Tag English sentences for Speech-to-Phrase with a subset check

### DIFF
--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -182,6 +182,38 @@ def resolve_domain_context(
     return slots, requires_context
 
 
+def partition_speech_to_phrase(
+    data_blocks: list,
+) -> Tuple[list, list]:
+    """Split a slot-combination's ``data`` blocks by Speech-to-Phrase role.
+
+    Returns ``(ha_blocks, s2p_only_blocks)``:
+
+    * ``ha_blocks`` are the blocks the Home Assistant grammar uses.
+    * ``s2p_only_blocks`` are ``speech_to_phrase``-tagged blocks that are dropped
+      from the Home Assistant grammar because a richer untagged block already
+      covers their language (verified by the subset check).
+
+    The rule is intentionally simple ("a tagged block is Speech-to-Phrase-only
+    iff the combo also has an untagged block"):
+
+    * If a combo has any untagged block, its tagged blocks are the lean
+      Speech-to-Phrase subset -> ``s2p_only_blocks``; the untagged blocks are
+      ``ha_blocks``.
+    * If every block is tagged (a combo whose only phrasing is already lean
+      enough to serve both), there is nothing to strip -> all blocks are
+      ``ha_blocks`` and Speech-to-Phrase uses them directly.
+
+    Speech-to-Phrase itself always consumes the tagged blocks; that selection is
+    the caller's concern and independent of this HA-side split.
+    """
+    untagged = [b for b in data_blocks if not b.get("speech_to_phrase")]
+    tagged = [b for b in data_blocks if b.get("speech_to_phrase")]
+    if untagged:
+        return untagged, tagged
+    return tagged, []
+
+
 def _slug(name: str) -> str:
     """Synthesize an id from a human name (mirrors the test harness)."""
     return name.strip().casefold().replace(" ", "_")

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -310,6 +310,13 @@ def SLOT_COMBO_SENTENCE_SCHEMA(
         ],
         vol.Required("response"): vol.In(response_names),
         vol.Optional("example"): non_empty_string,
+        # Marks a data block for inclusion in the Speech-to-Phrase constrained
+        # STT grammar. When a combo has both tagged and untagged blocks, the
+        # tagged (lean) block is a Speech-to-Phrase-only subset of the untagged
+        # (rich) block(s) and is stripped from the Home Assistant grammar; when
+        # the only block(s) are tagged, they serve both. See the subset check in
+        # tests/test_speech_to_phrase.py.
+        vol.Optional("speech_to_phrase"): bool,
     }
 
     if name_domains:

--- a/sentences/en/HassCancelTimer/default.yaml
+++ b/sentences/en/HassCancelTimer/default.yaml
@@ -7,3 +7,4 @@ data:
       - "<timer_cancel> [the|my] timer"
     example: "cancel timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/en/HassClimateGetTemperature/area_only.yaml
@@ -11,3 +11,8 @@ data:
       - "how (hot|cold|warm|cool) is [it <in>] [<the>] {area}"
     example: "what is the temperature in the living room"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "what is [the] temperature in [the] {area}"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassClimateGetTemperature/default.yaml
+++ b/sentences/en/HassClimateGetTemperature/default.yaml
@@ -10,3 +10,10 @@ data:
       - "how (hot|cold|warm|cool) is it [<here>]"
     example: "what is the temperature"
     response: "default"
+
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "what is [the] <temp>"
+      - "how (hot|cold|warm|cool) is it"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/en/HassClimateGetTemperature/name_only.yaml
@@ -13,3 +13,10 @@ data:
     name_domains:
       - "climate"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "what is [the] temperature of [the] {name}"
+    name_domains:
+      - "climate"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/en/HassDecreaseTimer/hours_only.yaml
@@ -8,3 +8,4 @@ data:
       - "decrease [the|my] timer by {timer_hours:hours}( |-)hour[s]"
     example: "remove 1 hour from timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/en/HassDecreaseTimer/minutes_only.yaml
@@ -10,3 +10,4 @@ data:
       - "decrease [the|my] timer by {timer_half:minutes} an hour[s]"
     example: "remove 5 minutes from timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/en/HassDecreaseTimer/seconds_only.yaml
@@ -10,3 +10,4 @@ data:
       - "decrease [the|my] timer by {timer_half:seconds} a minute[s]"
     example: "remove 30 seconds from timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassFanSetSpeed/default.yaml
+++ b/sentences/en/HassFanSetSpeed/default.yaml
@@ -11,3 +11,8 @@ data:
       - "[<set>] [the] speed [of [the]] fan[s] [<here>] [to] {fan_speed:percentage}[%| percent]"
     example: "set fans to 50%"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set fan[s] [speed] to {fan_speed:percentage}[ percent]"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassFanSetSpeed/name_only.yaml
+++ b/sentences/en/HassFanSetSpeed/name_only.yaml
@@ -14,3 +14,10 @@ data:
     name_domains:
       - "fan"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set [the] {name} [speed] to {fan_speed:percentage}[ percent]"
+    name_domains:
+      - "fan"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassGetCurrentDate/default.yaml
+++ b/sentences/en/HassGetCurrentDate/default.yaml
@@ -9,3 +9,4 @@ data:
       - "<what_is> the date [today]"
     example: "what is the date"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassGetCurrentTime/default.yaml
+++ b/sentences/en/HassGetCurrentTime/default.yaml
@@ -9,3 +9,4 @@ data:
       - "what time is it [[right] now]"
     example: "what time is it"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassGetState/name_only.yaml
+++ b/sentences/en/HassGetState/name_only.yaml
@@ -20,3 +20,12 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "what is [the] {name}"
+      - "what is the value of [the] {name}"
+      - "tell me [the] {name}"
+    name_domains:
+      - "sensor"
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/en/HassGetState/name_state.yaml
+++ b/sentences/en/HassGetState/name_state.yaml
@@ -49,3 +49,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "is [the] {name} {on_off_states:state}"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+
+  - sentences:
+      - "is [the] {name} {cover_states:state}"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+
+  - sentences:
+      - "is [the] {name} {lock_states:state}"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/en/HassGetWeather/default.yaml
+++ b/sentences/en/HassGetWeather/default.yaml
@@ -8,3 +8,4 @@ data:
       - "<what_is> [the] weather [like]"
     example: "what is the weather like"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/en/HassIncreaseTimer/hours_only.yaml
@@ -8,3 +8,4 @@ data:
       - "increase [the|my] timer by {timer_hours:hours}( |-)hour[s]"
     example: "add 1 hour to timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/en/HassIncreaseTimer/minutes_only.yaml
@@ -10,3 +10,4 @@ data:
       - "increase [the|my] timer by {timer_half:minutes} an hour[s]"
     example: "add 5 minutes to timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/en/HassIncreaseTimer/seconds_only.yaml
@@ -10,3 +10,4 @@ data:
       - "increase [the|my] timer by {timer_half:seconds} a minute[s]"
     example: "add 30 seconds to timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassLightSet/area_brightness.yaml
+++ b/sentences/en/HassLightSet/area_brightness.yaml
@@ -21,3 +21,10 @@ data:
     example: "set the bedroom brightness to 50%"
     inferred_domain: "light"
     response: "brightness"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set [the] {area} brightness to {brightness}[ percent]"
+      - "set [the] brightness in [the] {area} to {brightness}[ percent]"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/en/HassLightSet/brightness_only.yaml
+++ b/sentences/en/HassLightSet/brightness_only.yaml
@@ -14,3 +14,10 @@ data:
     example: "set the brightness to 50%"
     inferred_domain: "light"
     response: "brightness"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set [the] brightness to {brightness}[ percent]"
+      - "set [the] brightness to {brightness}%"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/en/HassLightSet/floor_brightness.yaml
+++ b/sentences/en/HassLightSet/floor_brightness.yaml
@@ -12,3 +12,9 @@ data:
     example: "set the first floor brightness to 50%"
     inferred_domain: "light"
     response: "brightness"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set [the] {floor} brightness to {brightness}[ percent]"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/en/HassLightSet/name_brightness.yaml
+++ b/sentences/en/HassLightSet/name_brightness.yaml
@@ -18,3 +18,10 @@ data:
     name_domains:
       - "light"
     response: "brightness"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "(set|change) [the] {name} brightness to {brightness}[ percent]"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/en/HassMediaNext/default.yaml
+++ b/sentences/en/HassMediaNext/default.yaml
@@ -10,3 +10,4 @@ data:
       - "(skip [(to [the] next [(song|track)]|([the] (song|track)|this [(song|track)]))])"
     example: "next track"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassMediaPause/default.yaml
+++ b/sentences/en/HassMediaPause/default.yaml
@@ -10,3 +10,4 @@ data:
       - "stop [playing]"
     example: "pause"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassMediaPlayerMute/default.yaml
+++ b/sentences/en/HassMediaPlayerMute/default.yaml
@@ -10,3 +10,8 @@ data:
       - "mute ([the] (music|media [player[s]])) [<here>]"
     example: "mute"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "mute"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/en/HassMediaPlayerUnmute/default.yaml
@@ -10,3 +10,8 @@ data:
       - "unmute ([the] (music|media [player[s]])) [<here>]"
     example: "unmute"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "unmute"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassMediaPrevious/default.yaml
+++ b/sentences/en/HassMediaPrevious/default.yaml
@@ -12,3 +12,4 @@ data:
       - "play [the] (previous|last) [(song|track)] [again]"
     example: "previous track"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassMediaUnpause/default.yaml
+++ b/sentences/en/HassMediaUnpause/default.yaml
@@ -9,3 +9,4 @@ data:
       - "(unpause|resume)"
     example: "resume"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassNevermind/default.yaml
+++ b/sentences/en/HassNevermind/default.yaml
@@ -9,3 +9,4 @@ data:
       - "never mind"
     example: "nevermind"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassPauseTimer/default.yaml
+++ b/sentences/en/HassPauseTimer/default.yaml
@@ -7,3 +7,4 @@ data:
       - "pause [the|my] timer"
     example: "pause timer"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassSetPosition/name_only.yaml
+++ b/sentences/en/HassSetPosition/name_only.yaml
@@ -14,3 +14,13 @@ data:
       - "cover"
       - "valve"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set [the] {name} [position] to {position}[ percent]"
+      - "open [the] {name} to {position}[ percent]"
+      - "close [the] {name} to {position}[ percent]"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassSetVolume/default.yaml
+++ b/sentences/en/HassSetVolume/default.yaml
@@ -13,3 +13,4 @@ data:
       - "turn (the volume;(up|down)) to {volume:volume_level}[([ ]%)| percent]"
     example: "set volume to 90 percent"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassSetVolumeRelative/default.yaml
+++ b/sentences/en/HassSetVolumeRelative/default.yaml
@@ -21,3 +21,4 @@ data:
       - "decrease [the] volume [by] {volume_step_down:volume_step}[%| percent]"
     example: "increase volume"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassStartTimer/hours_only.yaml
+++ b/sentences/en/HassStartTimer/hours_only.yaml
@@ -11,3 +11,9 @@ data:
       - "timer for {timer_hours:hours}( |-)hour[s]"
     example: "timer for 1 hour"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set a timer for {timer_hours:hours} hour[s]"
+      - "timer for {timer_hours:hours} hour[s]"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassStartTimer/minutes_only.yaml
+++ b/sentences/en/HassStartTimer/minutes_only.yaml
@@ -13,3 +13,11 @@ data:
       - "timer for {timer_half:minutes} an hour[s]"
     example: "timer for 5 minutes"
     response: "default"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "set a timer for {timer_minutes:minutes} minute[s]"
+      - "timer for {timer_minutes:minutes} minute[s]"
+      - "set a timer for {timer_half:minutes} an hour"
+      - "timer for {timer_half:minutes} an hour"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassStartTimer/seconds_only.yaml
+++ b/sentences/en/HassStartTimer/seconds_only.yaml
@@ -13,3 +13,9 @@ data:
       - "timer for {timer_half:seconds} a minute[s]"
     example: "timer for 30 seconds"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "set a timer for {timer_seconds:seconds} second[s]"
+      - "timer for {timer_seconds:seconds} second[s]"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassTimerStatus/default.yaml
+++ b/sentences/en/HassTimerStatus/default.yaml
@@ -11,3 +11,4 @@ data:
       - "status of [the|my] timer[s]"
     example: "timer status"
     response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOff/area_domain.yaml
+++ b/sentences/en/HassTurnOff/area_domain.yaml
@@ -34,3 +34,18 @@ data:
     example: "turn off the fans in the kitchen"
     inferred_domain: "fan"
     response: "fans_area"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "turn off [the] lights in [the] {area}"
+      - "turn off [the] {area} lights"
+      - "[the] {area} lights off"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+
+  - sentences:
+      - "turn off [the] fans in [the] {area}"
+      - "turn off [the] {area} fans"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOff/domain_only.yaml
+++ b/sentences/en/HassTurnOff/domain_only.yaml
@@ -31,3 +31,11 @@ data:
     example: "turn off the fans"
     inferred_domain: "fan"
     response: "fans_area"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "turn off [the] lights"
+      - "turn [the] lights off"
+      - "lights off"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOff/floor_domain.yaml
+++ b/sentences/en/HassTurnOff/floor_domain.yaml
@@ -22,3 +22,10 @@ data:
     example: "turn off the lights on the first floor"
     inferred_domain: "light"
     response: "lights_floor"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "turn off [the] lights on [the] {floor}"
+      - "turn off [the] {floor} lights"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOff/name_only.yaml
+++ b/sentences/en/HassTurnOff/name_only.yaml
@@ -48,3 +48,31 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "turn off [the] {name}"
+      - "switch off [the] {name}"
+      - "deactivate [the] {name}"
+      - "[the] {name} off"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+
+  - sentences:
+      - "close [the] {name}"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+
+  - sentences:
+      - "unlock [the] {name}"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOn/area_domain.yaml
+++ b/sentences/en/HassTurnOn/area_domain.yaml
@@ -32,3 +32,18 @@ data:
     example: "turn on the fans in the kitchen"
     inferred_domain: "fan"
     response: "fans_area"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "turn on [the] lights in [the] {area}"
+      - "turn on [the] {area} lights"
+      - "[the] {area} lights on"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+
+  - sentences:
+      - "turn on [the] fans in [the] {area}"
+      - "turn on [the] {area} fans"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOn/domain_only.yaml
+++ b/sentences/en/HassTurnOn/domain_only.yaml
@@ -33,3 +33,11 @@ data:
     example: "turn on the fans"
     inferred_domain: "fan"
     response: "fans_area"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "turn on [the] lights"
+      - "turn [the] lights on"
+      - "lights on"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOn/floor_domain.yaml
+++ b/sentences/en/HassTurnOn/floor_domain.yaml
@@ -22,3 +22,10 @@ data:
     example: "turn on the lights on the first floor"
     inferred_domain: "light"
     response: "lights_floor"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "turn on [the] lights on [the] {floor}"
+      - "turn on [the] {floor} lights"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOn/name_area.yaml
+++ b/sentences/en/HassTurnOn/name_area.yaml
@@ -57,3 +57,15 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "turn on [the] {name} in [the] {area}"
+      - "switch on [the] {name} in [the] {area}"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/en/HassTurnOn/name_only.yaml
+++ b/sentences/en/HassTurnOn/name_only.yaml
@@ -49,3 +49,32 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+
+  # Speech-to-Phrase: lean subset of the blocks above.
+  - sentences:
+      - "turn on [the] {name}"
+      - "switch on [the] {name}"
+      - "activate [the] {name}"
+      - "[the] {name} on"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+
+  - sentences:
+      - "open [the] {name}"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+
+  - sentences:
+      - "lock [the] {name}"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/en/HassUnpauseTimer/default.yaml
+++ b/sentences/en/HassUnpauseTimer/default.yaml
@@ -7,3 +7,4 @@ data:
       - "(resume|continue) [the|my] timer"
     example: "resume timer"
     response: "default"
+    speech_to_phrase: true

--- a/tests/test_slot_combinations.py
+++ b/tests/test_slot_combinations.py
@@ -38,6 +38,7 @@ from . import (
 # (the package has no ``script/__init__.py``), tripping "source file found twice".
 _util: Any = importlib.import_module("script.intentfest.util")
 resolve_domain_context = _util.resolve_domain_context
+partition_speech_to_phrase = _util.partition_speech_to_phrase
 
 
 def _slug(name: str) -> str:
@@ -195,16 +196,22 @@ def lang_resources_fixture(language: str, intent_schemas: dict[str, Any]):
             with open(sentences_path, "r", encoding="utf-8") as sentences_file:
                 test_data_dict = yaml.safe_load(sentences_file)
 
+                # Speech-to-Phrase-only blocks are a lean subset of their richer
+                # untagged siblings, so Home Assistant's grammar drops them (the
+                # subset is proven in tests/test_speech_to_phrase.py). Everything
+                # below sees only the blocks HA actually ships.
+                ha_blocks, _s2p_only = partition_speech_to_phrase(
+                    test_data_dict["data"]
+                )
+
                 # All sentence templates for this slot combination, across every
                 # group, so coverage is checked for the whole file (not just the
                 # first group a test sentence happens to match).
                 combo_templates = [
-                    sentence
-                    for group in test_data_dict["data"]
-                    for sentence in group["sentences"]
+                    sentence for group in ha_blocks for sentence in group["sentences"]
                 ]
 
-                for test_sentences_dict in test_data_dict["data"]:
+                for test_sentences_dict in ha_blocks:
                     test_slots, test_requires_context = resolve_domain_context(
                         test_sentences_dict, combo_info
                     )

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,0 +1,119 @@
+"""Speech-to-Phrase subset verification (Method B).
+
+A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
+the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
+also has untagged (rich) blocks, Home Assistant drops the tagged block from its
+grammar (see ``partition_speech_to_phrase`` and the loader in
+``test_slot_combinations.py``). That is only sound if the lean block's language
+is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
+recognise a phrasing HA never would.
+
+We verify containment by enumeration rather than with an FST/OpenFST toolchain:
+lean blocks are finite and small by construction, so we expand every phrasing on
+both sides (slots rendered as literal ``{list}`` sentinels via
+``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
+complete for the lean side (no recursion, bounded fan-out) and needs no slot
+lists, entities, or intent context.
+
+Only English is wired up for now; the collector is language-agnostic.
+"""
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from hassil import Intents, normalize_whitespace
+from hassil.sample import sample_sentence
+
+from . import RULES_DIR, SENTENCES_DIR
+
+_util: Any = importlib.import_module("script.intentfest.util")
+partition_speech_to_phrase = _util.partition_speech_to_phrase
+
+LANGUAGES = ["en"]
+
+
+def _load_expansion_rules(language: str) -> dict[str, str]:
+    rules: dict[str, str] = {}
+    rules_dir = RULES_DIR / language
+    if rules_dir.is_dir():
+        for rule_path in rules_dir.glob("*.yaml"):
+            rule_dict = yaml.safe_load(rule_path.read_text()) or {}
+            rules.update(rule_dict.get("expansion_rules", {}))
+    return rules
+
+
+def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
+    """Every phrasing a set of templates can produce, with slots left as literal
+    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
+    sides are compared on phrasing structure, not enumerated slot values."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {"_S2P": {"data": [{"sentences": sentences}]}},
+            "expansion_rules": rules,
+        }
+    )
+    parsed_rules = intents.expansion_rules
+    out: set[str] = set()
+    for intent_data in intents.intents["_S2P"].data:
+        for sentence in intent_data.sentences:
+            for text in sample_sentence(
+                sentence,
+                slot_lists=None,
+                expansion_rules=parsed_rules,
+                expand_lists=False,
+                expand_ranges=False,
+            ):
+                out.add(normalize_whitespace(text).strip())
+    return out
+
+
+def _collect() -> list[tuple[str, str, str]]:
+    """(language, intent, combo) for every combo file with a Speech-to-Phrase
+    block that has an untagged sibling (i.e. something to verify)."""
+    cases: list[tuple[str, str, str]] = []
+    for language in LANGUAGES:
+        lang_dir = SENTENCES_DIR / language
+        for combo_path in sorted(lang_dir.glob("*/*.yaml")):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            _ha, s2p_only = partition_speech_to_phrase(data)
+            if s2p_only:
+                cases.append((language, combo_path.parent.name, combo_path.stem))
+    return cases
+
+
+_CASES = _collect()
+
+
+@pytest.mark.parametrize("lang,intent,combo", _CASES)
+def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
+    combo_path = SENTENCES_DIR / lang / intent / f"{combo}.yaml"
+    data = yaml.safe_load(combo_path.read_text())["data"]
+    ha_blocks, s2p_only = partition_speech_to_phrase(data)
+
+    assert (
+        ha_blocks
+    ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
+
+    rules = _load_expansion_rules(lang)
+    rich = _phrasings(
+        [s for block in ha_blocks for s in block["sentences"]], lang, rules
+    )
+
+    for block in s2p_only:
+        lean = _phrasings(block["sentences"], lang, rules)
+        extra = lean - rich
+        assert not extra, (
+            f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
+            f"not recognised by the Home Assistant (rich) block(s): "
+            f"{sorted(extra)[:10]}"
+        )
+
+
+def test_speech_to_phrase_cases_exist() -> None:
+    """Guard against the collector silently finding nothing (e.g. a rename that
+    drops every tag), which would make the subset test vacuously pass."""
+    assert _CASES, "No speech_to_phrase blocks with an untagged sibling were found"

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -19,7 +19,6 @@ Only English is wired up for now; the collector is language-agnostic.
 """
 
 import importlib
-from pathlib import Path
 from typing import Any
 
 import pytest


### PR DESCRIPTION
## What

Introduces a `speech_to_phrase: true` field on slot-combination data blocks so [Speech-to-Phrase](https://github.com/OHF-Voice/speech-to-phrase) can source its constrained STT grammar directly from home-assistant-intents, instead of maintaining a parallel template tree. English only for now; the mechanism is language-agnostic.

## Why

Including the full rich templates in Speech-to-Phrase's grammar would explode it — some English combos fan out to **>100k phrasings** (e.g. `HassTurnOff/floor_domain` ≈ 132k, `HassLightSet/area_brightness` ≈ 175k). So each tagged block is a *lean* subset suitable for a constrained recognizer, while Home Assistant keeps using the rich templates.

## How

**Two categories of tag:**
- **20 combos** whose existing block is already small are tagged **in place** — shared by both HA and S2P, no duplication.
- **26 exploding combos** get a dedicated lean tagged block **alongside** the rich untagged block.

**One rule, three call sites** — `partition_speech_to_phrase` (`script/intentfest/util.py`): a tagged block is Speech-to-Phrase-only *iff* its combo also has an untagged block.
- The slot-combination test harness loads only the HA blocks and builds the coverage gate from them, so **HA recognition and existing tests are unchanged** and pay no runtime overhead for the lean duplicates (they'd otherwise co-match and churn the tiebreaker).
- Speech-to-Phrase consumes the tagged blocks.

**Subset verification (`tests/test_speech_to_phrase.py`)** — proves `lean ⊆ rich` per combo by enumerating every phrasing on both sides with slots rendered as literal `{list}` sentinels (`expand_lists=False`). This is complete for the finite lean side and needs **no OpenFST toolchain**. 27 lean blocks verified.

## Alignment with `intents.yaml` importance

| tier | total | tagged | coverage |
|---|---|---|---|
| required | 6 | 6 | **100%** |
| usable | 32 | 18 | 56% |
| complete | 144 | 20 | 13% |
| optional | 29 | 2 | 6% |

All `required` combos are covered. The notable untagged `usable` combos (candidates for follow-up) include `HassCancelAllTimers/default`, `HassCancelTimer/{hours,minutes,seconds}_only`, media `name_only`/`area_only` variants, `HassLightSet/name_{color,temperature}`, and `HassGetWeather/name_only`.

## Reviewer notes

- **No `tests/**/*.yaml` files were modified.** The coverage gate change is in the harness (`test_slot_combinations.py`), not the fixtures.
- A few Speech-to-Phrase phrasings had drifted from the *current* rich templates and were adapted to remain valid subsets (the subset test enforces this) — e.g. `set the fan` → `set fan` (current `HassFanSetSpeed/default` has no `[the]` before `fan`), and timer "half an hour" uses the `{timer_half:minutes} an hour` slot rather than a bare literal.
- Consuming the tag in the build/merge output and in Speech-to-Phrase itself is out of scope here (separate repos).

## Testing

- `python -m script.intentfest validate` — clean (all languages)
- `python -m pytest tests/` — **20,447 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)