### PR TITLE
[it] Add missing usable slot combinations

### DIFF
--- a/lists/it/lights.yaml
+++ b/lists/it/lights.yaml
@@ -1,5 +1,15 @@
 language: it
 lists:
+  color_temperature_names:
+    values:
+      - in: (luce di candela|candela)
+        out: 1900
+      - in: bianco caldo
+        out: 2700
+      - in: bianco freddo
+        out: 4000
+      - in: (luce diurna|luce del giorno)
+        out: 6500
   color:
     values:
       - in: bianco

--- a/responses/it/HassLightSet.yaml
+++ b/responses/it/HassLightSet.yaml
@@ -5,4 +5,5 @@ responses:
       brightness: "Ho impostato la luminosità di {{ slots.name }} al {{ slots.brightness }}"
       brightness_area: "Ho impostato la luminosità in {{ slots.area }} al {{ slots.brightness }}"
       color: "Ho impostato il colore di {{ slots.name }} su {{ slots.color }}"
+      temperature: "Ho impostato la temperatura di colore di {{ slots.name }}"
       color_area: "Ho impostato il colore in {{ slots.area }} su {{ slots.color }}"

--- a/responses/it/HassLightSet.yaml
+++ b/responses/it/HassLightSet.yaml
@@ -5,5 +5,5 @@ responses:
       brightness: "Ho impostato la luminosità di {{ slots.name }} al {{ slots.brightness }}"
       brightness_area: "Ho impostato la luminosità in {{ slots.area }} al {{ slots.brightness }}"
       color: "Ho impostato il colore di {{ slots.name }} su {{ slots.color }}"
-      temperature: "Ho impostato la temperatura di colore di {{ slots.name }}"
+      temperature: "Ho impostato la temperatura colore di {{ slots.name }}"
       color_area: "Ho impostato il colore in {{ slots.area }} su {{ slots.color }}"

--- a/responses/it/HassVacuumCleanArea.yaml
+++ b/responses/it/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: it
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Sto pulendo {{ slots.area }}"

--- a/sentences/it/HassLightSet/name_temperature.yaml
+++ b/sentences/it/HassLightSet/name_temperature.yaml
@@ -1,0 +1,18 @@
+---
+# HassLightSet - name_temperature
+# example: imposta la temperatura di colore della lampada camera a 2700 kelvin
+# slots:
+# - {name}
+# - {temperature}
+
+language: "it"
+data:
+  - sentences:
+      - "<set> [la] temperatura [(di|del) colore] [<of>] [<the>] {name} (a|al|su|in) {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<set> [<the>] {name} (a|al|su|in) [una] temperatura [(di|del) colore] [di] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<set> [la] temperatura [(di|del) colore] [<of>] [<the>] {name} (a|al|su|in) {color_temperature_names:temperature}"
+      - "<set> [<the>] {name} (a|al|su|in) [una] temperatura [(di|del) colore] [di] {color_temperature_names:temperature}"
+    example: "imposta la temperatura di colore della lampada camera a 2700 kelvin"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/it/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/it/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,11 @@
+---
+# HassVacuumCleanArea - context_area
+# example: pulisci qui
+# context_area: true
+
+language: "it"
+data:
+  - sentences:
+      - "(pulisci|aspira|passa l'aspirapolvere) <in_here>"
+    example: "pulisci qui"
+    response: "default"

--- a/tests/it/HassLightSet/name_temperature.yaml
+++ b/tests/it/HassLightSet/name_temperature.yaml
@@ -17,7 +17,7 @@ tests:
 
   - sentences:
       - imposta la temperatura di colore della lampada camera su bianco caldo
-      - metti la lampada camera su una temperatura colore bianco caldo
+      - metti la lampada camera su una temperatura di colore bianco caldo
     slots:
       temperature: 2700
       name: Lampada camera

--- a/tests/it/HassLightSet/name_temperature.yaml
+++ b/tests/it/HassLightSet/name_temperature.yaml
@@ -1,0 +1,48 @@
+---
+# HassLightSet - name_temperature
+
+language: it
+entities:
+  - name: Lampada camera
+    domain: light
+tests:
+  - sentences:
+      - imposta la temperatura di colore della lampada camera a 2700 kelvin
+      - cambia la temperatura della lampada camera a 2700 k
+      - imposta la lampada camera a una temperatura di colore di 2700 kelvin
+    slots:
+      temperature: 2700
+      name: Lampada camera
+    response: Ho impostato la temperatura di colore di Lampada camera
+
+  - sentences:
+      - imposta la temperatura di colore della lampada camera su bianco caldo
+      - metti la lampada camera su una temperatura di colore bianco caldo
+    slots:
+      temperature: 2700
+      name: Lampada camera
+    response: Ho impostato la temperatura di colore di Lampada camera
+
+  - sentences:
+      - imposta la temperatura della lampada camera su bianco freddo
+      - cambia la lampada camera a una temperatura di bianco freddo
+    slots:
+      temperature: 4000
+      name: Lampada camera
+    response: Ho impostato la temperatura di colore di Lampada camera
+
+  - sentences:
+      - imposta la temperatura di colore della lampada camera su luce di candela
+      - metti la lampada camera su temperatura candela
+    slots:
+      temperature: 1900
+      name: Lampada camera
+    response: Ho impostato la temperatura di colore di Lampada camera
+
+  - sentences:
+      - imposta la temperatura di colore della lampada camera su luce diurna
+      - cambia la lampada camera a una temperatura di luce del giorno
+    slots:
+      temperature: 6500
+      name: Lampada camera
+    response: Ho impostato la temperatura di colore di Lampada camera

