### PR TITLE
Apply language settings from _common.yaml in slot combination tests

### DIFF
--- a/tests/test_slot_combinations.py
+++ b/tests/test_slot_combinations.py
@@ -145,6 +145,7 @@ def lang_resources_fixture(language: str, intent_schemas: dict[str, Any]):
         with open(common_path, "r", encoding="utf-8") as common_file:
             common_dict = yaml.safe_load(common_file) or {}
         lang_intents_dict["skip_words"] = common_dict.get("skip_words", [])
+        lang_intents_dict["settings"] = common_dict.get("settings", {})
 
     # Load expansion rules
     rules_dict: dict[str, Any] = lang_intents_dict["expansion_rules"]


### PR DESCRIPTION
> [!IMPORTANT]
> **CI fails here by design, and the failure is the point.** With `settings` applied, the two English `search_query` examples currently on `main` are exposed as asserting a value that never occurs in Home Assistant:
> ```
> FAILED test_HassMediaSearchAndPlay_name_only[zh-TW]
> FAILED test_HassMediaSearchAndPlay_area_media_class[zh-TW]
> 2 failed, 260 passed
> ```
> Those two examples are corrected in #4026. Once that lands, this PR goes green with no changes needed here. Marked as draft until then.

## Changes

`lang_resources` (`tests/test_slot_combinations.py:132`) builds its intents dict by hand and reads only `skip_words` from `_common.yaml`, so `settings` is dropped. As a result **8 languages are tested under a configuration Home Assistant never uses**:

| languages | declared in `_common.yaml` | tested as |
|---|---|---|
| `zh-CN` `zh-HK` `zh-TW` | `ignore_whitespace: true` | `false` (hassil default) |
| `cs` `de` `ne` `nl` `vi` | `filter_with_regex: false` | `true` (hassil default) |

The same sentence can therefore resolve to different slot values here and in the packaged data. `在電視上播放 Taylor Swift` gives `search_query='Taylor Swift'` in this repo's tests but `'TaylorSwift'` in the `intents-package` sanity check, which loads the exported JSON where `settings` is present. That divergence is what #4026 had to work around.

`common_dict` is already loaded on the preceding line, so the fix is to read `settings` from it as well:

```python
lang_intents_dict["skip_words"] = common_dict.get("skip_words", [])
lang_intents_dict["settings"] = common_dict.get("settings", {})   # added
```

Worth noting why this stayed invisible: dropping `settings` only ever makes tests *more* permissive, never red. No existing test sentence can tell the two configurations apart — flipping `ignore_whitespace` to `false` for all three Chinese languages leaves them at 712 passed. The behaviour it protects (input containing spaces, e.g. `打開 大燈`) has no test coverage at all.

The underlying wildcard behaviour that this exposes is reported upstream in OHF-Voice/hassil#276.

## Testing

Verified on top of #4026:

- `python3 -m script.intentfest validate` (all languages) — All good!
- `pytest tests -n auto` — 14662 passed

No language changes behaviour under the corrected configuration.
