### PR TITLE
add rules and lists directory to test script

### DIFF
--- a/script/test_file
+++ b/script/test_file
@@ -21,6 +21,8 @@ def main():
         "sentences",
         "responses",
         "tests",
+        "rules",
+        "lists",
     ):
         print("Error: File must be in the sentences, responses or tests directory")
         sys.exit(2)

--- a/script/test_file
+++ b/script/test_file
@@ -24,7 +24,9 @@ def main():
         "rules",
         "lists",
     ):
-        print("Error: File must be in the sentences, responses or tests directory")
+        print(
+            "Error: File must be in the sentences, responses, tests, rules, or lists directory"
+        )
         sys.exit(2)
 
     language = target_path.parts[1]


### PR DESCRIPTION
follow-up for #4004 
this PR adds the rules and lists directory to the test_file script.
before the transition to the new structure it was possible to test lists and rules with this script so I think it makes sense to add this functionality again.