### PR TITLE
[pt] Add HassVacuumCleanArea context_area sentences

### DIFF
--- a/responses/pt/HassVacuumCleanArea.yaml
+++ b/responses/pt/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: pt
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "A limpar {{ slots.area }}"

--- a/rules/pt/common.yaml
+++ b/rules/pt/common.yaml
@@ -7,6 +7,7 @@ expansion_rules:
   mudar: (altera[r]|coloca[r]|define|definir|muda[r]|ponha|põe|pôr|ajusta[r]|aumenta[r]|baixa[r]|sobe|subir|desce[r])
   adicionar: (adicione|adiciona[r]|coloque|coloca[r]|junte|junta[r]|põe|ponha|pôr)
   qual: (que|qual|qual é|quais)
+  here: (aqui|nesta (sala|divisão|área)|neste (quarto|espaço))
   luz: (luz|luzes|candeeiro|candeeiros|lâmpada|lâmpadas)
   nb_seconds: ({timer_seconds:seconds}|{timer_words_seconds:seconds})
   nb_minutes: ({timer_minutes:minutes}|{timer_words_minutes:minutes})

--- a/sentences/pt/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/pt/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,6 @@
+language: pt
+data:
+  - sentences:
+      - "(aspirar|limpar) <here>"
+    example: "aspirar aqui"
+    response: "default"

--- a/tests/pt/HassVacuumCleanArea/context_area.yaml
+++ b/tests/pt/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,10 @@
+language: pt
+areas:
+  - name: "Sala"
+tests:
+  - sentences:
+      - "aspirar aqui"
+      - "limpar aqui"
+      - "aspirar nesta divisão"
+      - "limpar neste espaço"
+    response: "A limpar __context_area__"


### PR DESCRIPTION
Adds the `context_area` slot combination for `HassVacuumCleanArea` in Portuguese.

This is one of the combinations marked **usable** in `intents.yaml`, and it was the only usable combination still missing for `pt`.

`HassVacuumCleanArea` did not exist for Portuguese at all, so this also adds the response file.

## Changes

| File | Change |
| --- | --- |
| `sentences/pt/HassVacuumCleanArea/context_area.yaml` | new |
| `tests/pt/HassVacuumCleanArea/context_area.yaml` | new |
| `responses/pt/HassVacuumCleanArea.yaml` | new |
| `rules/pt/common.yaml` | added `here` expansion rule |

Portuguese had no `here` rule yet, unlike most other languages. It is added to `rules/pt/common.yaml` rather than inlined, to match how the other languages express this:

```yaml
here: (aqui|nesta (sala|divisão|área)|neste (quarto|espaço))
```

## Sentences

```
(aspirar|limpar) <here>
```

This covers aspirar aqui, limpar aqui, aspirar nesta divisão, limpar neste espaço.

## Scope

Only the usable combination is added here. `area_only` and `name_area` are `complete`-tier and remain unimplemented.

## Verification

- `python -m script.intentfest validate --language pt` → All good!
- `pytest tests --language pt` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)