### PR TITLE
[zh-TW] Add remaining slot combinations (climate floor, cover floor, vacuum area)

### DIFF
--- a/sentences/zh-TW/HassClimateGetTemperature/floor_only.yaml
+++ b/sentences/zh-TW/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "{floor}[的]<temp>[<how_many_is>]"
+      - "[現在]{floor}[有](幾|多少)度"
+      - "{floor}(現在|目前)[有](幾|多少)度"
+      - "[現在]{floor}[有]多(熱|冷)"
+    example: "現在二樓幾度"
+    response: "default"

--- a/sentences/zh-TW/HassSetPosition/floor_device_class.yaml
+++ b/sentences/zh-TW/HassSetPosition/floor_device_class.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{floor}[的]{cover_classes:device_class}[的][位置]<set_to>[百分之]{position}[ ][%|趴]"
+      - "[把|將]{floor}[的]{cover_classes:device_class}(開|關)到[百分之]{position}[ ][%|趴]"
+    inferred_domain: "cover"
+    example: "把二樓的窗簾開到50%"
+    response: "cover_device_class"

--- a/sentences/zh-TW/HassSetPosition/name_floor.yaml
+++ b/sentences/zh-TW/HassSetPosition/name_floor.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[把|將]{floor}的{name}[的][位置]<set_to>[百分之]{position}[ ][%|趴]"
+      - "[把|將]{floor}的{name}(開|關)到[百分之]{position}[ ][%|趴]"
+    name_domains:
+      - "cover"
+    example: "把二樓的窗簾開到50%"
+    response: "default"

--- a/sentences/zh-TW/HassVacuumReturnToBase/area_only.yaml
+++ b/sentences/zh-TW/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[讓|叫]{area}的(掃地機器人|掃地機|吸塵器)(回充電座|回去充電|返回充電座)"
+    example: "讓客廳的掃地機器人回充電座"
+    response: "default"

--- a/sentences/zh-TW/HassVacuumStart/area_only.yaml
+++ b/sentences/zh-TW/HassVacuumStart/area_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(啟動|開始){area}的(掃地機器人|掃地機|吸塵器)"
+      - "[讓]{area}的(掃地機器人|掃地機|吸塵器)開始(打掃|工作|掃地)"
+    example: "啟動客廳的掃地機器人"
+    response: "default"

--- a/tests/zh-TW/HassClimateGetTemperature/floor_only.yaml
+++ b/tests/zh-TW/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,22 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 溫控器
+    domain: climate
+    area: 二樓臥室
+    state: heat
+    attributes:
+      current_temperature: 18
+tests:
+  - sentences:
+      - 現在二樓幾度？
+      - 二樓現在幾度
+      - 二樓的溫度是多少
+      - 現在二樓有多熱
+    slots:
+      floor: 二樓
+    response: "18度"

--- a/tests/zh-TW/HassSetPosition/floor_device_class.yaml
+++ b/tests/zh-TW/HassSetPosition/floor_device_class.yaml
@@ -1,0 +1,21 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 二樓的大窗戶
+    domain: cover
+    area: 二樓臥室
+    attributes:
+      device_class: window
+tests:
+  - sentences:
+      - 把二樓的窗戶位置調到50%
+      - 把二樓的窗戶開到50%
+    slots:
+      floor: 二樓
+      device_class: window
+      position: 50
+    response: "window位置已調整"

--- a/tests/zh-TW/HassSetPosition/name_floor.yaml
+++ b/tests/zh-TW/HassSetPosition/name_floor.yaml
@@ -1,0 +1,19 @@
+language: zh-TW
+floors:
+  - name: 二樓
+areas:
+  - name: 二樓臥室
+    floor: 二樓
+entities:
+  - name: 窗簾
+    domain: cover
+    area: 二樓臥室
+tests:
+  - sentences:
+      - 把二樓的窗簾位置調到50%
+      - 把二樓的窗簾開到50%
+    slots:
+      floor: 二樓
+      name: 窗簾
+      position: 50
+    response: "位置已調整"

--- a/tests/zh-TW/HassVacuumReturnToBase/area_only.yaml
+++ b/tests/zh-TW/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,14 @@
+language: zh-TW
+areas:
+  - name: 客廳
+entities:
+  - name: 掃地機器人
+    domain: vacuum
+    area: 客廳
+tests:
+  - sentences:
+      - 讓客廳的掃地機器人回充電座
+      - 叫客廳的掃地機器人回去充電
+    slots:
+      area: 客廳
+    response: "正在返回充電座"

--- a/tests/zh-TW/HassVacuumStart/area_only.yaml
+++ b/tests/zh-TW/HassVacuumStart/area_only.yaml
@@ -1,0 +1,14 @@
+language: zh-TW
+areas:
+  - name: 客廳
+entities:
+  - name: 掃地機器人
+    domain: vacuum
+    area: 客廳
+tests:
+  - sentences:
+      - 啟動客廳的掃地機器人
+      - 讓客廳的掃地機器人開始打掃
+    slots:
+      area: 客廳
+    response: "已啟動"


### PR DESCRIPTION
## Changes

Fills the last gaps in zh-TW's slot-combination coverage. Five combinations across three intents, each with a matching self-contained test file.

**Vacuum — `area_only`** (the practically useful part)

`HassVacuumStart` already had `floor_only` and `name_only`, and `HassVacuumReturnToBase` only had `name_only` — so a robot could be addressed by name or by floor, but not by area:

- `HassVacuumStart/area_only` — 啟動客廳的掃地機器人 / 讓客廳的掃地機器人開始打掃
- `HassVacuumReturnToBase/area_only` — 讓客廳的掃地機器人回充電座

Beyond filling the asymmetry, these templates put the colloquial nouns (掃地機器人|掃地機|吸塵器) in the sentence itself and target via `{area}` + the vacuum domain, so they work regardless of what the entity happens to be named. The `name_only` templates only match when the user says the entity's registered name, which in practice often differs from what people actually call the device.

**Floor combinations**

- `HassClimateGetTemperature/floor_only` — 現在二樓幾度 / 二樓多熱
- `HassSetPosition/floor_device_class` — 把二樓的窗簾開到50%
- `HassSetPosition/name_floor` — 把二樓的窗簾開到50%

These mirror the existing zh-TW `area_only` / `area_device_class` / `name_area` templates with 樓層 targeting.

Note that `en` does not currently define any of these five combinations, so there is no `en` counterpart to mirror — the templates follow the zh-TW patterns already in the tree.

## Testing

- `python3 -m script.intentfest validate --language zh-TW` — All good!
- `pytest tests --language zh-TW` — 262 passed

Branch verified standalone in an isolated worktree, rebased onto current `main`.

The two vacuum templates were also verified against a live Home Assistant instance with a custom `home-assistant-intents` build: 讓臥室的掃地機器人回充電座 correctly resolves to the vacuum in that area even though the entity is registered under a different name.
