### PR TITLE
[es] Add HassLightSet name_temperature sentences

### DIFF
--- a/lists/es/lights.yaml
+++ b/lists/es/lights.yaml
@@ -1,5 +1,15 @@
 language: es
 lists:
+  color_temperature_names:
+    values:
+      - in: (luz de vela|vela)
+        out: 1900
+      - in: blanco cálido
+        out: 2700
+      - in: blanco frío
+        out: 4000
+      - in: luz de día
+        out: 6500
   color:
     values:
       - in: blanco

--- a/responses/es/HassLightSet.yaml
+++ b/responses/es/HassLightSet.yaml
@@ -4,3 +4,4 @@ responses:
     HassLightSet:
       brightness: "Brillo establecido"
       color: "Color establecido"
+      temperature: "Temperatura de color establecida"

--- a/sentences/es/HassLightSet/name_temperature.yaml
+++ b/sentences/es/HassLightSet/name_temperature.yaml
@@ -1,0 +1,18 @@
+---
+# HassLightSet - name_temperature
+# example: pon la temperatura de color de la lámpara de la mesilla a 2700 kelvin
+# slots:
+# - {name}
+# - {temperature}
+
+language: "es"
+data:
+  - sentences:
+      - "<establece> [la] temperatura [de color] [de] [el|la|los|las] {name} [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<establece> [el|la|los|las] {name} [a|al|en] [una] temperatura [de color] [de] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<establece> [la] temperatura [de color] [de] [el|la|los|las] {name} [a|al|en] {color_temperature_names:temperature}"
+      - "<establece> [el|la|los|las] {name} [a|al|en] [una] temperatura [de color] [de] {color_temperature_names:temperature}"
+    example: "pon la temperatura de color de la lámpara de la mesilla a 2700 kelvin"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/tests/es/HassLightSet/name_temperature.yaml
+++ b/tests/es/HassLightSet/name_temperature.yaml
@@ -1,0 +1,49 @@
+---
+# HassLightSet - name_temperature
+
+language: es
+entities:
+  - name: Lámpara de la mesilla
+    domain: light
+tests:
+  - sentences:
+      - pon la temperatura de color de la lámpara de la mesilla a 2700 kelvin
+      - ajusta la temperatura de la lámpara de la mesilla a 2700 K
+      - pon la lámpara de la mesilla a una temperatura de color de 2700 kelvin
+      - configura la lámpara de la mesilla en temperatura 2700
+    slots:
+      temperature: 2700
+      name: Lámpara de la mesilla
+    response: Temperatura de color establecida
+
+  - sentences:
+      - pon la temperatura de color de la lámpara de la mesilla en blanco cálido
+      - cambia la lámpara de la mesilla a una temperatura de blanco cálido
+    slots:
+      temperature: 2700
+      name: Lámpara de la mesilla
+    response: Temperatura de color establecida
+
+  - sentences:
+      - ajusta la temperatura de la lámpara de la mesilla a blanco frío
+      - pon la lámpara de la mesilla en temperatura de color blanco frío
+    slots:
+      temperature: 4000
+      name: Lámpara de la mesilla
+    response: Temperatura de color establecida
+
+  - sentences:
+      - pon la temperatura de color de la lámpara de la mesilla a luz de vela
+      - cambia la lámpara de la mesilla a temperatura de vela
+    slots:
+      temperature: 1900
+      name: Lámpara de la mesilla
+    response: Temperatura de color establecida
+
+  - sentences:
+      - pon la temperatura de color de la lámpara de la mesilla a luz de día
+      - ajusta la lámpara de la mesilla a una temperatura de luz de día
+    slots:
+      temperature: 6500
+      name: Lámpara de la mesilla
+    response: Temperatura de color establecida


### PR DESCRIPTION
Adds the `name_temperature` slot combination for `HassLightSet` in Spanish.

This is one of the combinations marked **usable** in `intents.yaml` (via `name_domains.usable: [light]`), and it was the only usable combination still missing for `es`.

## Changes

| File | Change |
| --- | --- |
| `sentences/es/HassLightSet/name_temperature.yaml` | new |
| `tests/es/HassLightSet/name_temperature.yaml` | new |
| `lists/es/lights.yaml` | added `color_temperature_names` |
| `responses/es/HassLightSet.yaml` | added `temperature` key |

The list and the response key are required for the combination to work at all, so they are included here.

## Sentences

Templates reuse the existing `<establece>` expansion rule:

```
<establece> [la] temperatura [de color] [de] [el|la|los|las] {name} [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]
<establece> [el|la|los|las] {name} [a|al|en] [una] temperatura [de color] [de] {color_temperature:temperature}[[ ](k|kelvin)]
<establece> [la] temperatura [de color] [de] [el|la|los|las] {name} [a|al|en] {color_temperature_names:temperature}
<establece> [el|la|los|las] {name} [a|al|en] [una] temperatura [de color] [de] {color_temperature_names:temperature}
```

## Colour temperature names

Values match the ones used by the other languages that define this list:

| Spanish | Kelvin |
| --- | --- |
| luz de vela / vela | 1900 |
| blanco cálido | 2700 |
| blanco frío | 4000 |
| luz de día | 6500 |

## Verification

- `python -m script.intentfest validate --language es` → All good!
- `pytest tests --language es` → 262 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)