### PR TITLE
[DE] Add "Welche Temperatur" phrasings for HassClimateGetTemperature

### DIFF
--- a/sentences/de/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/de/HassClimateGetTemperature/area_only.yaml
@@ -11,6 +11,7 @@ data:
       - "Wie[ (hoch|niedrig)] ist die Temperatur <von_dem> Thermostat <area>"
       - "Wie[ (hoch|niedrig)] ist die Temperatur des Thermostat[s] <area>"
       - "Wie (warm|kalt) ist [es ]<area>"
+      - "Welche Temperatur (hat[ es]|haben wir) <area>"
       - "<wieviel> Grad (hat|sind) [es ]<area>"
       - "Temperatur <area>"
       - "<area> Temperatur"

--- a/sentences/de/HassClimateGetTemperature/default.yaml
+++ b/sentences/de/HassClimateGetTemperature/default.yaml
@@ -9,6 +9,7 @@ data:
       - "Wie[ (hoch|niedrig)] ist die Temperatur[ <hier>]"
       - "Wie[ (hoch|niedrig)] ist <hier> die Temperatur"
       - "Wie (warm|kalt) ist es[ <hier>]"
+      - "Welche Temperatur (hat[ es]|haben wir)[ <hier>]"
       - "<wieviel> Grad (hat|sind) es[ <hier>]"
       - "Temperatur[ <hier>]"
     example: "Wie hoch ist die Temperatur"

--- a/sentences/de/HassClimateGetTemperature/floor_only.yaml
+++ b/sentences/de/HassClimateGetTemperature/floor_only.yaml
@@ -11,6 +11,7 @@ data:
       - "Wie[ (hoch|niedrig)] ist die Temperatur <von_dem> Thermostat <floor>"
       - "Wie[ (hoch|niedrig)] ist die Temperatur des Thermostat[s] <floor>"
       - "Wie (warm|kalt) ist [es ]<floor>"
+      - "Welche Temperatur (hat[ es]|haben wir) <floor>"
       - "<wieviel> Grad (hat|sind) [es ]<floor>"
       - "Temperatur <floor>"
       - "<floor> Temperatur"

--- a/sentences/de/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/de/HassClimateGetTemperature/name_only.yaml
@@ -9,6 +9,7 @@ data:
       - "Wie[ (hoch|niedrig)] ist die Temperatur[ <von_dem>] [<artikel_bestimmt> ]{name}"
       - "Wie[ (hoch|niedrig)] ist die Temperatur des [<artikel_bestimmt> ]{name}[s]"
       - "Wie (warm|kalt) ist [<artikel_bestimmt> ]{name}[ [ein]gestellt]"
+      - "Welche Temperatur hat [<artikel_bestimmt> ]{name}"
       - "Temperatur [<artikel_bestimmt> ]{name}"
       - "[<artikel_bestimmt> ]{name} Temperatur"
     example: "Wie warm ist das Wohnzimmerthermostat"

--- a/tests/de/HassClimateGetTemperature/area_only.yaml
+++ b/tests/de/HassClimateGetTemperature/area_only.yaml
@@ -49,6 +49,9 @@ tests:
       - "Wie warm ist das Wohnzimmer?"
       - "Temperatur Wohnzimmer"
       - "Wohnzimmer Temperatur"
+      - "Welche Temperatur hat das Wohnzimmer?"
+      - "Welche Temperatur hat es im Wohnzimmer?"
+      - "Welche Temperatur haben wir im Wohnzimmer?"
     slots:
       area: "Wohnzimmer"
     response: "22 Grad"

--- a/tests/de/HassClimateGetTemperature/default.yaml
+++ b/tests/de/HassClimateGetTemperature/default.yaml
@@ -33,6 +33,8 @@ tests:
       - "Temperatur"
       - "Temperatur hier"
       - "Temperatur in diesem Raum"
+      - "Welche Temperatur haben wir?"
+      - "Welche Temperatur hat es hier?"
     response: "22 Grad"
   - sentences:
       - "Auf wie viel Grad ist die Heizung hier eingestellt?"

--- a/tests/de/HassClimateGetTemperature/floor_only.yaml
+++ b/tests/de/HassClimateGetTemperature/floor_only.yaml
@@ -33,6 +33,8 @@ tests:
       - "Wie warm ist das Erdgeschoss?"
       - "Temperatur Erdgeschoss"
       - "Erdgeschoss Temperatur"
+      - "Welche Temperatur hat das Erdgeschoss?"
+      - "Welche Temperatur haben wir im Erdgeschoss?"
     slots:
       floor: "Erdgeschoss"
     response: "22 Grad"

--- a/tests/de/HassClimateGetTemperature/name_only.yaml
+++ b/tests/de/HassClimateGetTemperature/name_only.yaml
@@ -23,6 +23,7 @@ tests:
       - "wie warm ist das Wohnzimmerthermostat eingestellt"
       - "Temperatur Wohnzimmerthermostat"
       - "das Wohnzimmerthermostat Temperatur"
+      - "Welche Temperatur hat das Wohnzimmerthermostat?"
     slots:
       name: "Wohnzimmerthermostat"
     response: "22 Grad"


### PR DESCRIPTION
Asking "Welche Temperatur hat das Wohnzimmer?" did not match anything in German. The intent already covers "Wie hoch ist die Temperatur ...", "Wie warm ist es ..." and the bare "Temperatur ...", but not the "Welche Temperatur ..." question form, which is just as common in spoken German.

This adds one template to each of the four slot combinations, plus test sentences for them. The target temperature block is untouched, so "Auf welche Temperatur ist die Heizung eingestellt?" still answers with the target temperature and not the current one.