--- a/tests/it/HassLightSet/name_temperature.yaml
+++ b/tests/it/HassLightSet/name_temperature.yaml
@@ -17,11 +17,11 @@ tests:
 
   - sentences:
       - imposta la temperatura di colore della lampada camera su bianco caldo
-      - metti la lampada camera su una temperatura di colore bianco caldo
+      - metti la lampada camera su una temperatura colore bianco caldo
     slots:
       temperature: 2700
       name: Lampada camera
-    response: Ho impostato la temperatura di colore di Lampada camera
+    response: Ho impostato la temperatura colore di Lampada camera
 
   - sentences:
       - imposta la temperatura della lampada camera su bianco freddo
@@ -29,7 +29,7 @@ tests:
     slots:
       temperature: 4000
       name: Lampada camera
-    response: Ho impostato la temperatura di colore di Lampada camera
+    response: Ho impostato la temperatura colore di Lampada camera
 
   - sentences:
       - imposta la temperatura di colore della lampada camera su luce di candela
@@ -37,7 +37,7 @@ tests:
     slots:
       temperature: 1900
       name: Lampada camera
-    response: Ho impostato la temperatura di colore di Lampada camera
+    response: Ho impostato la temperatura colore di Lampada camera
 
   - sentences:
       - imposta la temperatura di colore della lampada camera su luce diurna
@@ -45,4 +45,4 @@ tests:
     slots:
       temperature: 6500
       name: Lampada camera
-    response: Ho impostato la temperatura di colore di Lampada camera
+    response: Ho impostato la temperatura colore di Lampada camera

--- a/tests/it/HassLightSet/name_temperature.yaml
+++ b/tests/it/HassLightSet/name_temperature.yaml
@@ -13,7 +13,7 @@ tests:
     slots:
       temperature: 2700
       name: Lampada camera
-    response: Ho impostato la temperatura di colore di Lampada camera
+    response: Ho impostato la temperatura colore di Lampada camera
 
   - sentences:
       - imposta la temperatura di colore della lampada camera su bianco caldo

--- a/tests/it/HassVacuumCleanArea/context_area.yaml
+++ b/tests/it/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,13 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: it
+areas:
+  - name: Soggiorno
+tests:
+  - sentences:
+      - pulisci qui
+      - aspira qua
+      - pulisci in questa stanza
+      - passa l'aspirapolvere in questa camera
+    response: Sto pulendo __context_area__


### PR DESCRIPTION
Adds the two slot combinations marked **usable** in `intents.yaml` that were still missing for Italian.

## HassLightSet / name_temperature

Set the colour temperature of a light by name (`name_domains.usable: [light]`).

Templates reuse the existing `<set>`, `<of>` and `<the>` expansion rules and mirror `name_color.yaml`:

```
<set> [la] temperatura [(di|del) colore] [<of>] [<the>] {name} (a|al|su|in) {color_temperature:temperature}[[ ](k|kelvin)]
<set> [<the>] {name} (a|al|su|in) [una] temperatura [(di|del) colore] [di] {color_temperature:temperature}[[ ](k|kelvin)]
<set> [la] temperatura [(di|del) colore] [<of>] [<the>] {name} (a|al|su|in) {color_temperature_names:temperature}
<set> [<the>] {name} (a|al|su|in) [una] temperatura [(di|del) colore] [di] {color_temperature_names:temperature}
```

Colour temperature names, matching the values used by the other languages that define this list:

| Italian | Kelvin |
| --- | --- |
| luce di candela / candela | 1900 |
| bianco caldo | 2700 |
| bianco freddo | 4000 |
| luce diurna / luce del giorno | 6500 |

The response does not interpolate `{{ slots.temperature }}`: `color_temperature_names` has numeric `out` values, and the test harness renders those as the matched *text* rather than the resolved number.

## HassVacuumCleanArea / context_area

Send a vacuum to clean the voice satellite's own area. `HassVacuumCleanArea` did not exist for Italian at all, so the response file is added too.

```
(pulisci|aspira|passa l'aspirapolvere) <in_here>
```

Only the usable combination is added; `area_only` and `name_area` are `complete`-tier and remain unimplemented.

## Changes

| File | Change |
| --- | --- |
| `sentences/it/HassLightSet/name_temperature.yaml` | new |
| `tests/it/HassLightSet/name_temperature.yaml` | new |
| `sentences/it/HassVacuumCleanArea/context_area.yaml` | new |
| `tests/it/HassVacuumCleanArea/context_area.yaml` | new |
| `responses/it/HassVacuumCleanArea.yaml` | new |
| `lists/it/lights.yaml` | added `color_temperature_names` |
| `responses/it/HassLightSet.yaml` | added `temperature` key |

## Verification

- `python -m script.intentfest validate --language it` → All good!
- `pytest tests --language it` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)