### PR TITLE
Validate 7 more languages: fix list-refs-in-alternatives readably

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -50,9 +50,10 @@ HA_LIST_NAMES = {"name", "area", "floor"}
 # etc.). Those are being fixed one language per PR; add a language here once it
 # validates cleanly. The remaining migrated-but-not-yet-clean languages have
 # real sentence/test issues (missing test files, GetState domain-slot
-# mismatches, missing volume_step slots, coverage gaps, and — for de/es — some
-# list-in-alternative sentences entangled with those other issues):
-#   ca cs de de-CH es fr lt mn ro sl sv th zh-CN
+# mismatches, missing volume_step slots, coverage gaps; bg's timer sentences
+# combine two digit-or-word list alternatives so they can't be split cleanly;
+# de/es also have list-in-alternative sentences entangled with those issues):
+#   bg ca cs de de-CH es fr lt mn ro sl sv th zh-CN
 SLOT_COMBO_VALIDATION_LANGUAGES = {
     "af",
     "ar",
@@ -86,11 +87,13 @@ SLOT_COMBO_VALIDATION_LANGUAGES = {
     "ms",
     "nb",
     "ne",
+    "nl",
     "pa",
     "pl",
     "pt",
     "pt-BR",
     "ru",
+    "sk",
     "sr",
     "sr-Latn",
     "sw",

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -49,10 +49,10 @@ HA_LIST_NAMES = {"name", "area", "floor"}
 # references inside alternatives, missing test files, untranslated responses,
 # etc.). Those are being fixed one language per PR; add a language here once it
 # validates cleanly. The remaining migrated-but-not-yet-clean languages have
-# real sentence/test issues (list references inside alternatives/optionals,
-# missing test files, GetState domain-slot mismatches, coverage gaps):
-#   bg ca cs de de-CH es fi fr lt mn nl ro
-#   ru sk sl sr sr-Latn sv th vi zh-CN
+# real sentence/test issues (missing test files, GetState domain-slot
+# mismatches, missing volume_step slots, coverage gaps, and — for de/es — some
+# list-in-alternative sentences entangled with those other issues):
+#   ca cs de de-CH es fr lt mn ro sl sv th zh-CN
 SLOT_COMBO_VALIDATION_LANGUAGES = {
     "af",
     "ar",
@@ -64,6 +64,7 @@ SLOT_COMBO_VALIDATION_LANGUAGES = {
     "et",
     "eu",
     "fa",
+    "fi",
     "gl",
     "gu",
     "he",
@@ -89,12 +90,16 @@ SLOT_COMBO_VALIDATION_LANGUAGES = {
     "pl",
     "pt",
     "pt-BR",
+    "ru",
+    "sr",
+    "sr-Latn",
     "sw",
     "ta",
     "te",
     "tr",
     "uk",
     "ur",
+    "vi",
     "zh-HK",
     "zh-TW",
 }

--- a/sentences/fi/HassDecreaseTimer/hours_minutes.yaml
+++ b/sentences/fi/HassDecreaseTimer/hours_minutes.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_hours:hours} (tuntia|tunti) [ja] {timer_minutes:minutes} (minuuttia|minuutti) [minun|mun] (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_hours:hours} (tuntia|tunti) [ja] {timer_minutes:minutes} (minuuttia|minuutti)|ota {timer_hours:hours} (tuntia|tunti) [ja] {timer_minutes:minutes} (minuuttia|minuutti) pois) [minun|mun] (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_hours:hours} (tuntia|tunti) [ja] {timer_minutes:minutes} (minuuttia|minuutti) [pois] [minun|mun] (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_hours:hours} (tuntia|tunti) [ja] {timer_minutes:minutes} (minuuttia|minuutti)"
     example: "poista 1 tunti ja 15 minuuttia ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/fi/HassDecreaseTimer/hours_only.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_hours:hours} (tuntia|tunti) [minun|mun] (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_hours:hours} (tuntia|tunti)|ota {timer_hours:hours} (tuntia|tunti) pois) [minun|mun] (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_hours:hours} (tuntia|tunti) [pois] [minun|mun] (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_hours:hours} (tuntia|tunti)"
     example: "poista 1 tunti ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/hours_seconds.yaml
+++ b/sentences/fi/HassDecreaseTimer/hours_seconds.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_hours:hours} (tuntia|tunti) [ja] {timer_seconds:seconds} (sekuntia|sekunti) [minun|mun] (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_hours:hours} (tuntia|tunti) [ja] {timer_seconds:seconds} (sekuntia|sekunti)|ota {timer_hours:hours} (tuntia|tunti) [ja] {timer_seconds:seconds} (sekuntia|sekunti) pois) [minun|mun] (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_hours:hours} (tuntia|tunti) [ja] {timer_seconds:seconds} (sekuntia|sekunti) [pois] [minun|mun] (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_hours:hours} (tuntia|tunti) [ja] {timer_seconds:seconds} (sekuntia|sekunti)"
     example: "poista 1 tunti ja 30 sekuntia ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/hours_start_hours.yaml
