### PR TITLE
[zh-TW] Add timer intents

### DIFF
--- a/lists/zh-TW/timers.yaml
+++ b/lists/zh-TW/timers.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+lists:
+  timer_half:
+    values:
+      - in: 半
+        out: 30

--- a/responses/zh-TW/HassCancelAllTimers.yaml
+++ b/responses/zh-TW/HassCancelAllTimers.yaml
@@ -1,0 +1,20 @@
+language: zh-TW
+responses:
+  intents:
+    HassCancelAllTimers:
+      default: >-
+        {%- if slots.canceled < 1 -%}
+        沒有取消任何計時器
+        {%- elif slots.canceled == 1 -%}
+        已取消1個計時器
+        {%- else -%}
+        已取消{{ slots.canceled }}個計時器
+        {%- endif -%}
+      area: >-
+        {%- if slots.canceled < 1 -%}
+        沒有取消{{ slots.area }}的任何計時器
+        {%- elif slots.canceled == 1 -%}
+        已取消{{ slots.area }}的1個計時器
+        {%- else -%}
+        已取消{{ slots.area }}的{{ slots.canceled }}個計時器
+        {%- endif -%}

--- a/responses/zh-TW/HassCancelTimer.yaml
+++ b/responses/zh-TW/HassCancelTimer.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassCancelTimer:
+      default: "計時器已取消"

--- a/responses/zh-TW/HassDecreaseTimer.yaml
+++ b/responses/zh-TW/HassDecreaseTimer.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+responses:
+  intents:
+    HassDecreaseTimer:
+      default: >-
+        {%- set h = slots.hours if slots.hours is defined else '' -%}
+        {%- set m = slots.minutes if slots.minutes is defined else '' -%}
+        {%- set s = slots.seconds if slots.seconds is defined else '' -%}
+        {%- set m = '30' if m == '半' else m -%}
+        {%- set s = '30' if s == '半' else s -%}
+        {%- set text = (h ~ '小時' if h else '') ~ (m ~ '分鐘' if m else '') ~ (s ~ '秒' if s else '') -%}
+        {%- set name = slots.name if slots.name is defined else '' -%}
+        已為{{ name }}計時器減少{{ text }}

--- a/responses/zh-TW/HassIncreaseTimer.yaml
+++ b/responses/zh-TW/HassIncreaseTimer.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+responses:
+  intents:
+    HassIncreaseTimer:
+      default: >-
+        {%- set h = slots.hours if slots.hours is defined else '' -%}
+        {%- set m = slots.minutes if slots.minutes is defined else '' -%}
+        {%- set s = slots.seconds if slots.seconds is defined else '' -%}
+        {%- set m = '30' if m == '半' else m -%}
+        {%- set s = '30' if s == '半' else s -%}
+        {%- set text = (h ~ '小時' if h else '') ~ (m ~ '分鐘' if m else '') ~ (s ~ '秒' if s else '') -%}
+        {%- set name = slots.name if slots.name is defined else '' -%}
+        已為{{ name }}計時器增加{{ text }}

--- a/responses/zh-TW/HassPauseTimer.yaml
+++ b/responses/zh-TW/HassPauseTimer.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassPauseTimer:
+      default: "計時器已暫停"

--- a/responses/zh-TW/HassStartTimer.yaml
+++ b/responses/zh-TW/HassStartTimer.yaml
@@ -1,0 +1,21 @@
+language: zh-TW
+responses:
+  intents:
+    HassStartTimer:
+      default: >-
+        {%- set h = slots.hours if slots.hours is defined else '' -%}
+        {%- set m = slots.minutes if slots.minutes is defined else '' -%}
+        {%- set s = slots.seconds if slots.seconds is defined else '' -%}
+        {%- set m = '30' if m == '半' else m -%}
+        {%- set s = '30' if s == '半' else s -%}
+        {%- set text = (h ~ '小時' if h else '') ~ (m ~ '分鐘' if m else '') ~ (s ~ '秒' if s else '') -%}
+        {%- set name = slots.name if slots.name is defined else '' -%}
+        已設定{{ text }}的{{ name }}計時器
+      command: >-
+        {%- set h = slots.hours if slots.hours is defined else '' -%}
+        {%- set m = slots.minutes if slots.minutes is defined else '' -%}
+        {%- set s = slots.seconds if slots.seconds is defined else '' -%}
+        {%- set m = '30' if m == '半' else m -%}
+        {%- set s = '30' if s == '半' else s -%}
+        {%- set text = (h ~ '小時' if h else '') ~ (m ~ '分鐘' if m else '') ~ (s ~ '秒' if s else '') -%}
+        將在{{ text }}後執行

--- a/responses/zh-TW/HassTimerStatus.yaml
+++ b/responses/zh-TW/HassTimerStatus.yaml
@@ -1,0 +1,44 @@
+language: zh-TW
+responses:
+  intents:
+    HassTimerStatus:
+      default: >-
+        {%- set num_timers = slots.timers | length -%}
+        {%- set paused_timers = slots.timers | selectattr("is_active", "equalto", false) | list -%}
+        {%- set active_timers = slots.timers | rejectattr("is_active", "equalto", false) | list -%}
+        {%- set num_active_timers = active_timers | length -%}
+        {%- set next_timer = none -%}
+        {%- set prefix = "" -%}
+        {%- if num_timers == 0 -%}
+          沒有計時器
+        {%- else -%}
+          {%- if num_active_timers > 0 -%}
+            {%- set sorted_timers = active_timers | sort(attribute="total_seconds_left") -%}
+            {%- set next_timer = sorted_timers[0] -%}
+            {%- if num_active_timers > 1 -%}
+              {%- set prefix = "最快結束的計時器還剩" -%}
+            {%- else -%}
+              {%- set prefix = "計時器還剩" -%}
+            {%- endif -%}
+          {%- elif paused_timers | length > 0 -%}
+            {%- set next_timer = paused_timers[0] -%}
+            {%- set prefix = "計時器已暫停，還剩" -%}
+          {%- endif -%}
+          {%- if next_timer -%}
+            {%- set duration = "" -%}
+            {%- if (next_timer.rounded_hours_left > 0) and (next_timer.rounded_minutes_left > 0) -%}
+              {%- set duration = next_timer.rounded_hours_left ~ "小時" ~ next_timer.rounded_minutes_left ~ "分鐘" -%}
+            {%- elif next_timer.rounded_hours_left > 0 -%}
+              {%- set duration = next_timer.rounded_hours_left ~ "小時" -%}
+            {%- elif (next_timer.rounded_minutes_left > 0) and (next_timer.rounded_seconds_left > 0) -%}
+              {%- set duration = next_timer.rounded_minutes_left ~ "分鐘" ~ next_timer.rounded_seconds_left ~ "秒" -%}
+            {%- elif next_timer.rounded_minutes_left > 0 -%}
+              {%- set duration = next_timer.rounded_minutes_left ~ "分鐘" -%}
+            {%- elif next_timer.rounded_seconds_left > 0 -%}
+              {%- set duration = next_timer.rounded_seconds_left ~ "秒" -%}
+            {%- else -%}
+              {%- set duration = "不到1秒" -%}
+            {%- endif -%}
+            {{ prefix }}{{ duration }}
+          {%- endif -%}
+        {%- endif -%}

--- a/responses/zh-TW/HassUnpauseTimer.yaml
+++ b/responses/zh-TW/HassUnpauseTimer.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "計時器繼續計時"

--- a/rules/zh-TW/timers.yaml
+++ b/rules/zh-TW/timers.yaml
@@ -1,0 +1,5 @@
+language: zh-TW
+expansion_rules:
+  timer: "(計時器|倒數計時器)"
+  timer_set: "(設定|設|開始|啟動|建立)"
+  timer_cancel: "(取消|停止|刪除)"

--- a/sentences/zh-TW/HassCancelAllTimers/area_only.yaml
+++ b/sentences/zh-TW/HassCancelAllTimers/area_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>{area}[的](所有|全部)[的]<timer>"
+      - "<timer_cancel>(所有|全部){area}的<timer>"
+    example: "取消廚房的所有計時器"
+    response: "area"

