### PR TITLE
[DE] Add imperative templates for HassVacuumCleanArea

### DIFF
--- a/sentences/de/HassVacuumCleanArea/area_only.yaml
+++ b/sentences/de/HassVacuumCleanArea/area_only.yaml
@@ -7,5 +7,6 @@ language: "de"
 data:
   - sentences:
       - "<area> (reinigen|putzen|[staub[ ]]saugen|wischen)"
+      - "<saugen> <area>"
     example: "das Wohnzimmer reinigen"
     response: "default"

--- a/sentences/de/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/de/HassVacuumCleanArea/context_area.yaml
@@ -7,5 +7,6 @@ language: "de"
 data:
   - sentences:
       - "<hier> (reinigen|putzen|[staub[ ]]saugen|wischen)"
+      - "<saugen> <hier>"
     example: "hier staubsaugen"
     response: "default"

--- a/tests/de/HassVacuumCleanArea/area_only.yaml
+++ b/tests/de/HassVacuumCleanArea/area_only.yaml
@@ -12,6 +12,11 @@ tests:
       - das Wohnzimmer staub saugen
       - das Wohnzimmer staubsaugen
       - das Wohnzimmer wischen
+      - sauge das Wohnzimmer
+      - reinige das Wohnzimmer
+      - staubsauge das Wohnzimmer
+      - putze im Wohnzimmer
+      - wische das Wohnzimmer
     slots:
       area: Wohnzimmer
     response: Wohnzimmer wird gereinigt

--- a/tests/de/HassVacuumCleanArea/context_area.yaml
+++ b/tests/de/HassVacuumCleanArea/context_area.yaml
@@ -10,4 +10,7 @@ tests:
       - hier staubsaugen
       - in diesem Raum staubsaugen
       - dieses Zimmer staubsaugen
+      - sauge hier
+      - reinige hier
+      - staubsauge in diesem Raum
     response: "__context_area__ wird gereinigt"


### PR DESCRIPTION
German `HassVacuumCleanArea` only matched the verb-final word order, for example "das Wohnzimmer reinigen". The imperative that people actually say to a voice assistant, "sauge das Wohnzimmer" or "sauge hier", did not match at all.

This adds one imperative template to `area_only` and one to `context_area`, both reusing the existing `<saugen>` rule from `rules/de/common.yaml`, plus test sentences for them. English has the mirror image: it ships the imperative and not the infinitive, so this gives German both.