+++ b/sentences/fi/HassDecreaseTimer/hours_start_hours.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_hours:hours} (tuntia|tunti) [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_hours:hours} (tuntia|tunti)|ota {timer_hours:hours} (tuntia|tunti) pois) [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_hours:hours} (tuntia|tunti) [pois] [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_hours:start_hours} tunnin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_hours:hours} (tuntia|tunti)"
     example: "poista 5 tuntia 3 tunnin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/hours_start_minutes.yaml
+++ b/sentences/fi/HassDecreaseTimer/hours_start_minutes.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_hours:hours} (tuntia|tunti) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_hours:hours} (tuntia|tunti)|ota {timer_hours:hours} (tuntia|tunti) pois) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_hours:hours} (tuntia|tunti) [pois] [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_hours:hours} (tuntia|tunti)"
     example: "poista 5 tuntia 10 minuutin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/hours_start_seconds.yaml
+++ b/sentences/fi/HassDecreaseTimer/hours_start_seconds.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_hours:hours} (tuntia|tunti) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_hours:hours} (tuntia|tunti)|ota {timer_hours:hours} (tuntia|tunti) pois) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_hours:hours} (tuntia|tunti) [pois] [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_hours:hours} (tuntia|tunti)"
     example: "poista 5 tuntia 10 sekunnin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/fi/HassDecreaseTimer/minutes_only.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_minutes:minutes} (minuuttia|minuutti) [minun|mun] (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_minutes:minutes} (minuuttia|minuutti)|ota {timer_minutes:minutes} (minuuttia|minuutti) pois) [minun|mun] (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_minutes:minutes} (minuuttia|minuutti) [pois] [minun|mun] (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_minutes:minutes} (minuuttia|minuutti)"
     example: "poista 5 minuuttia ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/minutes_seconds.yaml
+++ b/sentences/fi/HassDecreaseTimer/minutes_seconds.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_minutes:minutes} (minuuttia|minuutti) [ja] {timer_seconds:seconds} (sekuntia|sekunti) [minun|mun] (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_minutes:minutes} (minuuttia|minuutti) [ja] {timer_seconds:seconds} (sekuntia|sekunti)|ota {timer_minutes:minutes} (minuuttia|minuutti) [ja] {timer_seconds:seconds} (sekuntia|sekunti) pois) [minun|mun] (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_minutes:minutes} (minuuttia|minuutti) [ja] {timer_seconds:seconds} (sekuntia|sekunti) [pois] [minun|mun] (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_minutes:minutes} (minuuttia|minuutti) [ja] {timer_seconds:seconds} (sekuntia|sekunti)"
     example: "poista 5 minuuttia ja 30 sekuntia ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/minutes_start_hours.yaml
+++ b/sentences/fi/HassDecreaseTimer/minutes_start_hours.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_minutes:minutes} (minuuttia|minuutti) [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_minutes:minutes} (minuuttia|minuutti)|ota {timer_minutes:minutes} (minuuttia|minuutti) pois) [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_minutes:minutes} (minuuttia|minuutti) [pois] [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_hours:start_hours} tunnin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_minutes:minutes} (minuuttia|minuutti)"
     example: "poista 10 minuuttia 5 tunnin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/minutes_start_minutes.yaml
+++ b/sentences/fi/HassDecreaseTimer/minutes_start_minutes.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_minutes:minutes} (minuuttia|minuutti) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_minutes:minutes} (minuuttia|minuutti)|ota {timer_minutes:minutes} (minuuttia|minuutti) pois) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_minutes:minutes} (minuuttia|minuutti) [pois] [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_minutes:minutes} (minuuttia|minuutti)"
     example: "poista 5 minuuttia minun 10 minuutin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/minutes_start_seconds.yaml
