### PR TITLE
CI: update language labeler to support tests/ and lists/ directory changes

### DIFF
--- a/.github/workflows/ci_lang_labels.yaml
+++ b/.github/workflows/ci_lang_labels.yaml
@@ -33,7 +33,7 @@ jobs:
             }
 
             // Your regex
-            const LanguageFileRegex = /(?<section>sentences|responses|tests)\/(?<language_code>[a-z]{2}(-[a-zA-Z]{2,4})?)\/(?<intent>.+)\.yaml/;
+            const LanguageFileRegex = /(?<section>sentences|responses|tests|rules|lists)\/(?<language_code>[a-z]{2}(-[a-zA-Z]{2,4})?)\/(?<intent>.+)\.yaml/;
 
             // Collect changed files (no checkout required)
             const files = [];


### PR DESCRIPTION
currently the language labeler does not assign language labels when there are changes in the lists/ and/or rules/ directory only.