### PR TITLE
[da] Add HassLightSet name_temperature sentences

### DIFF
--- a/lists/da/lights.yaml
+++ b/lists/da/lights.yaml
@@ -6,6 +6,16 @@ lists:
         out: 100
       - in: (lavest[e]|mindst[e]|minimal[e]|minimum)
         out: 1
+  color_temperature_names:
+    values:
+      - in: (levende lys|stearinlys)
+        out: 1900
+      - in: varm[t] hvid[t]
+        out: 2700
+      - in: kold[t] hvid[t]
+        out: 4000
+      - in: dagslys
+        out: 6500
   color:
     values:
       - in: hvid[t]

--- a/responses/da/HassLightSet.yaml
+++ b/responses/da/HassLightSet.yaml
@@ -4,3 +4,4 @@ responses:
     HassLightSet:
       brightness: "Lysstyrke indstillet"
       color: "Farve indstillet"
+      temperature: "Farvetemperatur indstillet"

--- a/sentences/da/HassLightSet/name_temperature.yaml
+++ b/sentences/da/HassLightSet/name_temperature.yaml
@@ -1,0 +1,18 @@
+---
+# HassLightSet - name_temperature
+# example: sæt farvetemperaturen på soveværelseslyset til 2700 kelvin
+# slots:
+# - {name}
+# - {temperature}
+
+language: "da"
+data:
+  - sentences:
+      - "<sæt_numerisk_værdi> <navn> [farve]temperatur [til] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<sæt_numerisk_værdi> <navn> [farve]temperatur [til] {color_temperature_names:temperature}"
+      - "<sæt_numerisk_værdi> [farve]temperatur[en] (på|for) <navn> til {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<sæt_numerisk_værdi> [farve]temperatur[en] (på|for) <navn> til {color_temperature_names:temperature}"
+    example: "sæt farvetemperaturen på soveværelseslyset til 2700 kelvin"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/tests/da/HassLightSet/name_temperature.yaml
+++ b/tests/da/HassLightSet/name_temperature.yaml
@@ -1,0 +1,49 @@
+---
+# HassLightSet - name_temperature
+
+language: da
+entities:
+  - name: Soveværelseslys
+    domain: light
+tests:
+  - sentences:
+      - sæt soveværelseslysets farvetemperatur til 2700 kelvin
+      - sæt soveværelseslys temperatur til 2700 K
+      - sæt farvetemperaturen på soveværelseslyset til 2700 kelvin
+      - juster temperaturen for soveværelseslyset til 2700
+    slots:
+      temperature: 2700
+      name: Soveværelseslys
+    response: Farvetemperatur indstillet
+
+  - sentences:
+      - sæt soveværelseslysets farvetemperatur til varm hvid
+      - sæt farvetemperaturen på soveværelseslyset til varmt hvidt
+    slots:
+      temperature: 2700
+      name: Soveværelseslys
+    response: Farvetemperatur indstillet
+
+  - sentences:
+      - sæt soveværelseslys farvetemperatur til kold hvid
+      - sæt temperaturen på soveværelseslyset til koldt hvidt
+    slots:
+      temperature: 4000
+      name: Soveværelseslys
+    response: Farvetemperatur indstillet
+
+  - sentences:
+      - sæt soveværelseslyset temperatur til levende lys
+      - ændr farvetemperaturen for soveværelseslyset til stearinlys
+    slots:
+      temperature: 1900
+      name: Soveværelseslys
+    response: Farvetemperatur indstillet
+
+  - sentences:
+      - sæt soveværelseslysets farvetemperatur til dagslys
+      - sæt farvetemperaturen på soveværelseslyset til dagslys
+    slots:
+      temperature: 6500
+      name: Soveværelseslys
+    response: Farvetemperatur indstillet


### PR DESCRIPTION
Adds the `name_temperature` slot combination for `HassLightSet` in Danish.

This is one of the combinations marked **usable** in `intents.yaml` (via `name_domains.usable: [light]`), and it was the only usable combination still missing for `da`.

## Changes

| File | Change |
| --- | --- |
| `sentences/da/HassLightSet/name_temperature.yaml` | new |
| `tests/da/HassLightSet/name_temperature.yaml` | new |
| `lists/da/lights.yaml` | added `color_temperature_names` |
| `responses/da/HassLightSet.yaml` | added `temperature` key |

The list and the response key are required for the combination to work at all, so they are included here.

## Sentences

Templates reuse the existing `<sæt_numerisk_værdi>` and `<navn>` expansion rules and mirror the structure used by `nb`:

```
<sæt_numerisk_værdi> <navn> [farve]temperatur [til] {color_temperature:temperature}[[ ](k|kelvin)]
<sæt_numerisk_værdi> <navn> [farve]temperatur [til] {color_temperature_names:temperature}
<sæt_numerisk_værdi> [farve]temperatur[en] (på|for) <navn> til {color_temperature:temperature}[[ ](k|kelvin)]
<sæt_numerisk_værdi> [farve]temperatur[en] (på|for) <navn> til {color_temperature_names:temperature}
```

## Colour temperature names

Values match the ones used by the other languages that define this list:

| Danish | Kelvin |
| --- | --- |
| levende lys / stearinlys | 1900 |
| varm hvid | 2700 |
| kold hvid | 4000 |
| dagslys | 6500 |

## Verification

- `python -m script.intentfest validate --language da` → All good!
- `pytest tests --language da` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)