+++ b/sentences/fi/HassDecreaseTimer/minutes_start_seconds.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_minutes:minutes} (minuuttia|minuutti) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_minutes:minutes} (minuuttia|minuutti)|ota {timer_minutes:minutes} (minuuttia|minuutti) pois) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_minutes:minutes} (minuuttia|minuutti) [pois] [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_minutes:minutes} (minuuttia|minuutti)"
     example: "poista 10 minuuttia minun 1200 sekunnin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/fi/HassDecreaseTimer/seconds_only.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_seconds:seconds} (sekuntia|sekunti) [minun|mun] (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_seconds:seconds} (sekuntia|sekunti)|ota {timer_seconds:seconds} (sekuntia|sekunti) pois) [minun|mun] (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_seconds:seconds} (sekuntia|sekunti) [pois] [minun|mun] (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_seconds:seconds} (sekuntia|sekunti)"
     example: "poista 30 sekuntia ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/seconds_start_hours.yaml
+++ b/sentences/fi/HassDecreaseTimer/seconds_start_hours.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_seconds:seconds} (sekuntia|sekunti) [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_seconds:seconds} (sekuntia|sekunti)|ota {timer_seconds:seconds} (sekuntia|sekunti) pois) [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_seconds:seconds} (sekuntia|sekunti) [pois] [minun|mun] {timer_hours:start_hours} tunnin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_hours:start_hours} tunnin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_seconds:seconds} (sekuntia|sekunti)"
     example: "poista 5 sekuntia minun 1 tunnin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/seconds_start_minutes.yaml
+++ b/sentences/fi/HassDecreaseTimer/seconds_start_minutes.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_seconds:seconds} (sekuntia|sekunti) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_seconds:seconds} (sekuntia|sekunti)|ota {timer_seconds:seconds} (sekuntia|sekunti) pois) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_seconds:seconds} (sekuntia|sekunti) [pois] [minun|mun] {timer_minutes:start_minutes} minuutin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_minutes:start_minutes} minuutin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_seconds:seconds} (sekuntia|sekunti)"
     example: "poista 10 sekuntia minun 10 minuutin ajastimesta"
     response: "default"

--- a/sentences/fi/HassDecreaseTimer/seconds_start_seconds.yaml
+++ b/sentences/fi/HassDecreaseTimer/seconds_start_seconds.yaml
@@ -5,7 +5,7 @@ language: "fi"
 data:
   - sentences:
       - "poista {timer_seconds:seconds} (sekuntia|sekunti) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
-      - "(ota pois {timer_seconds:seconds} (sekuntia|sekunti)|ota {timer_seconds:seconds} (sekuntia|sekunti) pois) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
+      - "ota [pois] {timer_seconds:seconds} (sekuntia|sekunti) [pois] [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastimesta|ajastuksesta)"
       - "(vähennä|pienennä|lyhennä) [minun|mun] {timer_seconds:start_seconds} sekunnin (ajastinta|ajastusta|ajastimesta|ajastuksesta) {timer_seconds:seconds} (sekuntia|sekunti)"
     example: "poista 10 sekuntia 20 sekunnin ajastimesta"
     response: "default"

--- a/sentences/nl/HassMediaSearchAndPlay/name_area.yaml
+++ b/sentences/nl/HassMediaSearchAndPlay/name_area.yaml
@@ -9,9 +9,12 @@
 language: "nl"
 data:
   - sentences:
-      - "speel {search_query} op ([de|het] {name} [in|op|van|bij] [de|het] {area}|[de|het] {area}[ ][de|het] {name}) [af]"
-      - "speel {search_query} af op ([de|het] {name} [in|op|van|bij] [de|het] {area}|[de|het] {area}[ ][de|het] {name})"
-      - "(luister|kijk) (naar {search_query};op ([de|het] {name} [in|op|van|bij] [de|het] {area}|[de|het] {area}[ ][de|het] {name}))"
+      - "speel {search_query} op [de|het] {name} [in|op|van|bij] [de|het] {area} [af]"
+      - "speel {search_query} op [de|het] {area}[ ][de|het] {name} [af]"
+      - "speel {search_query} af op [de|het] {name} [in|op|van|bij] [de|het] {area}"
+      - "speel {search_query} af op [de|het] {area}[ ][de|het] {name}"
+      - "(luister|kijk) (naar {search_query};op [de|het] {name} [in|op|van|bij] [de|het] {area})"
+      - "(luister|kijk) (naar {search_query};op [de|het] {area}[ ][de|het] {name})"
     example: "speel The Office op de TV in de woonkamer"
     name_domains:
       - "media_player"

--- a/sentences/nl/HassMediaSearchAndPlay/name_area_media_class.yaml
+++ b/sentences/nl/HassMediaSearchAndPlay/name_area_media_class.yaml
@@ -10,9 +10,12 @@
 language: "nl"
 data:
   - sentences:
