### PR TITLE
[DE] Add missing floor phrasings for HassVacuumStart

### DIFF
--- a/sentences/de/HassVacuumStart/floor_only.yaml
+++ b/sentences/de/HassVacuumStart/floor_only.yaml
@@ -7,5 +7,8 @@ language: "de"
 data:
   - sentences:
       - "<saugen> <floor>"
+      - "(<schalten>|<machen>) [den ](Staubsauger|Saugroboter|Sauger) <floor> <an>"
+      - "(<ausfuehren>|<aktivieren>) [den ](Staubsauger|Saugroboter|Sauger) <floor>"
+      - "[den ](Staubsauger|Saugroboter|Sauger) <floor> (starten|<an>[schalten|machen])"
     example: "sauge im Erdgeschoss"
     response: "default"

--- a/tests/de/HassVacuumStart/floor_only.yaml
+++ b/tests/de/HassVacuumStart/floor_only.yaml
@@ -14,6 +14,11 @@ tests:
   - sentences:
       - "sauge im Erdgeschoss"
       - "reinige das Erdgeschoss"
+      - "starte den Staubsauger im Erdgeschoss"
+      - "schalte den Staubsauger im Erdgeschoss an"
+      - "aktiviere den Saugroboter im Erdgeschoss"
+      - "den Staubsauger im Erdgeschoss starten"
+      - "Staubsauger im Erdgeschoss anschalten"
     slots:
       floor: Erdgeschoss
     response: "Gestartet"


### PR DESCRIPTION
[DE] Add missing floor phrasings for HassVacuumStart

## What was broken

On current main (967fa468), `sentences/de/HassVacuumStart/floor_only.yaml` carried a single template:

```yaml
data:
  - sentences:
      - "<saugen> <floor>"
```

while its `area_only.yaml` sibling carried three more:

```yaml
data:
  - sentences:
      - "(<schalten>|<machen>) [den ](Staubsauger|Saugroboter|Sauger) <area> <an>"
      - "(<ausfuehren>|<aktivieren>) [den ](Staubsauger|Saugroboter|Sauger) <area>"
      - "[den ](Staubsauger|Saugroboter|Sauger) <area> (starten|<an>[schalten|machen])"
```

So every "Staubsauger" phrasing worked on an area but not on a floor. Recognizing against the whole merged German intent set (the same loader `check_overmatch` uses, with the `tests/de/HassVacuumStart/floor_only.yaml` fixture: floor Erdgeschoss, vacuum Rover) gave this before the change:

```
'sauge im Erdgeschoss'                       -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'reinige das Erdgeschoss'                    -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'starte den Staubsauger im Erdgeschoss'      -> NO MATCH
'schalte den Staubsauger im Erdgeschoss an'  -> NO MATCH
'schalte den Staubsauger im Erdgeschoss ein' -> NO MATCH
'Staubsauger im Erdgeschoss anschalten'      -> NO MATCH
'aktiviere den Saugroboter im Erdgeschoss'   -> NO MATCH
'aktiviere den Staubsauger im Erdgeschoss'   -> NO MATCH
'mach den Saugroboter im Erdgeschoss an'     -> NO MATCH
'den Sauger im Erdgeschoss anschalten'       -> NO MATCH
'den Staubsauger im Erdgeschoss starten'     -> HassMediaSearchAndPlay [default] {'search_query': 'den Staubsauger im Erdgeschoss', 'area': '__context_area__'}
```

The last line is the worst case: with nothing in HassVacuumStart to match it, the sentence fell through to HassMediaSearchAndPlay's `{search_query}` wildcard, so asking for the vacuum started a media search for "den Staubsauger im Erdgeschoss" in the context area.

The same sentences with an area work today, for example:

```
'starte den Staubsauger in der Küche'   -> HassVacuumStart [area_only] {'area': 'Küche'}
'den Staubsauger in der Küche starten'  -> HassVacuumStart [area_only] {'area': 'Küche'}
```