--- a/sentences/zh-TW/HassCancelAllTimers/default.yaml
+++ b/sentences/zh-TW/HassCancelAllTimers/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>(所有|全部)[的]<timer>"
+    example: "取消所有計時器"
+    response: "default"

--- a/sentences/zh-TW/HassCancelTimer/area_only.yaml
+++ b/sentences/zh-TW/HassCancelTimer/area_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>{area}[的]<timer>"
+    example: "取消廚房的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassCancelTimer/default.yaml
+++ b/sentences/zh-TW/HassCancelTimer/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>[我的]<timer>"
+    example: "取消計時器"
+    response: "default"

--- a/sentences/zh-TW/HassCancelTimer/hours_only.yaml
+++ b/sentences/zh-TW/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>[那個|我的]{timer_hours:start_hours}[個]小時[的]<timer>"
+    example: "取消2小時的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassCancelTimer/minutes_only.yaml
+++ b/sentences/zh-TW/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>[那個|我的]{timer_minutes:start_minutes}分鐘[的]<timer>"
+    example: "取消5分鐘的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassCancelTimer/name_only.yaml
+++ b/sentences/zh-TW/HassCancelTimer/name_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>[我的]{timer_name:name}[的]<timer>"
+      - "<timer_cancel>[我的]<timer>(名為|叫做){timer_name:name}"
+    example: "取消泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassCancelTimer/seconds_only.yaml
+++ b/sentences/zh-TW/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_cancel>[那個|我的]{timer_seconds:start_seconds}秒[鐘][的]<timer>"
+    example: "取消45秒的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/area_hours.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/area_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時"
+      - "(減|減少|縮短)[我的]{area}[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫廚房的計時器減1小時"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/area_hours_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/area_hours_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的]{area}[的]<timer>{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+    example: "幫廚房的計時器減1小時5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/area_hours_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/area_hours_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]{area}[的]<timer>{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+    example: "幫廚房的計時器減1小時30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/area_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/area_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的]{area}[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫廚房的計時器減5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/area_minutes_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/area_minutes_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]{area}[的]<timer>{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+    example: "幫廚房的計時器減5分鐘30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/area_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/area_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(減|減少|縮短){timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]{area}[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫廚房的計時器減30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/hours_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/hours_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的]<timer>{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+    example: "幫計時器減1小時5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/hours_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時"
+      - "(減|減少|縮短)[我的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫計時器減1小時"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/hours_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/hours_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]<timer>{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+    example: "幫計時器減1小時30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/hours_start_hours.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/hours_start_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時"
+      - "(減|減少|縮短)[我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫2小時的計時器減1小時"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/hours_start_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/hours_start_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時"
+      - "(減|減少|縮短)[我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫10分鐘的計時器減1小時"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/hours_start_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/hours_start_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時"
+      - "(減|減少|縮短)[我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫45秒的計時器減1小時"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/minutes_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫計時器減5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/minutes_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/minutes_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]<timer>{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+    example: "幫計時器減5分鐘30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/minutes_start_hours.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/minutes_start_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫2小時的計時器減5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/minutes_start_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/minutes_start_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫10分鐘的計時器減5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/minutes_start_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/minutes_start_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫45秒的計時器減5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/name_hours.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/name_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時"
+      - "(減|減少|縮短)[我的]{timer_name:name}[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫泡麵計時器減1小時"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/name_hours_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/name_hours_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的]{timer_name:name}[的]<timer>{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+    example: "幫泡麵計時器減1小時5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/name_hours_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/name_hours_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(減|減少|縮短){timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]{timer_name:name}[的]<timer>{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+    example: "幫泡麵計時器減1小時30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/name_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/name_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(減|減少|縮短){timer_minutes:minutes}分鐘"
+      - "(減|減少|縮短)[我的]{timer_name:name}[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫泡麵計時器減5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/name_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/name_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(減|減少|縮短){timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]{timer_name:name}[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫泡麵計時器減30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/seconds_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(減|減少|縮短){timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫計時器減30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/seconds_start_hours.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/seconds_start_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>(減|減少|縮短){timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫2小時的計時器減30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/seconds_start_minutes.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/seconds_start_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>(減|減少|縮短){timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫10分鐘的計時器減30秒"
+    response: "default"

--- a/sentences/zh-TW/HassDecreaseTimer/seconds_start_seconds.yaml
+++ b/sentences/zh-TW/HassDecreaseTimer/seconds_start_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>(減|減少|縮短){timer_seconds:seconds}秒[鐘]"
+      - "(減|減少|縮短)[我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫45秒的計時器減30秒"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/area_hours.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/area_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(加|增加|延長){timer_hours:hours}[個]小時"
+      - "(加|增加|延長)[我的]{area}[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫廚房的計時器加1小時"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/area_minutes.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/area_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(加|增加|延長){timer_minutes:minutes}分鐘"
+      - "(加|增加|延長)[我的]{area}[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫廚房的計時器加5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/area_seconds.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/area_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{area}[的]<timer>(加|增加|延長){timer_seconds:seconds}秒[鐘]"
+      - "(加|增加|延長)[我的]{area}[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫廚房的計時器加30秒"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/hours_minutes.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/hours_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(加|增加|延長){timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+      - "(加|增加|延長)[我的]<timer>{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+    example: "幫計時器加1小時5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/hours_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(加|增加|延長){timer_hours:hours}[個]小時"
+      - "(加|增加|延長)[我的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫計時器加1小時"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/hours_start_hours.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/hours_start_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>(加|增加|延長){timer_hours:hours}[個]小時"
+      - "(加|增加|延長)[我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫2小時的計時器加1小時"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/hours_start_minutes.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/hours_start_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>(加|增加|延長){timer_hours:hours}[個]小時"
+      - "(加|增加|延長)[我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫10分鐘的計時器加1小時"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/hours_start_seconds.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/hours_start_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>(加|增加|延長){timer_hours:hours}[個]小時"
+      - "(加|增加|延長)[我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫45秒的計時器加1小時"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/minutes_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(加|增加|延長){timer_minutes:minutes}分鐘"
+      - "(加|增加|延長)[我的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫計時器加5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/minutes_seconds.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/minutes_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(加|增加|延長){timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+      - "(加|增加|延長)[我的]<timer>{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+    example: "幫計時器加5分鐘30秒"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/minutes_start_hours.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/minutes_start_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>(加|增加|延長){timer_minutes:minutes}分鐘"
+      - "(加|增加|延長)[我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫2小時的計時器加5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/minutes_start_minutes.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/minutes_start_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>(加|增加|延長){timer_minutes:minutes}分鐘"
+      - "(加|增加|延長)[我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫10分鐘的計時器加5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/minutes_start_seconds.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/minutes_start_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>(加|增加|延長){timer_minutes:minutes}分鐘"
+      - "(加|增加|延長)[我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫45秒的計時器加5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/name_hours.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/name_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(加|增加|延長){timer_hours:hours}[個]小時"
+      - "(加|增加|延長)[我的]{timer_name:name}[的]<timer>{timer_hours:hours}[個]小時"
+    example: "幫泡麵計時器加1小時"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/name_minutes.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/name_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(加|增加|延長){timer_minutes:minutes}分鐘"
+      - "(加|增加|延長)[我的]{timer_name:name}[的]<timer>{timer_minutes:minutes}分鐘"
+    example: "幫泡麵計時器加5分鐘"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/name_seconds.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/name_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]{timer_name:name}[的]<timer>(加|增加|延長){timer_seconds:seconds}秒[鐘]"
+      - "(加|增加|延長)[我的]{timer_name:name}[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫泡麵計時器加30秒"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/seconds_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的]<timer>(加|增加|延長){timer_seconds:seconds}秒[鐘]"
+      - "(加|增加|延長)[我的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫計時器加30秒"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/seconds_start_hours.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/seconds_start_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>(加|增加|延長){timer_seconds:seconds}秒[鐘]"
+      - "(加|增加|延長)[我的][那個]{timer_hours:start_hours}[個]小時[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫2小時的計時器加30秒"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/seconds_start_minutes.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/seconds_start_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>(加|增加|延長){timer_seconds:seconds}秒[鐘]"
+      - "(加|增加|延長)[我的][那個]{timer_minutes:start_minutes}分鐘[的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫10分鐘的計時器加30秒"
+    response: "default"

--- a/sentences/zh-TW/HassIncreaseTimer/seconds_start_seconds.yaml
+++ b/sentences/zh-TW/HassIncreaseTimer/seconds_start_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[幫|給|把|將][我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>(加|增加|延長){timer_seconds:seconds}秒[鐘]"
+      - "(加|增加|延長)[我的][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>{timer_seconds:seconds}秒[鐘]"
+    example: "幫45秒的計時器加30秒"
+    response: "default"

--- a/sentences/zh-TW/HassPauseTimer/area_only.yaml
+++ b/sentences/zh-TW/HassPauseTimer/area_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "暫停{area}[的]<timer>"
+    example: "暫停廚房的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassPauseTimer/default.yaml
+++ b/sentences/zh-TW/HassPauseTimer/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "暫停[我的]<timer>"
+    example: "暫停計時器"
+    response: "default"

--- a/sentences/zh-TW/HassPauseTimer/hours_only.yaml
+++ b/sentences/zh-TW/HassPauseTimer/hours_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "暫停[那個|我的]{timer_hours:start_hours}[個]小時[的]<timer>"
+    example: "暫停2小時的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassPauseTimer/minutes_only.yaml
+++ b/sentences/zh-TW/HassPauseTimer/minutes_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "暫停[那個|我的]{timer_minutes:start_minutes}分鐘[的]<timer>"
+    example: "暫停10分鐘的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassPauseTimer/name_only.yaml
+++ b/sentences/zh-TW/HassPauseTimer/name_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "暫停[我的]{timer_name:name}[的]<timer>"
+      - "暫停[我的]<timer>(名為|叫做){timer_name:name}"
+    example: "暫停泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassPauseTimer/seconds_only.yaml
+++ b/sentences/zh-TW/HassPauseTimer/seconds_only.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "暫停[那個|我的]{timer_seconds:start_seconds}秒[鐘][的]<timer>"
+    example: "暫停45秒的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/command_hours.yaml
+++ b/sentences/zh-TW/HassStartTimer/command_hours.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[在|等|過|倒數|計時]{timer_hours:hours}[個]小時[後|之後]{timer_command:conversation_command}"
+    example: "2小時後關燈"
+    response: "command"

--- a/sentences/zh-TW/HassStartTimer/command_hours_minutes.yaml
+++ b/sentences/zh-TW/HassStartTimer/command_hours_minutes.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[在|等|過|倒數|計時]{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘[後|之後]{timer_command:conversation_command}"
+    example: "1小時30分鐘後關燈"
+    response: "command"

--- a/sentences/zh-TW/HassStartTimer/command_hours_minutes_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/command_hours_minutes_seconds.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[在|等|過|倒數|計時]{timer_hours:hours}[個]小時{timer_minutes:minutes}分鐘{timer_seconds:seconds}秒[鐘][後|之後]{timer_command:conversation_command}"
+    example: "1小時5分鐘30秒後關燈"
+    response: "command"

--- a/sentences/zh-TW/HassStartTimer/command_hours_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/command_hours_seconds.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[在|等|過|倒數|計時]{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘][後|之後]{timer_command:conversation_command}"
+    example: "1小時20秒後關燈"
+    response: "command"

--- a/sentences/zh-TW/HassStartTimer/command_minutes.yaml
+++ b/sentences/zh-TW/HassStartTimer/command_minutes.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[在|等|過|倒數|計時]{timer_minutes:minutes}分鐘[後|之後]{timer_command:conversation_command}"
+    example: "5分鐘後關燈"
+    response: "command"

--- a/sentences/zh-TW/HassStartTimer/command_minutes_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/command_minutes_seconds.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[在|等|過|倒數|計時]{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘][後|之後]{timer_command:conversation_command}"
+    example: "5分鐘30秒後關燈"
+    response: "command"

--- a/sentences/zh-TW/HassStartTimer/command_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/command_seconds.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[在|等|過|倒數|計時]{timer_seconds:seconds}秒[鐘][後|之後]{timer_command:conversation_command}"
+    example: "45秒後關燈"
+    response: "command"

--- a/sentences/zh-TW/HassStartTimer/hours_minutes.yaml
+++ b/sentences/zh-TW/HassStartTimer/hours_minutes.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘[的]<timer>"
+      - "<timer_set><timer>{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+      - "{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘[的]<timer>"
+      - "(倒數|計時){timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘"
+      - "<timer_set>[一][個]{timer_hours:hours}個{timer_half:minutes}小時[的]<timer>"
+      - "(倒數|計時){timer_hours:hours}個{timer_half:minutes}小時"
+    example: "設定一個1小時30分鐘的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/hours_minutes_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/hours_minutes_seconds.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時{timer_minutes:minutes}分鐘{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "<timer_set><timer>{timer_hours:hours}[個]小時{timer_minutes:minutes}分鐘{timer_seconds:seconds}秒[鐘]"
+      - "{timer_hours:hours}[個]小時{timer_minutes:minutes}分鐘{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "(倒數|計時){timer_hours:hours}[個]小時{timer_minutes:minutes}分鐘{timer_seconds:seconds}秒[鐘]"
+    example: "設定一個1小時5分鐘30秒的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/hours_only.yaml
+++ b/sentences/zh-TW/HassStartTimer/hours_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[的]<timer>"
+      - "<timer_set><timer>{timer_hours:hours}[個]小時"
+      - "{timer_hours:hours}[個]小時[的]<timer>"
+      - "(倒數|計時){timer_hours:hours}[個]小時"
+    example: "設定一個2小時的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/hours_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/hours_seconds.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "<timer_set><timer>{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+      - "{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "(倒數|計時){timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘]"
+    example: "設定一個1小時20秒的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/minutes_only.yaml
+++ b/sentences/zh-TW/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_minutes:minutes}分鐘[的]<timer>"
+      - "<timer_set><timer>{timer_minutes:minutes}分鐘"
+      - "{timer_minutes:minutes}分鐘[的]<timer>"
+      - "(倒數|計時){timer_minutes:minutes}分鐘"
+      - "<timer_set>{timer_half:minutes}[個]小時[的]<timer>"
+      - "(倒數|計時){timer_half:minutes}[個]小時"
+    example: "設定一個5分鐘的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/minutes_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/minutes_seconds.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "<timer_set><timer>{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+      - "{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "(倒數|計時){timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘]"
+      - "<timer_set>[一][個]{timer_minutes:minutes}分{timer_half:seconds}[的]<timer>"
+      - "(倒數|計時){timer_minutes:minutes}分{timer_half:seconds}"
+    example: "設定一個5分鐘30秒的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/name_hours.yaml
+++ b/sentences/zh-TW/HassStartTimer/name_hours.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[的]{timer_name:name}[的]<timer>"
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[的]<timer>(名為|叫做|取名為){timer_name:name}"
+    example: "設定一個2小時的泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/name_hours_minutes.yaml
+++ b/sentences/zh-TW/HassStartTimer/name_hours_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘[的]{timer_name:name}[的]<timer>"
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[又]{timer_minutes:minutes}分鐘[的]<timer>(名為|叫做|取名為){timer_name:name}"
+    example: "設定一個1小時30分鐘的泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/name_hours_minutes_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/name_hours_minutes_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時{timer_minutes:minutes}分鐘{timer_seconds:seconds}秒[鐘][的]{timer_name:name}[的]<timer>"
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時{timer_minutes:minutes}分鐘{timer_seconds:seconds}秒[鐘][的]<timer>(名為|叫做|取名為){timer_name:name}"
+    example: "設定一個1小時5分鐘30秒的泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/name_hours_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/name_hours_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘][的]{timer_name:name}[的]<timer>"
+      - "<timer_set>[一][個]{timer_hours:hours}[個]小時[又]{timer_seconds:seconds}秒[鐘][的]<timer>(名為|叫做|取名為){timer_name:name}"
+    example: "設定一個1小時20秒的泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/name_minutes.yaml
+++ b/sentences/zh-TW/HassStartTimer/name_minutes.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_minutes:minutes}分鐘[的]{timer_name:name}[的]<timer>"
+      - "<timer_set>[一][個]{timer_minutes:minutes}分鐘[的]<timer>(名為|叫做|取名為){timer_name:name}"
+    example: "設定一個5分鐘的泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/name_minutes_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/name_minutes_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘][的]{timer_name:name}[的]<timer>"
+      - "<timer_set>[一][個]{timer_minutes:minutes}分鐘[又]{timer_seconds:seconds}秒[鐘][的]<timer>(名為|叫做|取名為){timer_name:name}"
+    example: "設定一個5分鐘30秒的泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/name_seconds.yaml
+++ b/sentences/zh-TW/HassStartTimer/name_seconds.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_seconds:seconds}秒[鐘][的]{timer_name:name}[的]<timer>"
+      - "<timer_set>[一][個]{timer_seconds:seconds}秒[鐘][的]<timer>(名為|叫做|取名為){timer_name:name}"
+    example: "設定一個45秒的泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassStartTimer/seconds_only.yaml
+++ b/sentences/zh-TW/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer_set>[一][個]{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "<timer_set><timer>{timer_seconds:seconds}秒[鐘]"
+      - "{timer_seconds:seconds}秒[鐘][的]<timer>"
+      - "(倒數|計時){timer_seconds:seconds}秒[鐘]"
+    example: "設定一個45秒的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassTimerStatus/area_only.yaml
+++ b/sentences/zh-TW/HassTimerStatus/area_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "{area}[的]<timer>[的]狀態"
+      - "{area}[的]<timer>(還剩|剩下|還有|還要)(多少時間|多久)"
+    example: "廚房的計時器還剩多久"
+    response: "default"

--- a/sentences/zh-TW/HassTimerStatus/default.yaml
+++ b/sentences/zh-TW/HassTimerStatus/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "<timer>[的]狀態"
+      - "[我的]<timer>(還剩|剩下|還有|還要)(多少時間|多久)"
+    example: "計時器還剩多久"
+    response: "default"

--- a/sentences/zh-TW/HassTimerStatus/hours_only.yaml
+++ b/sentences/zh-TW/HassTimerStatus/hours_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[那個]{timer_hours:start_hours}[個]小時[的]<timer>[的]狀態"
+      - "[那個]{timer_hours:start_hours}[個]小時[的]<timer>(還剩|剩下|還有|還要)(多少時間|多久)"
+    example: "2小時的計時器還剩多久"
+    response: "default"

--- a/sentences/zh-TW/HassTimerStatus/minutes_only.yaml
+++ b/sentences/zh-TW/HassTimerStatus/minutes_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[那個]{timer_minutes:start_minutes}分鐘[的]<timer>[的]狀態"
+      - "[那個]{timer_minutes:start_minutes}分鐘[的]<timer>(還剩|剩下|還有|還要)(多少時間|多久)"
+    example: "5分鐘的計時器還剩多久"
+    response: "default"

--- a/sentences/zh-TW/HassTimerStatus/name_only.yaml
+++ b/sentences/zh-TW/HassTimerStatus/name_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "{timer_name:name}[的]<timer>[的]狀態"
+      - "{timer_name:name}[的]<timer>(還剩|剩下|還有|還要)(多少時間|多久)"
+    example: "泡麵計時器還剩多久"
+    response: "default"

--- a/sentences/zh-TW/HassTimerStatus/seconds_only.yaml
+++ b/sentences/zh-TW/HassTimerStatus/seconds_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "[那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>[的]狀態"
+      - "[那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>(還剩|剩下|還有|還要)(多少時間|多久)"
+    example: "45秒的計時器還剩多久"
+    response: "default"

--- a/sentences/zh-TW/HassUnpauseTimer/area_only.yaml
+++ b/sentences/zh-TW/HassUnpauseTimer/area_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(繼續|恢復){area}[的]<timer>"
+      - "[讓]{area}[的]<timer>繼續[計時]"
+    example: "繼續廚房的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassUnpauseTimer/default.yaml
+++ b/sentences/zh-TW/HassUnpauseTimer/default.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(繼續|恢復)[我的]<timer>"
+      - "[讓][我的]<timer>繼續[計時]"
+    example: "繼續計時器"
+    response: "default"

--- a/sentences/zh-TW/HassUnpauseTimer/hours_only.yaml
+++ b/sentences/zh-TW/HassUnpauseTimer/hours_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(繼續|恢復)[那個|我的]{timer_hours:start_hours}[個]小時[的]<timer>"
+      - "[讓][那個]{timer_hours:start_hours}[個]小時[的]<timer>繼續[計時]"
+    example: "繼續2小時的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassUnpauseTimer/minutes_only.yaml
+++ b/sentences/zh-TW/HassUnpauseTimer/minutes_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(繼續|恢復)[那個|我的]{timer_minutes:start_minutes}分鐘[的]<timer>"
+      - "[讓][那個]{timer_minutes:start_minutes}分鐘[的]<timer>繼續[計時]"
+    example: "繼續10分鐘的計時器"
+    response: "default"

--- a/sentences/zh-TW/HassUnpauseTimer/name_only.yaml
+++ b/sentences/zh-TW/HassUnpauseTimer/name_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(繼續|恢復)[我的]{timer_name:name}[的]<timer>"
+      - "[讓]{timer_name:name}<timer>繼續[計時]"
+    example: "繼續泡麵計時器"
+    response: "default"

--- a/sentences/zh-TW/HassUnpauseTimer/seconds_only.yaml
+++ b/sentences/zh-TW/HassUnpauseTimer/seconds_only.yaml
@@ -1,0 +1,7 @@
+language: zh-TW
+data:
+  - sentences:
+      - "(繼續|恢復)[那個|我的]{timer_seconds:start_seconds}秒[鐘][的]<timer>"
+      - "[讓][那個]{timer_seconds:start_seconds}秒[鐘][的]<timer>繼續[計時]"
+    example: "繼續45秒的計時器"
+    response: "default"

--- a/sentences/zh-TW/_common.yaml
+++ b/sentences/zh-TW/_common.yaml
@@ -30,6 +30,9 @@ responses:
     duplicate_entities: "有多個叫做「{{ entity }}」的裝置"
     duplicate_entities_in_area: "{{ area }}裡面有多個叫做「{{ entity }}」的裝置"
     duplicate_entities_in_floor: "{{ floor }}有多個叫做「{{ entity }}」的裝置"
+    timer_not_found: "抱歉，找不到這個計時器"
+    multiple_timers_matched: "抱歉，無法同時操作多個計時器"
+    no_timer_support: "抱歉，這個裝置不支援計時器"
 skip_words:
   - "請"
   - "請問"

--- a/tests/zh-TW/HassCancelAllTimers/area_only.yaml
+++ b/tests/zh-TW/HassCancelAllTimers/area_only.yaml
@@ -1,0 +1,15 @@
+language: zh-TW
+areas:
+  - name: 廚房
+timers:
+  - start_minutes: 5
+    area: 廚房
+    total_seconds_left: 300
+    rounded_minutes_left: 5
+tests:
+  - sentences:
+      - 取消廚房的所有計時器
+      - 停止所有廚房的計時器
+    slots:
+      area: 廚房
+    response: "已取消廚房的1個計時器"

--- a/tests/zh-TW/HassCancelAllTimers/default.yaml
+++ b/tests/zh-TW/HassCancelAllTimers/default.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+    rounded_minutes_left: 5
+  - start_minutes: 10
+    total_seconds_left: 600
+    rounded_minutes_left: 10
+tests:
+  - sentences:
+      - 取消所有計時器
+      - 停止全部的計時器
+    response: "已取消2個計時器"

--- a/tests/zh-TW/HassCancelTimer/area_only.yaml
+++ b/tests/zh-TW/HassCancelTimer/area_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 取消廚房的計時器
+      - 停止廚房計時器
+    slots:
+      area: 廚房
+    response: "計時器已取消"

--- a/tests/zh-TW/HassCancelTimer/default.yaml
+++ b/tests/zh-TW/HassCancelTimer/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 取消計時器
+      - 停止我的計時器
+    response: "計時器已取消"

--- a/tests/zh-TW/HassCancelTimer/hours_only.yaml
+++ b/tests/zh-TW/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 取消2小時的計時器
+      - 停止那個2小時的計時器
+    slots:
+      start_hours: 2
+    response: "計時器已取消"

--- a/tests/zh-TW/HassCancelTimer/minutes_only.yaml
+++ b/tests/zh-TW/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 取消5分鐘的計時器
+      - 停止那個5分鐘的計時器
+    slots:
+      start_minutes: 5
+    response: "計時器已取消"

--- a/tests/zh-TW/HassCancelTimer/name_only.yaml
+++ b/tests/zh-TW/HassCancelTimer/name_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 取消泡麵計時器
+      - 停止計時器叫做泡麵
+    slots:
+      name: "泡麵"
+    response: "計時器已取消"

--- a/tests/zh-TW/HassCancelTimer/seconds_only.yaml
+++ b/tests/zh-TW/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 取消45秒的計時器
+      - 停止那個45秒的計時器
+    slots:
+      start_seconds: 45
+    response: "計時器已取消"

--- a/tests/zh-TW/HassDecreaseTimer/area_hours.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/area_hours.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器減1小時
+      - 把廚房的計時器縮短1小時
+      - 減少廚房的計時器1小時
+    slots:
+      area: 廚房
+      hours: 1
+    response: "已為計時器減少1小時"

--- a/tests/zh-TW/HassDecreaseTimer/area_hours_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/area_hours_minutes.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器減1小時5分鐘
+      - 把廚房的計時器縮短1小時5分鐘
+      - 減少廚房的計時器1小時5分鐘
+    slots:
+      area: 廚房
+      hours: 1
+      minutes: 5
+    response: "已為計時器減少1小時5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/area_hours_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/area_hours_seconds.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器減1小時30秒
+      - 把廚房的計時器縮短1小時30秒
+      - 減少廚房的計時器1小時30秒
+    slots:
+      area: 廚房
+      hours: 1
+      seconds: 30
+    response: "已為計時器減少1小時30秒"

--- a/tests/zh-TW/HassDecreaseTimer/area_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/area_minutes.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器減5分鐘
+      - 把廚房的計時器縮短5分鐘
+      - 減少廚房的計時器5分鐘
+    slots:
+      area: 廚房
+      minutes: 5
+    response: "已為計時器減少5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/area_minutes_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/area_minutes_seconds.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器減5分鐘30秒
+      - 把廚房的計時器縮短5分鐘30秒
+      - 減少廚房的計時器5分鐘30秒
+    slots:
+      area: 廚房
+      minutes: 5
+      seconds: 30
+    response: "已為計時器減少5分鐘30秒"

--- a/tests/zh-TW/HassDecreaseTimer/area_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/area_seconds.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器減30秒
+      - 把廚房的計時器縮短30秒
+      - 減少廚房的計時器30秒
+    slots:
+      area: 廚房
+      seconds: 30
+    response: "已為計時器減少30秒"

--- a/tests/zh-TW/HassDecreaseTimer/hours_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/hours_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器減1小時5分鐘
+      - 把計時器縮短1小時5分鐘
+      - 減少計時器1小時5分鐘
+    slots:
+      hours: 1
+      minutes: 5
+    response: "已為計時器減少1小時5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/hours_only.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/hours_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器減1小時
+      - 把計時器縮短1小時
+      - 減少計時器1小時
+    slots:
+      hours: 1
+    response: "已為計時器減少1小時"

--- a/tests/zh-TW/HassDecreaseTimer/hours_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/hours_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器減1小時30秒
+      - 把計時器縮短1小時30秒
+      - 減少計時器1小時30秒
+    slots:
+      hours: 1
+      seconds: 30
+    response: "已為計時器減少1小時30秒"

--- a/tests/zh-TW/HassDecreaseTimer/hours_start_hours.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/hours_start_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫2小時的計時器減1小時
+      - 把2小時的計時器縮短1小時
+      - 減少2小時的計時器1小時
+    slots:
+      start_hours: 2
+      hours: 1
+    response: "已為計時器減少1小時"

--- a/tests/zh-TW/HassDecreaseTimer/hours_start_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/hours_start_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫10分鐘的計時器減1小時
+      - 把10分鐘的計時器縮短1小時
+      - 減少10分鐘的計時器1小時
+    slots:
+      start_minutes: 10
+      hours: 1
+    response: "已為計時器減少1小時"

--- a/tests/zh-TW/HassDecreaseTimer/hours_start_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/hours_start_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫45秒的計時器減1小時
+      - 把45秒的計時器縮短1小時
+      - 減少45秒的計時器1小時
+    slots:
+      start_seconds: 45
+      hours: 1
+    response: "已為計時器減少1小時"

--- a/tests/zh-TW/HassDecreaseTimer/minutes_only.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/minutes_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器減5分鐘
+      - 把計時器縮短5分鐘
+      - 減少計時器5分鐘
+      - 將計時器縮短5分鐘
+    slots:
+      minutes: 5
+    response: "已為計時器減少5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/minutes_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/minutes_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器減5分鐘30秒
+      - 把計時器縮短5分鐘30秒
+      - 減少計時器5分鐘30秒
+    slots:
+      minutes: 5
+      seconds: 30
+    response: "已為計時器減少5分鐘30秒"

--- a/tests/zh-TW/HassDecreaseTimer/minutes_start_hours.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/minutes_start_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫2小時的計時器減5分鐘
+      - 把2小時的計時器縮短5分鐘
+      - 減少2小時的計時器5分鐘
+    slots:
+      start_hours: 2
+      minutes: 5
+    response: "已為計時器減少5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/minutes_start_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/minutes_start_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫10分鐘的計時器減5分鐘
+      - 把10分鐘的計時器縮短5分鐘
+      - 減少10分鐘的計時器5分鐘
+    slots:
+      start_minutes: 10
+      minutes: 5
+    response: "已為計時器減少5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/minutes_start_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/minutes_start_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫45秒的計時器減5分鐘
+      - 把45秒的計時器縮短5分鐘
+      - 減少45秒的計時器5分鐘
+    slots:
+      start_seconds: 45
+      minutes: 5
+    response: "已為計時器減少5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/name_hours.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/name_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器減1小時
+      - 把泡麵計時器縮短1小時
+      - 減少泡麵計時器1小時
+    slots:
+      name: "泡麵"
+      hours: 1
+    response: "已為泡麵計時器減少1小時"

--- a/tests/zh-TW/HassDecreaseTimer/name_hours_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/name_hours_minutes.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器減1小時5分鐘
+      - 把泡麵計時器縮短1小時5分鐘
+      - 減少泡麵計時器1小時5分鐘
+    slots:
+      name: "泡麵"
+      hours: 1
+      minutes: 5
+    response: "已為泡麵計時器減少1小時5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/name_hours_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/name_hours_seconds.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器減1小時30秒
+      - 把泡麵計時器縮短1小時30秒
+      - 減少泡麵計時器1小時30秒
+    slots:
+      name: "泡麵"
+      hours: 1
+      seconds: 30
+    response: "已為泡麵計時器減少1小時30秒"

--- a/tests/zh-TW/HassDecreaseTimer/name_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/name_minutes.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器減5分鐘
+      - 把泡麵計時器縮短5分鐘
+      - 減少泡麵計時器5分鐘
+      - 將泡麵計時器縮短5分鐘
+    slots:
+      name: "泡麵"
+      minutes: 5
+    response: "已為泡麵計時器減少5分鐘"

--- a/tests/zh-TW/HassDecreaseTimer/name_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/name_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器減30秒
+      - 把泡麵計時器縮短30秒
+      - 減少泡麵計時器30秒
+    slots:
+      name: "泡麵"
+      seconds: 30
+    response: "已為泡麵計時器減少30秒"

--- a/tests/zh-TW/HassDecreaseTimer/seconds_only.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器減30秒
+      - 把計時器縮短30秒
+      - 減少計時器30秒
+    slots:
+      seconds: 30
+    response: "已為計時器減少30秒"

--- a/tests/zh-TW/HassDecreaseTimer/seconds_start_hours.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/seconds_start_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫2小時的計時器減30秒
+      - 把2小時的計時器縮短30秒
+      - 減少2小時的計時器30秒
+    slots:
+      start_hours: 2
+      seconds: 30
+    response: "已為計時器減少30秒"

--- a/tests/zh-TW/HassDecreaseTimer/seconds_start_minutes.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/seconds_start_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫10分鐘的計時器減30秒
+      - 把10分鐘的計時器縮短30秒
+      - 減少10分鐘的計時器30秒
+    slots:
+      start_minutes: 10
+      seconds: 30
+    response: "已為計時器減少30秒"

--- a/tests/zh-TW/HassDecreaseTimer/seconds_start_seconds.yaml
+++ b/tests/zh-TW/HassDecreaseTimer/seconds_start_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫45秒的計時器減30秒
+      - 把45秒的計時器縮短30秒
+      - 減少45秒的計時器30秒
+    slots:
+      start_seconds: 45
+      seconds: 30
+    response: "已為計時器減少30秒"

--- a/tests/zh-TW/HassIncreaseTimer/area_hours.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/area_hours.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器加1小時
+      - 把廚房的計時器延長1小時
+      - 增加廚房的計時器1小時
+    slots:
+      area: 廚房
+      hours: 1
+    response: "已為計時器增加1小時"

--- a/tests/zh-TW/HassIncreaseTimer/area_minutes.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/area_minutes.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器加5分鐘
+      - 把廚房的計時器延長5分鐘
+      - 增加廚房的計時器5分鐘
+    slots:
+      area: 廚房
+      minutes: 5
+    response: "已為計時器增加5分鐘"

--- a/tests/zh-TW/HassIncreaseTimer/area_seconds.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/area_seconds.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 幫廚房的計時器加30秒
+      - 把廚房的計時器延長30秒
+      - 增加廚房的計時器30秒
+    slots:
+      area: 廚房
+      seconds: 30
+    response: "已為計時器增加30秒"

--- a/tests/zh-TW/HassIncreaseTimer/hours_minutes.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/hours_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器加1小時5分鐘
+      - 把計時器延長1小時5分鐘
+      - 增加計時器1小時5分鐘
+    slots:
+      hours: 1
+      minutes: 5
+    response: "已為計時器增加1小時5分鐘"

--- a/tests/zh-TW/HassIncreaseTimer/hours_only.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/hours_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器加1小時
+      - 把計時器延長1小時
+      - 增加計時器1小時
+      - 將計時器延長1小時
+    slots:
+      hours: 1
+    response: "已為計時器增加1小時"

--- a/tests/zh-TW/HassIncreaseTimer/hours_start_hours.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/hours_start_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫2小時的計時器加1小時
+      - 把2小時的計時器延長1小時
+      - 增加2小時的計時器1小時
+    slots:
+      start_hours: 2
+      hours: 1
+    response: "已為計時器增加1小時"

--- a/tests/zh-TW/HassIncreaseTimer/hours_start_minutes.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/hours_start_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫10分鐘的計時器加1小時
+      - 把10分鐘的計時器延長1小時
+      - 增加10分鐘的計時器1小時
+    slots:
+      start_minutes: 10
+      hours: 1
+    response: "已為計時器增加1小時"

--- a/tests/zh-TW/HassIncreaseTimer/hours_start_seconds.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/hours_start_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫45秒的計時器加1小時
+      - 把45秒的計時器延長1小時
+      - 增加45秒的計時器1小時
+    slots:
+      start_seconds: 45
+      hours: 1
+    response: "已為計時器增加1小時"

--- a/tests/zh-TW/HassIncreaseTimer/minutes_only.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/minutes_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器加5分鐘
+      - 把計時器延長5分鐘
+      - 增加計時器5分鐘
+    slots:
+      minutes: 5
+    response: "已為計時器增加5分鐘"

--- a/tests/zh-TW/HassIncreaseTimer/minutes_seconds.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/minutes_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器加5分鐘30秒
+      - 把計時器延長5分鐘30秒
+      - 增加計時器5分鐘30秒
+    slots:
+      minutes: 5
+      seconds: 30
+    response: "已為計時器增加5分鐘30秒"

--- a/tests/zh-TW/HassIncreaseTimer/minutes_start_hours.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/minutes_start_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫2小時的計時器加5分鐘
+      - 把2小時的計時器延長5分鐘
+      - 增加2小時的計時器5分鐘
+    slots:
+      start_hours: 2
+      minutes: 5
+    response: "已為計時器增加5分鐘"

--- a/tests/zh-TW/HassIncreaseTimer/minutes_start_minutes.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/minutes_start_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫10分鐘的計時器加5分鐘
+      - 把10分鐘的計時器延長5分鐘
+      - 增加10分鐘的計時器5分鐘
+    slots:
+      start_minutes: 10
+      minutes: 5
+    response: "已為計時器增加5分鐘"

--- a/tests/zh-TW/HassIncreaseTimer/minutes_start_seconds.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/minutes_start_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫45秒的計時器加5分鐘
+      - 把45秒的計時器延長5分鐘
+      - 增加45秒的計時器5分鐘
+    slots:
+      start_seconds: 45
+      minutes: 5
+    response: "已為計時器增加5分鐘"

--- a/tests/zh-TW/HassIncreaseTimer/name_hours.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/name_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器加1小時
+      - 把泡麵計時器延長1小時
+      - 增加泡麵計時器1小時
+    slots:
+      name: "泡麵"
+      hours: 1
+    response: "已為泡麵計時器增加1小時"

--- a/tests/zh-TW/HassIncreaseTimer/name_minutes.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/name_minutes.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器加5分鐘
+      - 把泡麵計時器延長5分鐘
+      - 增加泡麵計時器5分鐘
+      - 將泡麵計時器延長5分鐘
+    slots:
+      name: "泡麵"
+      minutes: 5
+    response: "已為泡麵計時器增加5分鐘"

--- a/tests/zh-TW/HassIncreaseTimer/name_seconds.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/name_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫泡麵計時器加30秒
+      - 把泡麵計時器延長30秒
+      - 增加泡麵計時器30秒
+    slots:
+      name: "泡麵"
+      seconds: 30
+    response: "已為泡麵計時器增加30秒"

--- a/tests/zh-TW/HassIncreaseTimer/seconds_only.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫計時器加30秒
+      - 把計時器延長30秒
+      - 增加計時器30秒
+    slots:
+      seconds: 30
+    response: "已為計時器增加30秒"

--- a/tests/zh-TW/HassIncreaseTimer/seconds_start_hours.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/seconds_start_hours.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫2小時的計時器加30秒
+      - 把2小時的計時器延長30秒
+      - 增加2小時的計時器30秒
+    slots:
+      start_hours: 2
+      seconds: 30
+    response: "已為計時器增加30秒"

--- a/tests/zh-TW/HassIncreaseTimer/seconds_start_minutes.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/seconds_start_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫10分鐘的計時器加30秒
+      - 把10分鐘的計時器延長30秒
+      - 增加10分鐘的計時器30秒
+    slots:
+      start_minutes: 10
+      seconds: 30
+    response: "已為計時器增加30秒"

--- a/tests/zh-TW/HassIncreaseTimer/seconds_start_seconds.yaml
+++ b/tests/zh-TW/HassIncreaseTimer/seconds_start_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 幫45秒的計時器加30秒
+      - 把45秒的計時器延長30秒
+      - 增加45秒的計時器30秒
+    slots:
+      start_seconds: 45
+      seconds: 30
+    response: "已為計時器增加30秒"

--- a/tests/zh-TW/HassPauseTimer/area_only.yaml
+++ b/tests/zh-TW/HassPauseTimer/area_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 暫停廚房的計時器
+      - 暫停廚房計時器
+    slots:
+      area: 廚房
+    response: "計時器已暫停"

--- a/tests/zh-TW/HassPauseTimer/default.yaml
+++ b/tests/zh-TW/HassPauseTimer/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 暫停計時器
+      - 暫停我的計時器
+    response: "計時器已暫停"

--- a/tests/zh-TW/HassPauseTimer/hours_only.yaml
+++ b/tests/zh-TW/HassPauseTimer/hours_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 暫停2小時的計時器
+      - 暫停那個2小時計時器
+    slots:
+      start_hours: 2
+    response: "計時器已暫停"

--- a/tests/zh-TW/HassPauseTimer/minutes_only.yaml
+++ b/tests/zh-TW/HassPauseTimer/minutes_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 暫停10分鐘的計時器
+      - 暫停那個10分鐘計時器
+    slots:
+      start_minutes: 10
+    response: "計時器已暫停"

--- a/tests/zh-TW/HassPauseTimer/name_only.yaml
+++ b/tests/zh-TW/HassPauseTimer/name_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 暫停泡麵計時器
+      - 暫停計時器叫做泡麵
+    slots:
+      name: "泡麵"
+    response: "計時器已暫停"

--- a/tests/zh-TW/HassPauseTimer/seconds_only.yaml
+++ b/tests/zh-TW/HassPauseTimer/seconds_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 暫停45秒的計時器
+      - 暫停那個45秒計時器
+    slots:
+      start_seconds: 45
+    response: "計時器已暫停"

--- a/tests/zh-TW/HassStartTimer/command_hours.yaml
+++ b/tests/zh-TW/HassStartTimer/command_hours.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 2小時後關燈
+      - 等2小時之後關燈
+      - 倒數2小時後關燈
+      - 計時2小時後關燈
+      - 倒數2小時關燈
+    slots:
+      hours: 2
+      conversation_command: "關燈"
+    response: "將在2小時後執行"

--- a/tests/zh-TW/HassStartTimer/command_hours_minutes.yaml
+++ b/tests/zh-TW/HassStartTimer/command_hours_minutes.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 1小時30分鐘後關燈
+      - 等1小時30分鐘之後關燈
+      - 倒數1小時30分鐘後關燈
+      - 倒數1小時30分鐘關燈
+    slots:
+      hours: 1
+      minutes: 30
+      conversation_command: "關燈"
+    response: "將在1小時30分鐘後執行"

--- a/tests/zh-TW/HassStartTimer/command_hours_minutes_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/command_hours_minutes_seconds.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 1小時5分鐘30秒後關燈
+      - 等1小時5分鐘30秒之後關燈
+      - 倒數1小時5分鐘30秒後關燈
+      - 倒數1小時5分鐘30秒關燈
+    slots:
+      hours: 1
+      minutes: 5
+      seconds: 30
+      conversation_command: "關燈"
+    response: "將在1小時5分鐘30秒後執行"

--- a/tests/zh-TW/HassStartTimer/command_hours_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/command_hours_seconds.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 1小時20秒後關燈
+      - 等1小時20秒之後關燈
+      - 倒數1小時20秒後關燈
+      - 計時1小時20秒後關燈
+      - 倒數1小時20秒關燈
+    slots:
+      hours: 1
+      seconds: 20
+      conversation_command: "關燈"
+    response: "將在1小時20秒後執行"

--- a/tests/zh-TW/HassStartTimer/command_minutes.yaml
+++ b/tests/zh-TW/HassStartTimer/command_minutes.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 5分鐘後關燈
+      - 等5分鐘之後關燈
+      - 倒數5分鐘後關燈
+      - 計時5分鐘後關燈
+      - 倒數5分鐘關燈
+    slots:
+      minutes: 5
+      conversation_command: "關燈"
+    response: "將在5分鐘後執行"

--- a/tests/zh-TW/HassStartTimer/command_minutes_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/command_minutes_seconds.yaml
@@ -1,0 +1,13 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 5分鐘30秒後關燈
+      - 等5分鐘30秒之後關燈
+      - 倒數5分鐘30秒後關燈
+      - 計時5分鐘30秒後關燈
+      - 倒數5分鐘30秒關燈
+    slots:
+      minutes: 5
+      seconds: 30
+      conversation_command: "關燈"
+    response: "將在5分鐘30秒後執行"

--- a/tests/zh-TW/HassStartTimer/command_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/command_seconds.yaml
@@ -1,0 +1,19 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 45秒後關燈
+      - 等45秒之後關燈
+      - 倒數45秒後關燈
+      - 計時45秒後關燈
+      - 倒數45秒關燈
+    slots:
+      seconds: 45
+      conversation_command: "關燈"
+    response: "將在45秒後執行"
+  - sentences:
+      - 倒數三十秒打開入口燈
+      - 三十秒後打開入口燈
+    slots:
+      seconds: 30
+      conversation_command: "打開入口燈"
+    response: "將在三十秒後執行"

--- a/tests/zh-TW/HassStartTimer/hours_minutes.yaml
+++ b/tests/zh-TW/HassStartTimer/hours_minutes.yaml
@@ -1,0 +1,25 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個1小時30分鐘的計時器
+      - 設定計時器1小時30分鐘
+      - 1小時30分鐘計時器
+      - 倒數1小時30分鐘
+    slots:
+      hours: 1
+      minutes: 30
+    response: "已設定1小時30分鐘的計時器"
+  - sentences:
+      - 設定一個1個半小時的計時器
+      - 倒數1個半小時
+    slots:
+      hours: 1
+      minutes: 30
+    response: "已設定1小時30分鐘的計時器"
+  - sentences:
+      - 設定一個半小時的計時器
+      - 倒數一個半小時
+    slots:
+      hours: 1
+      minutes: 30
+    response: "已設定一小時30分鐘的計時器"

--- a/tests/zh-TW/HassStartTimer/hours_minutes_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/hours_minutes_seconds.yaml
@@ -1,0 +1,12 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個1小時5分鐘30秒的計時器
+      - 設定計時器1小時5分鐘30秒
+      - 1小時5分鐘30秒計時器
+      - 倒數1小時5分鐘30秒
+    slots:
+      hours: 1
+      minutes: 5
+      seconds: 30
+    response: "已設定1小時5分鐘30秒的計時器"

--- a/tests/zh-TW/HassStartTimer/hours_only.yaml
+++ b/tests/zh-TW/HassStartTimer/hours_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個2小時的計時器
+      - 設定計時器2小時
+      - 2小時計時器
+      - 倒數2小時
+    slots:
+      hours: 2
+    response: "已設定2小時的計時器"

--- a/tests/zh-TW/HassStartTimer/hours_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/hours_seconds.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個1小時20秒的計時器
+      - 設定計時器1小時20秒
+      - 1小時20秒計時器
+      - 倒數1小時20秒
+    slots:
+      hours: 1
+      seconds: 20
+    response: "已設定1小時20秒的計時器"

--- a/tests/zh-TW/HassStartTimer/minutes_only.yaml
+++ b/tests/zh-TW/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,16 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個5分鐘的計時器
+      - 設定計時器5分鐘
+      - 5分鐘計時器
+      - 倒數5分鐘
+    slots:
+      minutes: 5
+    response: "已設定5分鐘的計時器"
+  - sentences:
+      - 設定半個小時的計時器
+      - 倒數半個小時
+    slots:
+      minutes: 30
+    response: "已設定30分鐘的計時器"

--- a/tests/zh-TW/HassStartTimer/minutes_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/minutes_seconds.yaml
@@ -1,0 +1,18 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個5分鐘30秒的計時器
+      - 設定計時器5分鐘30秒
+      - 5分鐘30秒計時器
+      - 倒數5分鐘30秒
+    slots:
+      minutes: 5
+      seconds: 30
+    response: "已設定5分鐘30秒的計時器"
+  - sentences:
+      - 設定一個5分半的計時器
+      - 倒數5分半
+    slots:
+      minutes: 5
+      seconds: 30
+    response: "已設定5分鐘30秒的計時器"

--- a/tests/zh-TW/HassStartTimer/name_hours.yaml
+++ b/tests/zh-TW/HassStartTimer/name_hours.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個2小時的泡麵計時器
+      - 設定2小時的計時器叫做泡麵
+    slots:
+      hours: 2
+      name: "泡麵"
+    response: "已設定2小時的泡麵計時器"

--- a/tests/zh-TW/HassStartTimer/name_hours_minutes.yaml
+++ b/tests/zh-TW/HassStartTimer/name_hours_minutes.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個1小時30分鐘的泡麵計時器
+      - 設定1小時30分鐘的計時器叫做泡麵
+    slots:
+      hours: 1
+      minutes: 30
+      name: "泡麵"
+    response: "已設定1小時30分鐘的泡麵計時器"

--- a/tests/zh-TW/HassStartTimer/name_hours_minutes_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/name_hours_minutes_seconds.yaml
@@ -1,0 +1,11 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個1小時5分鐘30秒的泡麵計時器
+      - 設定1小時5分鐘30秒的計時器叫做泡麵
+    slots:
+      hours: 1
+      minutes: 5
+      seconds: 30
+      name: "泡麵"
+    response: "已設定1小時5分鐘30秒的泡麵計時器"

--- a/tests/zh-TW/HassStartTimer/name_hours_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/name_hours_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個1小時20秒的泡麵計時器
+      - 設定1小時20秒的計時器叫做泡麵
+    slots:
+      hours: 1
+      seconds: 20
+      name: "泡麵"
+    response: "已設定1小時20秒的泡麵計時器"

--- a/tests/zh-TW/HassStartTimer/name_minutes.yaml
+++ b/tests/zh-TW/HassStartTimer/name_minutes.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個5分鐘的泡麵計時器
+      - 設定5分鐘的計時器叫做泡麵
+    slots:
+      minutes: 5
+      name: "泡麵"
+    response: "已設定5分鐘的泡麵計時器"

--- a/tests/zh-TW/HassStartTimer/name_minutes_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/name_minutes_seconds.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個5分鐘30秒的泡麵計時器
+      - 設定5分鐘30秒的計時器叫做泡麵
+    slots:
+      minutes: 5
+      seconds: 30
+      name: "泡麵"
+    response: "已設定5分鐘30秒的泡麵計時器"

--- a/tests/zh-TW/HassStartTimer/name_seconds.yaml
+++ b/tests/zh-TW/HassStartTimer/name_seconds.yaml
@@ -1,0 +1,9 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個45秒的泡麵計時器
+      - 設定45秒的計時器叫做泡麵
+    slots:
+      seconds: 45
+      name: "泡麵"
+    response: "已設定45秒的泡麵計時器"

--- a/tests/zh-TW/HassStartTimer/seconds_only.yaml
+++ b/tests/zh-TW/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 設定一個45秒的計時器
+      - 設定計時器45秒
+      - 45秒計時器
+      - 倒數45秒
+    slots:
+      seconds: 45
+    response: "已設定45秒的計時器"

--- a/tests/zh-TW/HassTimerStatus/area_only.yaml
+++ b/tests/zh-TW/HassTimerStatus/area_only.yaml
@@ -1,0 +1,18 @@
+language: zh-TW
+areas:
+  - name: 廚房
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - 廚房的計時器的狀態
+      - 廚房的計時器還剩多久
+      - 廚房計時器還有多久
+    slots:
+      area: 廚房
+    response: "計時器還剩5分鐘"

--- a/tests/zh-TW/HassTimerStatus/default.yaml
+++ b/tests/zh-TW/HassTimerStatus/default.yaml
@@ -1,0 +1,16 @@
+language: zh-TW
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - 計時器的狀態
+      - 我的計時器還剩多久
+      - 計時器還有多久
+      - 計時器還有多少時間
+      - 計時器還要多少時間
+    response: "計時器還剩5分鐘"

--- a/tests/zh-TW/HassTimerStatus/hours_only.yaml
+++ b/tests/zh-TW/HassTimerStatus/hours_only.yaml
@@ -1,0 +1,16 @@
+language: zh-TW
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_hours: 2
+tests:
+  - sentences:
+      - 2小時的計時器的狀態
+      - 2小時的計時器還剩多久
+      - 那個2小時計時器還有多久
+    slots:
+      start_hours: 2
+    response: "計時器還剩5分鐘"

--- a/tests/zh-TW/HassTimerStatus/minutes_only.yaml
+++ b/tests/zh-TW/HassTimerStatus/minutes_only.yaml
@@ -1,0 +1,16 @@
+language: zh-TW
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - 5分鐘的計時器的狀態
+      - 5分鐘的計時器還剩多久
+      - 那個5分鐘計時器還有多久
+    slots:
+      start_minutes: 5
+    response: "計時器還剩5分鐘"

--- a/tests/zh-TW/HassTimerStatus/name_only.yaml
+++ b/tests/zh-TW/HassTimerStatus/name_only.yaml
@@ -1,0 +1,17 @@
+language: zh-TW
+timers:
+  - is_active: true
+    name: 泡麵
+    total_seconds_left: 1500
+    rounded_hours_left: 0
+    rounded_minutes_left: 25
+    rounded_seconds_left: 0
+    start_minutes: 25
+tests:
+  - sentences:
+      - 泡麵計時器的狀態
+      - 泡麵計時器還剩多久
+      - 泡麵的計時器還有多久
+    slots:
+      name: 泡麵
+    response: "計時器還剩25分鐘"

--- a/tests/zh-TW/HassTimerStatus/seconds_only.yaml
+++ b/tests/zh-TW/HassTimerStatus/seconds_only.yaml
@@ -1,0 +1,16 @@
+language: zh-TW
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_seconds: 45
+tests:
+  - sentences:
+      - 45秒的計時器的狀態
+      - 45秒的計時器還剩多久
+      - 那個45秒計時器還有多久
+    slots:
+      start_seconds: 45
+    response: "計時器還剩5分鐘"

--- a/tests/zh-TW/HassUnpauseTimer/area_only.yaml
+++ b/tests/zh-TW/HassUnpauseTimer/area_only.yaml
@@ -1,0 +1,10 @@
+language: zh-TW
+areas:
+  - name: 廚房
+tests:
+  - sentences:
+      - 繼續廚房的計時器
+      - 讓廚房的計時器繼續計時
+    slots:
+      area: 廚房
+    response: "計時器繼續計時"

--- a/tests/zh-TW/HassUnpauseTimer/default.yaml
+++ b/tests/zh-TW/HassUnpauseTimer/default.yaml
@@ -1,0 +1,6 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 繼續計時器
+      - 讓計時器繼續計時
+    response: "計時器繼續計時"

--- a/tests/zh-TW/HassUnpauseTimer/hours_only.yaml
+++ b/tests/zh-TW/HassUnpauseTimer/hours_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 繼續2小時的計時器
+      - 讓2小時的計時器繼續計時
+    slots:
+      start_hours: 2
+    response: "計時器繼續計時"

--- a/tests/zh-TW/HassUnpauseTimer/minutes_only.yaml
+++ b/tests/zh-TW/HassUnpauseTimer/minutes_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 繼續10分鐘的計時器
+      - 讓10分鐘的計時器繼續計時
+    slots:
+      start_minutes: 10
+    response: "計時器繼續計時"

--- a/tests/zh-TW/HassUnpauseTimer/name_only.yaml
+++ b/tests/zh-TW/HassUnpauseTimer/name_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 繼續泡麵計時器
+      - 讓泡麵計時器繼續計時
+    slots:
+      name: "泡麵"
+    response: "計時器繼續計時"

--- a/tests/zh-TW/HassUnpauseTimer/seconds_only.yaml
+++ b/tests/zh-TW/HassUnpauseTimer/seconds_only.yaml
@@ -1,0 +1,8 @@
+language: zh-TW
+tests:
+  - sentences:
+      - 繼續45秒的計時器
+      - 讓45秒的計時器繼續計時
+    slots:
+      start_seconds: 45
+    response: "計時器繼續計時"


### PR DESCRIPTION
All eight timer intents in the slot-combination format, 93 combinations, reaching parity with `en` — plus lists/rules for the timer vocabulary and the three timer error responses.

| Intent | Slot combinations |
| --- | --- |
| `HassStartTimer` | 21 |
| `HassCancelTimer` | 6 |
| `HassCancelAllTimers` | 2 |
| `HassIncreaseTimer` | 20 |
| `HassDecreaseTimer` | 26 |
| `HassPauseTimer` | 6 |
| `HassUnpauseTimer` | 6 |
| `HassTimerStatus` | 6 |

`validate` clean, 262 tests pass, `check_overmatch` reports 0 cross-intent over-matches over 716 sentences, `prettier` clean.