-      - "speel [de|het] ({media_class};{search_query}) op ([de|het] {name} [in|op|van|bij] [de|het] {area}|[de|het] {area}[ ][de|het] {name}) [af]"
-      - "speel [de|het] ({media_class};{search_query}) af op ([de|het] {name} [in|op|van|bij] [de|het] {area}|[de|het] {area}[ ][de|het] {name})"
-      - "(luister|kijk) (naar [de|het] ({media_class};{search_query});op ([de|het] {name} [in|op|van|bij] [de|het] {area}|[de|het] {area}[ ][de|het] {name}))"
+      - "speel [de|het] ({media_class};{search_query}) op [de|het] {name} [in|op|van|bij] [de|het] {area} [af]"
+      - "speel [de|het] ({media_class};{search_query}) op [de|het] {area}[ ][de|het] {name} [af]"
+      - "speel [de|het] ({media_class};{search_query}) af op [de|het] {name} [in|op|van|bij] [de|het] {area}"
+      - "speel [de|het] ({media_class};{search_query}) af op [de|het] {area}[ ][de|het] {name}"
+      - "(luister|kijk) (naar [de|het] ({media_class};{search_query});op [de|het] {name} [in|op|van|bij] [de|het] {area})"
+      - "(luister|kijk) (naar [de|het] ({media_class};{search_query});op [de|het] {area}[ ][de|het] {name})"
     example: "luister naar de artiest Queen op de TV in de keuken"
     name_domains:
       - "media_player"

--- a/sentences/nl/HassTurnOn/name_scene.yaml
+++ b/sentences/nl/HassTurnOn/name_scene.yaml
@@ -8,7 +8,7 @@ data:
   - sentences:
       - "(activeer|start|schakel) [scene|scène] [de|het] {name}[ ][scene|scène] [<to>] [in]"
       - "[<change>] [scene|scène] [de|het] {name}[ ][scene|scène] [<to>] (aan|in)"
-      - "([de|het] {name}[ ][scene|scène]|[scene|scène] [de|het] {name}) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
+      - "[scene|scène] [de|het] {name}[ ][scene|scène] [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
     example: "activeer feestmodus scene"
     name_domains:
       - "scene"

--- a/sentences/nl/HassTurnOn/name_script.yaml
+++ b/sentences/nl/HassTurnOn/name_script.yaml
@@ -6,9 +6,9 @@
 language: "nl"
 data:
   - sentences:
-      - "(activeer|start|schakel) ([script] [de|het] {name}|[de|het] {name}[ ][script]) [<to>] [in]"
-      - "[<change>] ([script] [de|het] {name}|[de|het] {name}[ ][script]) [<to>] (aan|in)"
-      - "([script] [de|het] {name}|[de|het] {name}[ ][script]) [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
+      - "(activeer|start|schakel) [script] [de|het] {name}[ ][script] [<to>] [in]"
+      - "[<change>] [script] [de|het] {name}[ ][script] [<to>] (aan|in)"
+      - "[script] [de|het] {name}[ ][script] [<to>] (aan[ ](zetten|doen)|inschakelen|starten|activeren)"
     example: "start stealthmodus script"
     name_domains:
       - "script"

--- a/sentences/ru/HassTurnOff/name_area.yaml
+++ b/sentences/ru/HassTurnOff/name_area.yaml
@@ -7,7 +7,8 @@ language: "ru"
 data:
   # off-able domains
   - sentences:
-      - "<turn_off> ([в|во|на] {area} {name}|{name} [в|во|на] {area})"
+      - "<turn_off> [в|во|на] {area} {name}"
+      - "<turn_off> {name} [в|во|на] {area}"
     example: "выключи лампу в гостиной"
     name_domains:
       - "light"

--- a/sentences/ru/HassTurnOn/name_area.yaml
+++ b/sentences/ru/HassTurnOn/name_area.yaml
@@ -7,7 +7,8 @@ language: "ru"
 data:
   # on-able domains
   - sentences:
-      - "<turn_on> ([в|во|на] {area} {name}|{name} [в|во|на] {area})"
+      - "<turn_on> [в|во|на] {area} {name}"
+      - "<turn_on> {name} [в|во|на] {area}"
     example: "включи лампу в гостиной"
     name_domains:
       - "light"

--- a/sentences/sk/HassLightSet/area_brightness.yaml
+++ b/sentences/sk/HassLightSet/area_brightness.yaml
@@ -1,8 +1,11 @@
 language: sk
 data:
   - sentences:
