### PR TITLE
Revert "Add optional `id` slot to timer change intents"

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -2213,9 +2213,6 @@ HassCancelTimer:
     area:
       description: "Area of the device used to start the timer"
       required: false
-    id:
-      description: "ID of the timer"
-      required: false
   slot_combinations:
     # -------------------------------------------------------------------------
     # Usable slot combinations
@@ -2276,15 +2273,6 @@ HassCancelTimer:
         - "start_seconds"
       example: "cancel the 30 second timer"
 
-    # -------------------------------------------------------------------------
-
-    id_only:
-      description: "Cancels a timer by ID"
-      importance: "usable"
-      slots:
-        - "id"
-      example: "cancel the timer with ID 12345"
-
 # -----------------------------------------------------------------------------
 
 HassIncreaseTimer:
@@ -2315,9 +2303,6 @@ HassIncreaseTimer:
       required: false
     area:
       description: "Area of the device used to start the timer"
-      required: false
-    id:
-      description: "ID of the timer"
       required: false
   slot_combinations:
     hours_only:
@@ -2402,44 +2387,6 @@ HassIncreaseTimer:
       wildcard_slots:
         - "name"
       example: "add 30 seconds to the pizza timer"
-
-    # -------------------------------------------------------------------------
-    # id
-    # -------------------------------------------------------------------------
-
-    id_hours:
-      description: "Add hours to a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "hours"
-      wildcard_slots:
-        - "id"
-      example: "add 1 hour to the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
-
-    id_minutes:
-      description: "Add minutes to a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "minutes"
-      wildcard_slots:
-        - "id"
-      example: "add 10 minutes to the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
-
-    id_seconds:
-      description: "Add seconds to a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "seconds"
-      wildcard_slots:
-        - "id"
-      example: "add 30 seconds to the timer with ID 12345"
 
     # -------------------------------------------------------------------------
     # area
@@ -2599,9 +2546,6 @@ HassDecreaseTimer:
       required: false
     area:
       description: "Area of the device used to start the timer"
-      required: false
-    id:
-      description: "ID of the timer"
       required: false
   slot_combinations:
     hours_only:
@@ -2789,71 +2733,6 @@ HassDecreaseTimer:
       example: "remove 1 hour and 30 seconds from the kitchen timer"
 
     # -------------------------------------------------------------------------
-    # id
-    # -------------------------------------------------------------------------
-
-    id_hours:
-      description: "Remove hours from a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "hours"
-      example: "remove 1 hour from the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
-
-    id_minutes:
-      description: "Remove minutes from a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "minutes"
-      example: "remove 10 minutes from the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
-
-    id_seconds:
-      description: "Remove seconds from a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "seconds"
-      example: "remove 30 seconds from the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
-
-    id_minutes_seconds:
-      description: "Remove minutes and seconds from a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "minutes"
-        - "seconds"
-      example: "remove 10 minutes and 30 seconds from the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
-
-    id_hours_minutes:
-      description: "Remove hours and minutes from a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "hours"
-        - "minutes"
-      example: "remove 1 hour and 10 minutes from the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
-
-    id_hours_seconds:
-      description: "Remove hours and seconds from a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-        - "hours"
-        - "seconds"
-      example: "remove 1 hour and 30 seconds from the timer with ID 12345"
-
-    # -------------------------------------------------------------------------
     # hours + start
     # -------------------------------------------------------------------------
 
@@ -2971,9 +2850,6 @@ HassPauseTimer:
     area:
       description: "Area of the device used to start the timer"
       required: false
-    id:
-      description: "ID of the timer"
-      required: false
   slot_combinations:
     default:
       description: "Pause the most recent timer"
@@ -3000,15 +2876,6 @@ HassPauseTimer:
       slots:
         - "area"
       example: "pause the kitchen timer"
-
-    # -------------------------------------------------------------------------
-
-    id_only:
-      description: "Pause a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-      example: "pause the timer with ID 12345"
 
     # -------------------------------------------------------------------------
 
@@ -3059,9 +2926,6 @@ HassUnpauseTimer:
     area:
       description: "Area of the device used to start the timer"
       required: false
-    id:
-      description: "ID of the timer"
-      required: false
   slot_combinations:
     default:
       description: "Resume the most recent timer"
@@ -3088,15 +2952,6 @@ HassUnpauseTimer:
       slots:
         - "area"
       example: "resume the kitchen timer"
-
-    # -------------------------------------------------------------------------
-
-    id_only:
-      description: "Resume a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-      example: "resume the timer with ID 12345"
 
     # -------------------------------------------------------------------------
 
@@ -3147,9 +3002,6 @@ HassTimerStatus:
     area:
       description: "Area of the device used to start the timer"
       required: false
-    id:
-      description: "ID of the timer"
-      required: false
   slot_combinations:
     # -------------------------------------------------------------------------
     # Usable slot combinations
@@ -3182,15 +3034,6 @@ HassTimerStatus:
       slots:
         - "area"
       example: "how much time is left on the kitchen timer"
-
-    # -------------------------------------------------------------------------
-
-    id_only:
-      description: "Get status of a timer by ID"
-      importance: "complete"
-      slots:
-        - "id"
-      example: "how much time is left on the timer with ID 12345"
 
     # -------------------------------------------------------------------------
 


### PR DESCRIPTION
Reverts OHF-Voice/intents#3735

This is not appropriate for this repo. People do not speak timer ids.