### PR TITLE
[pl] Add missing usable slot combinations

### DIFF
--- a/lists/pl/lights.yaml
+++ b/lists/pl/lights.yaml
@@ -1,5 +1,15 @@
 language: pl
 lists:
+  color_temperature_names:
+    values:
+      - in: (światło świecy|świec(a|ę|y))
+        out: 1900
+      - in: (ciepła|ciepłą|ciepły) biel
+        out: 2700
+      - in: (zimna|zimną|zimny|chłodna|chłodną) biel
+        out: 4000
+      - in: (światło dzienne|dzienna biel|dzienną biel)
+        out: 6500
   color:
     values:
       - in: biel|biał(y|o|e)

--- a/responses/pl/HassLightSet.yaml
+++ b/responses/pl/HassLightSet.yaml
@@ -4,3 +4,4 @@ responses:
     HassLightSet:
       brightness: Ustawiono jasność
       color: Ustawiono kolor
+      temperature: Ustawiono temperaturę barwową

--- a/responses/pl/HassVacuumCleanArea.yaml
+++ b/responses/pl/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: pl
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Sprzątanie rozpoczęte"

--- a/sentences/pl/HassLightSet/name_temperature.yaml
+++ b/sentences/pl/HassLightSet/name_temperature.yaml
@@ -1,0 +1,16 @@
+---
+# HassLightSet - name_temperature
+# example: ustaw temperaturę barwową lampy na 2700 kelwinów
+# slots: {name}, {temperature}
+
+language: "pl"
+data:
+  - sentences:
+      - "<set> temperaturę [barwową|koloru|światła] {name} na {color_temperature:temperature}[[ ](k|kelwin[ów|a|y])]"
+      - "<set> {name} na temperaturę [barwową|koloru|światła] {color_temperature:temperature}[[ ](k|kelwin[ów|a|y])]"
+      - "<set> temperaturę [barwową|koloru|światła] {name} na {color_temperature_names:temperature}"
+      - "<set> {name} na {color_temperature_names:temperature}"
+    example: "ustaw temperaturę barwową lampy na 2700 kelwinów"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/pl/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/pl/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,11 @@
+---
+# HassVacuumCleanArea - context_area
+# example: odkurz tutaj
+# context_area: true
+
+language: "pl"
+data:
+  - sentences:
+      - "<clean> <here>"
+    example: "odkurz tutaj"
+    response: "default"

--- a/tests/pl/HassLightSet/name_temperature.yaml
+++ b/tests/pl/HassLightSet/name_temperature.yaml
@@ -1,0 +1,44 @@
+---
+# HassLightSet - name_temperature
+
+language: pl
+entities:
+  - name: Lampa
+    domain: light
+tests:
+  - sentences:
+      - ustaw temperaturę barwową Lampa na 2700 kelwinów
+      - zmień temperaturę światła Lampa na 2700 k
+      - ustaw Lampa na temperaturę barwową 2700 kelwinów
+    slots:
+      name: Lampa
+      temperature: 2700
+    response: Ustawiono temperaturę barwową
+  - sentences:
+      - ustaw temperaturę barwową Lampa na ciepłą biel
+      - ustaw Lampa na ciepła biel
+    slots:
+      name: Lampa
+      temperature: 2700
+    response: Ustawiono temperaturę barwową
+  - sentences:
+      - ustaw temperaturę barwową Lampa na zimną biel
+      - zmień Lampa na chłodna biel
+    slots:
+      name: Lampa
+      temperature: 4000
+    response: Ustawiono temperaturę barwową
+  - sentences:
+      - ustaw temperaturę barwową Lampa na światło świecy
+      - ustaw Lampa na świecę
+    slots:
+      name: Lampa
+      temperature: 1900
+    response: Ustawiono temperaturę barwową
+  - sentences:
+      - ustaw temperaturę barwową Lampa na światło dzienne
+      - ustaw Lampa na dzienną biel
+    slots:
+      name: Lampa
+      temperature: 6500
+    response: Ustawiono temperaturę barwową

--- a/tests/pl/HassVacuumCleanArea/context_area.yaml
+++ b/tests/pl/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,13 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: pl
+areas:
+  - name: Salon
+tests:
+  - sentences:
+      - odkurz tutaj
+      - posprzątaj tutaj
+      - odkurz w tym pokoju
+      - wyczyść w tym pomieszczeniu
+    response: Sprzątanie rozpoczęte


### PR DESCRIPTION
Adds the two slot combinations marked **usable** in `intents.yaml` that were still missing for Polish.

## HassLightSet / name_temperature

Set the colour temperature of a light by name (`name_domains.usable: [light]`).

Templates reuse the existing `<set>` expansion rule and mirror `name_color.yaml`:

```
<set> temperaturę [barwową|koloru|światła] {name} na {color_temperature:temperature}[[ ](k|kelwin[ów|a|y])]
<set> {name} na temperaturę [barwową|koloru|światła] {color_temperature:temperature}[[ ](k|kelwin[ów|a|y])]
<set> temperaturę [barwową|koloru|światła] {name} na {color_temperature_names:temperature}
<set> {name} na {color_temperature_names:temperature}
```

Colour temperature names, matching the values used by the other languages that define this list. Both nominative and accusative forms are accepted, since the names follow *na*:

| Polish | Kelvin |
| --- | --- |
| światło świecy / świeca / świecę / świecy | 1900 |
| ciepła biel / ciepłą biel | 2700 |
| zimna biel / zimną biel / chłodna biel | 4000 |
| światło dzienne / dzienna biel | 6500 |

## HassVacuumCleanArea / context_area

Send a vacuum to clean the voice satellite's own area. `HassVacuumCleanArea` did not exist for Polish at all, so the response file is added too.

The template reuses the existing `<clean>` and `<here>` rules, so no rule changes are needed:

```
<clean> <here>
```

Only the usable combination is added; `area_only` and `name_area` are `complete`-tier and remain unimplemented — note the existing `HassVacuumStart/area_only` already handles odkurz salon.

## Changes

| File | Change |
| --- | --- |
| `sentences/pl/HassLightSet/name_temperature.yaml` | new |
| `tests/pl/HassLightSet/name_temperature.yaml` | new |
| `sentences/pl/HassVacuumCleanArea/context_area.yaml` | new |
| `tests/pl/HassVacuumCleanArea/context_area.yaml` | new |
| `responses/pl/HassVacuumCleanArea.yaml` | new |
| `lists/pl/lights.yaml` | added `color_temperature_names` |
| `responses/pl/HassLightSet.yaml` | added `temperature` key |

## Verification

- `python -m script.intentfest validate --language pl` → All good!
- `pytest tests --language pl` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)