-      - "<set> (<area>;svetl(á|o)) na (<brightness>|{brightness_level:brightness}) [jas]"
-      - "<set> (jas [svetla|svetiel];<area>) na (<brightness>|{brightness_level:brightness})"
-      - "<set> (<area>;(<brightness>|{brightness_level:brightness}) jas [svetla|svetiel])"
+      - "<set> (<area>;svetl(á|o)) na <brightness> [jas]"
+      - "<set> (<area>;svetl(á|o)) na {brightness_level:brightness} [jas]"
+      - "<set> (jas [svetla|svetiel];<area>) na <brightness>"
+      - "<set> (jas [svetla|svetiel];<area>) na {brightness_level:brightness}"
+      - "<set> (<area>;<brightness> jas [svetla|svetiel])"
+      - "<set> (<area>;{brightness_level:brightness} jas [svetla|svetiel])"
     inferred_domain: "light"
     response: brightness_area

--- a/sentences/sk/HassLightSet/area_temperature.yaml
+++ b/sentences/sk/HassLightSet/area_temperature.yaml
@@ -1,8 +1,11 @@
 language: sk
 data:
   - sentences:
-      - "<set> teplotu [farby] <area> [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
-      - "<set> <area> [svetl(á|o)] [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature}) [teplotu [farby]]"
-      - "<set> teplotu [farby] [svetiel|svetla] <area> [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+      - "<set> teplotu [farby] <area> [na] {color_temperature:temperature}[[ ]k]"
+      - "<set> teplotu [farby] <area> [na] {color_temperature_names:temperature}"
+      - "<set> <area> [svetl(á|o)] [na] {color_temperature:temperature}[[ ]k] [teplotu [farby]]"
+      - "<set> <area> [svetl(á|o)] [na] {color_temperature_names:temperature} [teplotu [farby]]"
+      - "<set> teplotu [farby] [svetiel|svetla] <area> [na] {color_temperature:temperature}[[ ]k]"
+      - "<set> teplotu [farby] [svetiel|svetla] <area> [na] {color_temperature_names:temperature}"
     inferred_domain: "light"
     response: temperature

--- a/sentences/sk/HassLightSet/brightness_only.yaml
+++ b/sentences/sk/HassLightSet/brightness_only.yaml
@@ -1,7 +1,9 @@
 language: sk
 data:
   - sentences:
-      - "[<set>] ([<here>];jas) na (<brightness>|{brightness_level:brightness})"
-      - "[<set>] ([<here>];(<brightness>|{brightness_level:brightness}) jas)"
+      - "[<set>] ([<here>];jas) na <brightness>"
+      - "[<set>] ([<here>];jas) na {brightness_level:brightness}"
+      - "[<set>] ([<here>];<brightness> jas)"
+      - "[<set>] ([<here>];{brightness_level:brightness} jas)"
     inferred_domain: "light"
     response: brightness_here

--- a/sentences/sk/HassLightSet/floor_brightness.yaml
+++ b/sentences/sk/HassLightSet/floor_brightness.yaml
@@ -1,7 +1,9 @@
 language: sk
 data:
   - sentences:
-      - "<set> (jas [svetla|svetiel];<floor>) [na] (<brightness>|{brightness_level:brightness})"
-      - "<set> <floor> [svetl(á|o)] [na] (<brightness>|{brightness_level:brightness}) [jas]"
+      - "<set> (jas [svetla|svetiel];<floor>) [na] <brightness>"
+      - "<set> (jas [svetla|svetiel];<floor>) [na] {brightness_level:brightness}"
+      - "<set> <floor> [svetl(á|o)] [na] <brightness> [jas]"
+      - "<set> <floor> [svetl(á|o)] [na] {brightness_level:brightness} [jas]"
     inferred_domain: "light"
     response: brightness

--- a/sentences/sk/HassLightSet/floor_temperature.yaml
+++ b/sentences/sk/HassLightSet/floor_temperature.yaml
@@ -1,7 +1,9 @@
 language: sk
 data:
   - sentences:
-      - "<set> teplotu [farby] <floor> [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
-      - "<set> <floor> [svetl(á|o)] [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature}) [teplotu [farby]]"
+      - "<set> teplotu [farby] <floor> [na] {color_temperature:temperature}[[ ]k]"
+      - "<set> teplotu [farby] <floor> [na] {color_temperature_names:temperature}"
+      - "<set> <floor> [svetl(á|o)] [na] {color_temperature:temperature}[[ ]k] [teplotu [farby]]"
+      - "<set> <floor> [svetl(á|o)] [na] {color_temperature_names:temperature} [teplotu [farby]]"
     inferred_domain: "light"
     response: temperature

