### PR TITLE
[DE] Add missing localized examples for HassMediaSearchAndPlay

### DIFF
--- a/sentences/de/HassMediaSearchAndPlay/name_area_media_class.yaml
+++ b/sentences/de/HassMediaSearchAndPlay/name_area_media_class.yaml
@@ -18,6 +18,7 @@ data:
   - sentences:
       - "spiel[e] (den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class} (<an>|am) [<artikel_bestimmt> ]{name} <area>[ ab]"
       - "(den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class} (<an>|am) [<artikel_bestimmt> ]{name} <area> <starten_end_of_sentence>"
+    example: spiele meine Rock-Playlist auf dem TV in der Küche
     name_domains:
       - media_player
     response: default
@@ -26,6 +27,7 @@ data:
   - sentences:
       - "spiel[e] [(<an>|am) ][<artikel_bestimmt> ]{name} <area> (den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class}[ ab]"
       - "[(<an>|am) ][<artikel_bestimmt> ]{name} <area> (den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class} <starten_end_of_sentence>"
+    example: spiele auf dem TV in der Küche meine Rock-Playlist
     name_domains:
       - media_player
     response: default

--- a/sentences/de/HassMediaSearchAndPlay/name_media_class.yaml
+++ b/sentences/de/HassMediaSearchAndPlay/name_media_class.yaml
@@ -18,6 +18,7 @@ data:
   - sentences:
       - "spiel[e] (den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class} (<an>|am) [<artikel_bestimmt> ]{name}[ ab]"
       - "(den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class} (<an>|am) [<artikel_bestimmt> ]{name} <starten_end_of_sentence>"
+    example: spiele meine Rock-Playlist auf dem TV
     name_domains:
       - media_player
     response: default
@@ -26,6 +27,7 @@ data:
   - sentences:
       - "spiel[e] [(<an>|am) ][<artikel_bestimmt> ]{name} (den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class}[ ab]"
       - "[(<an>|am) ][<artikel_bestimmt> ]{name} (den|die|meine[n]|unsere[n]) {search_query}[ |-]{media_class_my_split:media_class} <starten_end_of_sentence>"
+    example: spiele auf dem TV meine Rock-Playlist
     name_domains:
       - media_player
     response: default


### PR DESCRIPTION
[DE] Add missing localized examples for HassMediaSearchAndPlay

## What was broken

`python3 -m script.intentfest validate --language de` printed four warnings on current main (967fa468), and they were the only warnings German had:

```
Language: de
[WARN] sentences/de/HassMediaSearchAndPlay/name_area_media_class.yaml: group #2 has a missing/empty example (should be localized)
[WARN] sentences/de/HassMediaSearchAndPlay/name_area_media_class.yaml: group #3 has a missing/empty example (should be localized)
[WARN] sentences/de/HassMediaSearchAndPlay/name_media_class.yaml: group #2 has a missing/empty example (should be localized)
[WARN] sentences/de/HassMediaSearchAndPlay/name_media_class.yaml: group #3 has a missing/empty example (should be localized)

All good!
```

Groups 2 and 3 of both files went straight from the last sentence template to `name_domains:` with no `example:` key, while group 1 of each file has one. These are the "meine Rock-Playlist" phrasings: the query carrying the media class as a suffix, once with the target after the query and once before it.

Two consequences besides the warning:

- The language page on the website lists one example per data block that has an `example` key (`script/intentfest/slot_combination_summary.py` collects them, `website/src-11ty/language.html` joins them into the combination row). Both rows therefore showed only group 1's phrasing. The rows did still render as supported, but a reader browsing the language page had no way to tell that the two "meine Rock-Playlist" phrasings work.
- `script/intentfest/report_unparsed_examples.py` does `example = block.get("example")` / `if not example: continue`, so the groups were never sentence-checked either. Nothing verified they still parse.

## What changed

One `example:` per affected group, placed before `name_domains:` to match the style of group 1 in the same file:

- `sentences/de/HassMediaSearchAndPlay/name_media_class.yaml`
  - group 2: `spiele meine Rock-Playlist auf dem TV`
  - group 3: `spiele auf dem TV meine Rock-Playlist`
- `sentences/de/HassMediaSearchAndPlay/name_area_media_class.yaml`
  - group 2: `spiele meine Rock-Playlist auf dem TV in der Küche`
  - group 3: `spiele auf dem TV in der Küche meine Rock-Playlist`

No sentence templates, lists or rules change, so there is no new match surface. Only example metadata is added.

Each new example was run through `recognize_example` with the same slot-list fixtures `report_unparsed_examples` uses, and every slot resolves with a highlightable span:

```
'spiele meine Rock-Playlist auf dem TV'
  -> HassMediaSearchAndPlay slots={'search_query': 'Rock', 'media_class': 'playlist', 'name': 'TV'}
     spans={'search_query': (13, 17), 'media_class': (18, 26), 'name': (36, 38)}
'spiele auf dem TV meine Rock-Playlist'
  -> HassMediaSearchAndPlay slots={'name': 'TV', 'search_query': 'Rock', 'media_class': 'playlist'}
     spans={'name': (15, 17), 'search_query': (24, 28), 'media_class': (29, 37)}
'spiele meine Rock-Playlist auf dem TV in der Küche'
  -> HassMediaSearchAndPlay slots={'search_query': 'Rock', 'media_class': 'playlist', 'name': 'TV', 'area': 'Küche'}
     spans={'search_query': (13, 17), 'media_class': (18, 26), 'name': (36, 38), 'area': (46, 51)}
'spiele auf dem TV in der Küche meine Rock-Playlist'
  -> HassMediaSearchAndPlay slots={'name': 'TV', 'area': 'Küche', 'search_query': 'Rock', 'media_class': 'playlist'}
     spans={'name': (15, 17), 'area': (25, 30), 'search_query': (37, 41), 'media_class': (42, 50)}
```

## Verification

Each command was run on its own and its exit code read directly from that command. Results in prose rather than pasted console output, since the tools print more than the lines that matter here.

On main at 967fa468, before the change:

- `validate --language de` exits 0 and prints the four warnings quoted above; they are the only warnings German has.
- `report_unparsed_examples --language de` reports 339 examples for German: 308 highlighted, 31 with no slot to highlight, 0 problems. Exit 0.

After the change:

- `validate --language de` exits 0 and prints only `All good!`, with no warnings left. The `Language: de` header disappears because `script/intentfest/validate.py` prints it only inside the `if warnings:` block.
- `report_unparsed_examples --language de` reports 343 examples for German: 312 highlighted, 31 with no slot to highlight, 0 problems. Exit 0. The four new examples are the increase from 308 to 312 highlighted.
- `pytest tests --language de` exits 0 with 262 tests passed.
- `check_overmatch --language de` exits 0: 3580 test sentences checked, 0 cross-intent over-matches, 0 no-match sentences. The count is unchanged because no test sentences were added.
- `prune --language de --check` exits 0 and reports 0 dead rules and 0 dead lists. It also lists 8 orphaned response keys (`HassGetState.default`, `HassTurnOff.close_all`, `HassTurnOff.fan`, `HassTurnOff.fan_all`, `HassTurnOn.fan`, `HassTurnOn.fan_all`, `HassTurnOn.light_all`, `HassTurnOn.open_all`) and `Total dead items: 8`. Those are present unchanged on main, are unrelated to this change, and `--check` returns 1 only for dead rules or dead lists.
- `pre-commit run prettier` on both changed files passes.
