### PR TITLE
[nb] Add HassVacuumCleanArea context_area sentences

### DIFF
--- a/responses/nb/HassVacuumCleanArea.yaml
+++ b/responses/nb/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: nb
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Rengjør {{ slots.area }}"

--- a/sentences/nb/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/nb/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,6 @@
+language: "nb"
+data:
+  - sentences:
+      - "(støvsug|rengjør) <here>"
+    example: "støvsug her inne"
+    response: "default"

--- a/tests/nb/HassVacuumCleanArea/context_area.yaml
+++ b/tests/nb/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,10 @@
+language: "nb"
+areas:
+  - name: "Stua"
+tests:
+  - sentences:
+      - "støvsug her inne"
+      - "rengjør her inne"
+      - "støvsug her i rommet"
+      - "rengjør her i området"
+    response: "Rengjør __context_area__"


### PR DESCRIPTION
Adds the `context_area` slot combination for `HassVacuumCleanArea` in Norwegian Bokmål.

This is one of the combinations marked **usable** in `intents.yaml`, and it was the only usable combination still missing for `nb`.

`HassVacuumCleanArea` did not exist for Norwegian at all, so this also adds the response file.

## Changes

| File | Change |
| --- | --- |
| `sentences/nb/HassVacuumCleanArea/context_area.yaml` | new |
| `tests/nb/HassVacuumCleanArea/context_area.yaml` | new |
| `responses/nb/HassVacuumCleanArea.yaml` | new |

## Sentences

The template reuses the existing `<here>` expansion rule from `rules/nb/common.yaml` and the same verbs as the existing `HassVacuumStart/floor_only.yaml`, so no rule changes are needed:

```
(støvsug|rengjør) <here>
```

This covers støvsug her inne, rengjør her inne, støvsug her i rommet, rengjør her i området.

## Scope

Only the usable combination is added here. `area_only` and `name_area` are `complete`-tier and remain unimplemented.

## Verification

- `python -m script.intentfest validate --language nb` → All good!
- `pytest tests --language nb` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)