--- a/sentences/sk/HassLightSet/name_brightness.yaml
+++ b/sentences/sk/HassLightSet/name_brightness.yaml
@@ -1,10 +1,14 @@
 language: sk
 data:
   - sentences:
-      - "<set> {name} na (<brightness>|{brightness_level:brightness}) [jas[u]]"
-      - "<set> jas [svetla] {name} na (<brightness>|{brightness_level:brightness})"
-      - "<set> ([na] {name};(<brightness>|{brightness_level:brightness}) jas)"
-      - "<set> ([na] {name};jas) [na] (<brightness>|{brightness_level:brightness})"
+      - "<set> {name} na <brightness> [jas[u]]"
+      - "<set> {name} na {brightness_level:brightness} [jas[u]]"
+      - "<set> jas [svetla] {name} na <brightness>"
+      - "<set> jas [svetla] {name} na {brightness_level:brightness}"
+      - "<set> ([na] {name};<brightness> jas)"
+      - "<set> ([na] {name};{brightness_level:brightness} jas)"
+      - "<set> ([na] {name};jas) [na] <brightness>"
+      - "<set> ([na] {name};jas) [na] {brightness_level:brightness}"
     name_domains:
       - "light"
     response: brightness

--- a/sentences/sk/HassLightSet/name_temperature.yaml
+++ b/sentences/sk/HassLightSet/name_temperature.yaml
@@ -1,8 +1,10 @@
 language: sk
 data:
   - sentences:
-      - "<set> [teplotu [farby]] {name} [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
-      - "<set> [teplotu [farby] [svetla]] [na] {name} [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
+      - "<set> [teplotu [farby]] {name} [na] {color_temperature:temperature}[[ ]k]"
+      - "<set> [teplotu [farby]] {name} [na] {color_temperature_names:temperature}"
+      - "<set> [teplotu [farby] [svetla]] [na] {name} [na] {color_temperature:temperature}[[ ]k]"
+      - "<set> [teplotu [farby] [svetla]] [na] {name} [na] {color_temperature_names:temperature}"
     name_domains:
       - "light"
     response: temperature

--- a/sentences/sk/HassLightSet/temperature_only.yaml
+++ b/sentences/sk/HassLightSet/temperature_only.yaml
@@ -1,7 +1,9 @@
 language: sk
 data:
   - sentences:
-      - "[<set>] ([<here>];teplotu [farby]) [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature})"
-      - "[<set>] [teplotu [farby] [svetla]] [na] ({color_temperature:temperature}[[ ]k]|{color_temperature_names:temperature}) [<here>]"
+      - "[<set>] ([<here>];teplotu [farby]) [na] {color_temperature:temperature}[[ ]k]"
+      - "[<set>] ([<here>];teplotu [farby]) [na] {color_temperature_names:temperature}"
+      - "[<set>] [teplotu [farby] [svetla]] [na] {color_temperature:temperature}[[ ]k] [<here>]"
+      - "[<set>] [teplotu [farby] [svetla]] [na] {color_temperature_names:temperature} [<here>]"
     inferred_domain: "light"
     response: temperature

--- a/sentences/sr-Latn/HassLightSet/area_color.yaml
+++ b/sentences/sr-Latn/HassLightSet/area_color.yaml
@@ -2,8 +2,8 @@ language: sr-Latn
 data:
   - sentences:
       - "<set> [boju] [svih] <light> u {area} [na|u] {color}"
-      - "<set> svuda [boju] <light> [u {area}] [na|u] {color}"
-      - "<set> sva <light> [{area}] [na|u] {color} [boju]"
+      - "<set> svuda [boju] <light> u {area} [na|u] {color}"
+      - "<set> sva <light> {area} [na|u] {color} [boju]"
     example: "podesi boju svetla u dnevnoj sobi na zeleno"
     inferred_domain: "light"
     response: "color_area"

--- a/sentences/sr/HassLightSet/area_color.yaml
+++ b/sentences/sr/HassLightSet/area_color.yaml
@@ -2,8 +2,8 @@ language: sr
 data:
   - sentences:
       - "<set> [боју] [свих] <light> у {area} [на|у] {color}"