`floor_only.yaml` has not been touched since 56813f4a, the modern-syntax conversion (#3887, 2026-06-23), which introduced it with that one `<saugen> <floor>` template. The three "Staubsauger" templates came later, in e170b614 "[DE] Add vacuum area slot combinations (#3993)" (2026-07-20), which added `area_only.yaml`; `floor_only.yaml` was not extended to match. So the asymmetry is an omission from #3993, not a deliberate restriction.

## What changed

`sentences/de/HassVacuumStart/floor_only.yaml` gets the three `area_only` templates verbatim, with `<area>` swapped for `<floor>`, so both combinations cover the same "Staubsauger" phrasings. `floor_only` keeps its own `<saugen> <floor>` template on top of those, which `area_only` has no counterpart for, so it ends up a superset: four templates against `area_only`'s three. No new expansion rules are needed: `<schalten>`, `<machen>`, `<ausfuehren>`, `<aktivieren>` and `<an>` all exist in `rules/de/common.yaml` already.

`tests/de/HassVacuumStart/floor_only.yaml` pins five of the newly working sentences, including the one that used to reach HassMediaSearchAndPlay.

After the change, the whole probe set above resolves correctly:

```
'sauge im Erdgeschoss'                       -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'reinige das Erdgeschoss'                    -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'starte den Staubsauger im Erdgeschoss'      -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'schalte den Staubsauger im Erdgeschoss an'  -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'schalte den Staubsauger im Erdgeschoss ein' -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'Staubsauger im Erdgeschoss anschalten'      -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'aktiviere den Saugroboter im Erdgeschoss'   -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'aktiviere den Staubsauger im Erdgeschoss'   -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'mach den Saugroboter im Erdgeschoss an'     -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'den Sauger im Erdgeschoss anschalten'       -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
'den Staubsauger im Erdgeschoss starten'     -> HassVacuumStart [floor_only] {'floor': 'Erdgeschoss'}
```

## Verification

Each command was run on its own and its exit code read directly from that command. Results in prose rather than pasted console output, since the tools print more than the lines that matter here.

- `validate --language de` exits 0 and ends with `All good!`. It still prints four `[WARN]` lines about missing localized examples in `sentences/de/HassMediaSearchAndPlay/name_area_media_class.yaml` and `name_media_class.yaml` (groups #2 and #3). Those are present on unmodified main, in files this pull request does not touch. In the changed-files mode CI uses, `validate --language de --changed-files-json '["sentences/de/HassVacuumStart/floor_only.yaml","tests/de/HassVacuumStart/floor_only.yaml"]'` also exits 0, because the warned files are not among the changed ones.
- `pytest tests --language de` exits 0 with 262 tests passed.
- `check_overmatch --language de` exits 0: 3585 test sentences checked (3580 before, plus the five new ones), 0 cross-intent over-matches, 0 no-match sentences.
- `prune --language de --check` exits 0 and reports 0 dead rules and 0 dead lists. It also lists 8 orphaned response keys (`HassGetState.default`, `HassTurnOff.close_all`, `HassTurnOff.fan`, `HassTurnOff.fan_all`, `HassTurnOn.fan`, `HassTurnOn.fan_all`, `HassTurnOn.light_all`, `HassTurnOn.open_all`) and `Total dead items: 8`. Those are present unchanged on main, are unrelated to this change, and `--check` returns 1 only for dead rules or dead lists.
- `report_unparsed_examples --language de` exits 0 and reports 339 examples for German: 308 highlighted, 31 with no slot to highlight, 0 problems. Unchanged from main, since this change adds no examples.
- `pre-commit run prettier` on both changed files passes.

One thing worth flagging about the before state: `check_overmatch` reported 0 no-match sentences even while those eight phrasings did not match anything, because none of them were in a test file. Pinning them in `tests/de` is what lets the gate see a regression here in future.
