### PR TITLE
[zh-CN] Add HassLightSet name_temperature sentences

### DIFF
--- a/lists/zh-CN/lights.yaml
+++ b/lists/zh-CN/lights.yaml
@@ -1,5 +1,15 @@
 language: zh-CN
 lists:
+  color_temperature_names:
+    values:
+      - in: (烛光|蜡烛光)
+        out: 1900
+      - in: (暖白|暖白光|暖光)
+        out: 2700
+      - in: (冷白|冷白光|冷光)
+        out: 4000
+      - in: (日光|正白光)
+        out: 6500
   color:
     values:
       - in: 白色

--- a/responses/zh-CN/HassLightSet.yaml
+++ b/responses/zh-CN/HassLightSet.yaml
@@ -63,4 +63,5 @@ responses:
         {% endif %}
         {{ slots.area }}灯亮度已设置为{{ value }}%
       color: "颜色已设置"
+      temperature: "色温已设置"
       color_area: "{{ slots.area }}灯颜色已设置"

--- a/sentences/zh-CN/HassLightSet/name_temperature.yaml
+++ b/sentences/zh-CN/HassLightSet/name_temperature.yaml
@@ -1,0 +1,19 @@
+language: "zh-CN"
+data:
+  # numeric color temperature
+  - sentences:
+      - "[把|将|让|给]{name}[的][色温|颜色温度][<set_to>]{color_temperature:temperature}[开|K|开尔文]"
+      - "(设置|调节){name}[的](色温|颜色温度)<to>{color_temperature:temperature}[开|K|开尔文]"
+    example: "把易来吸顶灯的色温设置为2700开"
+    name_domains:
+      - "light"
+    response: "temperature"
+
+  # named color temperature
+  - sentences:
+      - "[把|将|让|给]{name}[的][色温|颜色温度][<set_to>]{color_temperature_names:temperature}"
+      - "(设置|调节){name}[的](色温|颜色温度)<to>{color_temperature_names:temperature}"
+    example: "把易来吸顶灯色温设置为暖白"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/tests/zh-CN/HassLightSet/name_temperature.yaml
+++ b/tests/zh-CN/HassLightSet/name_temperature.yaml
@@ -1,0 +1,46 @@
+language: "zh-CN"
+entities:
+  - name: "易来吸顶灯"
+    domain: "light"
+
+tests:
+  - sentences:
+      - "把易来吸顶灯的色温设置为2700开"
+      - "易来吸顶灯色温调到2700K"
+      - "设置易来吸顶灯的色温为2700开尔文"
+    slots:
+      name: 易来吸顶灯
+      temperature: 2700
+    response: 色温已设置
+
+  - sentences:
+      - "把易来吸顶灯色温设置为暖白"
+      - "调节易来吸顶灯的颜色温度为暖光"
+    slots:
+      name: 易来吸顶灯
+      temperature: 2700
+    response: 色温已设置
+
+  - sentences:
+      - "把易来吸顶灯的色温设为冷白"
+      - "设置易来吸顶灯的色温为冷光"
+    slots:
+      name: 易来吸顶灯
+      temperature: 4000
+    response: 色温已设置
+
+  - sentences:
+      - "把易来吸顶灯色温调到烛光"
+      - "设置易来吸顶灯的色温为蜡烛光"
+    slots:
+      name: 易来吸顶灯
+      temperature: 1900
+    response: 色温已设置
+
+  - sentences:
+      - "把易来吸顶灯的色温设置为日光"
+      - "调节易来吸顶灯的色温为正白光"
+    slots:
+      name: 易来吸顶灯
+      temperature: 6500
+    response: 色温已设置


### PR DESCRIPTION
Adds the `name_temperature` slot combination for `HassLightSet` in Simplified Chinese.

This is one of the combinations marked **usable** in `intents.yaml` (via `name_domains.usable: [light]`), and it was the only usable combination still missing for `zh-CN`.

## Changes

| File | Change |
| --- | --- |
| `sentences/zh-CN/HassLightSet/name_temperature.yaml` | new |
| `tests/zh-CN/HassLightSet/name_temperature.yaml` | new |
| `lists/zh-CN/lights.yaml` | added `color_temperature_names` |
| `responses/zh-CN/HassLightSet.yaml` | added `temperature` key |

The list and the response key are required for the combination to work at all, so they are included here.

## Sentences

Templates follow the structure of the existing `name_color.yaml` / `name_brightness.yaml` and reuse the `<set_to>` and `<to>` expansion rules, with numeric and named color temperatures split into two groups:

```
[把|将|让|给]{name}[的][色温|颜色温度][<set_to>]{color_temperature:temperature}[开|K|开尔文]
(设置|调节){name}[的](色温|颜色温度)<to>{color_temperature:temperature}[开|K|开尔文]
[把|将|让|给]{name}[的][色温|颜色温度][<set_to>]{color_temperature_names:temperature}
(设置|调节){name}[的](色温|颜色温度)<to>{color_temperature_names:temperature}
```

## Colour temperature names

Values match the ones used by the other languages that define this list:

| Chinese | Kelvin |
| --- | --- |
| 烛光 / 蜡烛光 | 1900 |
| 暖白 / 暖白光 / 暖光 | 2700 |
| 冷白 / 冷白光 / 冷光 | 4000 |
| 日光 / 正白光 | 6500 |

## Verification

- `python -m script.intentfest validate --language zh-CN` → All good!
- `pytest tests --language zh-CN` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)