-      - "<set> свуда [боју] <light> [у {area}] [на|у] {color}"
-      - "<set> сва <light> [{area}] [на|у] {color} [боју]"
+      - "<set> свуда [боју] <light> у {area} [на|у] {color}"
+      - "<set> сва <light> {area} [на|у] {color} [боју]"
     example: "подеси боју светла у дневној соби на зелено"
     inferred_domain: "light"
     response: "color_area"

--- a/sentences/vi/HassTurnOn/name_scene.yaml
+++ b/sentences/vi/HassTurnOn/name_scene.yaml
@@ -9,7 +9,8 @@ data:
       - "[kích hoạt] [cảnh] {name}"
       - "[cái] {name} cảnh bật"
       - "<turn> ([cảnh] {name};bật)"
-      - "(chuyển đổi|chuyển) sang ({name} [cảnh]|cảnh {name})"
+      - "(chuyển đổi|chuyển) sang {name} [cảnh]"
+      - "(chuyển đổi|chuyển) sang cảnh {name}"
     example: "kích hoạt cảnh chế độ tiệc"
     name_domains:
       - "scene"

--- a/tests/nl/HassMediaSearchAndPlay/name_area.yaml
+++ b/tests/nl/HassMediaSearchAndPlay/name_area.yaml
@@ -19,6 +19,8 @@ tests:
       - speel The Office af op de TV in de woonkamer
       - kijk naar The Office op de woonkamer TV
       - kijk op de TV in de woonkamer naar The Office
+      - speel The Office op de woonkamer TV
+      - speel The Office af op de woonkamer TV
     slots:
       search_query: The Office
       name: TV

--- a/tests/nl/HassMediaSearchAndPlay/name_area_media_class.yaml
+++ b/tests/nl/HassMediaSearchAndPlay/name_area_media_class.yaml
@@ -18,6 +18,9 @@ tests:
       - luister naar de artiest Queen op de TV in de keuken
       - speel de artiest Queen op de TV in de keuken
       - speel de artiest Queen af op de TV in de keuken
+      - speel de artiest Queen op de keuken TV
+      - speel de artiest Queen af op de keuken TV
+      - luister naar de artiest Queen op de keuken TV
     slots:
       search_query: Queen
       name: TV

--- a/tests/sk/HassLightSet/area_brightness.yaml
+++ b/tests/sk/HassLightSet/area_brightness.yaml
@@ -10,3 +10,11 @@ tests:
       brightness: 50
       area: "spáln(i|e)|spálň(a|u)"
     response: "Jas v oblasti nastavený na 50 %"
+  - sentences:
+      - "nastav svetlo v spálni na maximum"
+      - "nastav jas svetla v spálni na maximum"
+      - "nastav maximum jas svetiel v spálni"
+    slots:
+      brightness: 100
+      area: "spáln(i|e)|spálň(a|u)"
+    response: "Jas v oblasti nastavený na maximum"

--- a/tests/sk/HassLightSet/area_temperature.yaml
+++ b/tests/sk/HassLightSet/area_temperature.yaml
@@ -10,3 +10,11 @@ tests:
       temperature: 2700
       area: "spáln(i|e)|spálň(a|u)"
     response: "Teplota farby nastavená"
+  - sentences:
+      - "nastav v spálni svetlá na teplú bielu"
+      - "nastav teplotu svetiel v spálni na 2700"
+      - "nastav teplotu farby v spálni na teplú bielu"
+    slots:
+      temperature: 2700
+      area: "spáln(i|e)|spálň(a|u)"
+    response: "Teplota farby nastavená"

--- a/tests/sk/HassLightSet/brightness_only.yaml
+++ b/tests/sk/HassLightSet/brightness_only.yaml
@@ -10,3 +10,11 @@ tests:
     slots:
       brightness: 30
     response: "Jas tu bol nastavený na 30 %"
+  - sentences:
+      - "nastav tu jas na maximum"
+      - "nastav maximum jas"
+    context:
+      area: "Spálňa"
+    slots:
+      brightness: 100
+    response: "Jas tu bol nastavený na maximum"

--- a/tests/sk/HassLightSet/floor_brightness.yaml
+++ b/tests/sk/HassLightSet/floor_brightness.yaml
@@ -9,3 +9,10 @@ tests:
       brightness: 50
       floor: "prvom poschodí"
     response: "Jas nastavený na 50 %"
+  - sentences:
+      - "nastav jas na prvom poschodí na maximum"
+      - "nastav na prvom poschodí svetlá na maximum jas"
+    slots:
+      brightness: 100
+      floor: "prvom poschodí"
+    response: "Jas nastavený na maximum"

