### PR TITLE
[ca] Add HassClimateGetTemperature name_only sentences

### DIFF
--- a/sentences/ca/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/ca/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,15 @@
+---
+# HassClimateGetTemperature - name_only
+# example: quina és la temperatura del termòstat oficina
+# slots: {name}
+
+language: "ca"
+data:
+  - sentences:
+      - "quina és la <temp> [<actual>] [de|del|de la|d'] [<pronom_singular>]{name}"
+      - "quina <temp> (marca|té) [<actual>] [<pronom_singular>]{name}"
+      - "a quina <temp> està [<actual>] [<pronom_singular>]{name}"
+    example: "quina és la temperatura del termòstat oficina"
+    name_domains:
+      - "climate"
+    response: "default"

--- a/tests/ca/HassClimateGetTemperature/name_only.yaml
+++ b/tests/ca/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,20 @@
+---
+# HassClimateGetTemperature - name_only
+
+language: ca
+entities:
+  - name: Termòstat oficina
+    domain: climate
+    state: "22"
+    attributes:
+      current_temperature: 22
+tests:
+  - sentences:
+      - quina és la temperatura del termòstat oficina?
+      - quina és la temperatura actual del termòstat oficina?
+      - quina temperatura marca el termòstat oficina?
+      - quina temperatura té ara el termòstat oficina?
+      - a quina temperatura està el termòstat oficina?
+    slots:
+      name: Termòstat oficina
+    response: 22 graus


### PR DESCRIPTION
Adds the `name_only` slot combination for `HassClimateGetTemperature` in Catalan.

This is one of the combinations marked **usable** in `intents.yaml` (via `name_domains.usable: [climate]`), and it was the only usable combination still missing for `ca`.

## Sentences

Templates reuse the existing `<temp>`, `<actual>` and `<pronom_singular>` expansion rules from `rules/ca/`, and mirror the structure of the existing `area_only.yaml`:

```
quina és la <temp> [<actual>] [de|del|de la|d'] [<pronom_singular>]{name}
quina <temp> (marca|té) [<actual>] [<pronom_singular>]{name}
a quina <temp> està [<actual>] [<pronom_singular>]{name}
```

## Verification

- `python -m script.intentfest validate --language ca` → All good!
- `pytest tests --language ca` → 262 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)