### PR TITLE
[zh-TW] Use Chinese search_query examples in HassMediaSearchAndPlay tests

### DIFF
--- a/tests/zh-TW/HassMediaSearchAndPlay/area_media_class.yaml
+++ b/tests/zh-TW/HassMediaSearchAndPlay/area_media_class.yaml
@@ -3,7 +3,6 @@ areas:
   - name: 客廳
 media:
   - title: 五月天
-  - title: Taylor Swift
 tests:
   - sentences:
       - 在客廳播放怪物的專輯
@@ -12,12 +11,11 @@ tests:
       area: 客廳
       media_class: "album"
     response: "正在播放"
-  # An English query keeps its internal whitespace even though the language
-  # sets ignore_whitespace.
+  # Spaces around the query are dropped regardless of ignore_whitespace.
   - sentences:
-      - 在客廳播放 Taylor Swift 的歌
+      - 在客廳播放 怪物 的專輯
     slots:
-      search_query: "Taylor Swift"
+      search_query: "怪物"
       area: 客廳
-      media_class: "track"
+      media_class: "album"
     response: "正在播放"

--- a/tests/zh-TW/HassMediaSearchAndPlay/name_only.yaml
+++ b/tests/zh-TW/HassMediaSearchAndPlay/name_only.yaml
@@ -4,7 +4,6 @@ entities:
     domain: media_player
 media:
   - title: 五月天
-  - title: Taylor Swift
 tests:
   - sentences:
       - 在電視上播放五月天
@@ -13,9 +12,10 @@ tests:
       search_query: "五月天"
       name: "電視"
     response: "正在播放"
+  # A space before the query is dropped regardless of ignore_whitespace.
   - sentences:
-      - 在電視上播放 Taylor Swift
+      - 在電視上播放 五月天
     slots:
-      search_query: "Taylor Swift"
+      search_query: "五月天"
       name: "電視"
     response: "正在播放"


### PR DESCRIPTION
## Changes

The two English `search_query` examples added in #4025 pass this repo's CI but **fail the packaging sanity check** in `OHF-Voice/intents-package`, which will break the nightly build

The cause is a configuration difference, not the templates. zh-TW sets `ignore_whitespace: true`, which strips whitespace from the whole utterance before matching. `在電視上播放 Taylor Swift` therefore resolves to `search_query='TaylorSwift'` when language settings are applied — as they are in the packaged JSON that Home Assistant loads — but to `'Taylor Swift'` when they are not, which is the case in this repo's test fixture.

This PR replaces both English examples with Chinese ones that resolve to the same value under **either** configuration, so the sanity check passes regardless:

| sentence | `ignore_whitespace: false` | `true` |
|---|---|---|
| `在電視上播放 五月天` | `'五月天'` | `'五月天'` |
| `在客廳播放 怪物 的專輯` | `'怪物'` | `'怪物'` |

Spaces around a query are dropped either way, because the wildcard strips leading and trailing whitespace from its capture.

The fixture issue behind the divergence is fixed separately in #4027. The underlying wildcard behaviour is reported upstream in OHF-Voice/hassil#276.

## Testing

- `python3 -m script.intentfest validate` (all languages) — All good!
- `pytest tests -n auto` — 14662 passed
- Same suite re-run with `settings` applied (i.e. the packaged configuration) — 14662 passed

The second run is the one that matters here: it confirms these examples hold under the configuration the sanity check uses.