--- a/tests/sk/HassLightSet/floor_temperature.yaml
+++ b/tests/sk/HassLightSet/floor_temperature.yaml
@@ -9,3 +9,10 @@ tests:
       temperature: 2700
       floor: "prvom poschodí"
     response: "Teplota farby nastavená"
+  - sentences:
+      - "nastav na prvom poschodí svetlá na 2700 k"
+      - "nastav teplotu farby na prvom poschodí na teplú bielu"
+    slots:
+      temperature: 2700
+      floor: "prvom poschodí"
+    response: "Teplota farby nastavená"

--- a/tests/sk/HassLightSet/name_brightness.yaml
+++ b/tests/sk/HassLightSet/name_brightness.yaml
@@ -12,3 +12,12 @@ tests:
       brightness: 50
       name: "nočn(á|ú|ej) lamp(a|u|y|e)"
     response: "Jas nastavený na 50 %"
+  - sentences:
+      - "nastav nočnú lampu na maximum"
+      - "nastav jas svetla nočnej lampy na maximum"
+      - "nastav maximum jas na nočnej lampe"
+      - "nastav na nočnej lampe jas na maximum"
+    slots:
+      brightness: 100
+      name: "nočn(á|ú|ej) lamp(a|u|y|e)"
+    response: "Jas nastavený na maximum"

--- a/tests/sk/HassLightSet/name_temperature.yaml
+++ b/tests/sk/HassLightSet/name_temperature.yaml
@@ -11,3 +11,9 @@ tests:
       temperature: 2700
       name: "nočn(á|ú|ej) lamp(a|u|y|e)"
     response: "Teplota farby nastavená"
+  - sentences:
+      - "nastav teplotu farby na nočnej lampe na teplú bielu"
+    slots:
+      temperature: 2700
+      name: "nočn(á|ú|ej) lamp(a|u|y|e)"
+    response: "Teplota farby nastavená"

--- a/tests/sk/HassLightSet/temperature_only.yaml
+++ b/tests/sk/HassLightSet/temperature_only.yaml
@@ -11,3 +11,10 @@ tests:
     slots:
       temperature: 2700
     response: "Teplota farby nastavená"
+  - sentences:
+      - "nastav teplotu farby svetla na teplú bielu tu"
+    context:
+      area: "Obývačka"
+    slots:
+      temperature: 2700
+    response: "Teplota farby nastavená"


### PR DESCRIPTION
Clears the `no_alternative_list_references` validator errors for the languages where it can be done **readably** (splitting/collapsing sentences, not hiding the construct behind an expansion rule), and adds them to `SLOT_COMBO_VALIDATION_LANGUAGES` (**43 → 50**).

## Two shapes of the problem

**Word-order swaps** — a word/phrase reorders around a slot. Fixed with no new rules and no test edits:
- **fi** `HassDecreaseTimer`: `(ota pois X\|ota X pois)` → `ota [pois] X [pois]` (only "pois" moved, so an optional on each side collapses it to one clean template).
- **ru / vi**: split the `{area}`/`{name}` word-order alternative into two top-level templates (both orders already tested).
- **sr / sr-Latn** `HassLightSet/area_color`: `{area}` was inside an `[optional]` in a combo where area is *required* — dropped the brackets (a latent bug, not just the lint). sr-Latn regenerated via the transliterate script.

**Alternatives between different inputs** — split into separate templates, and add coverage for the branch the tests didn't exercise:
- **nl** `HassTurnOn` scene/script: collapsed `([w] {name}\|{name} [w])` → `[w] {name} [w]`. `HassMediaSearchAndPlay`: split the `{name}`/`{area}` order swap and added the missing area-first "speel …" tests.
- **sk** `HassLightSet` brightness/temperature: split `(<brightness>\|{brightness_level})` and `({color_temperature}[k]\|{color_temperature_names})` into numeric/named templates, and added the named-level (min/max) and named-color-temperature test sentences the split left uncovered.

Test YAML was edited **only** under `tests/sk/` and `tests/nl/` (to cover the newly-split named branches); no other language's tests were touched.

## Deliberately not included
- **bg** — timer sentences combine *two* digit-or-word list alternatives at once, so splitting is combinatorial. The shared `timer_words_*` ("one"/"two") lists (bg/es/pt/pt-BR/gl) want a structural fix, not per-language splits.
- **de, es** — their list-in-alternative sentences are entangled with their other pending issues (GetState domain-slot, `volume_step`); left for those languages' PRs.

## Verification
- `python -m script.intentfest validate` → **All good!**
- Full suite → **20420 passed**
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)