### PR TITLE
[hr] Add missing usable slot combinations

### DIFF
--- a/lists/hr/lights.yaml
+++ b/lists/hr/lights.yaml
@@ -1,5 +1,15 @@
 language: hr
 lists:
+  color_temperature_names:
+    values:
+      - in: (svjetlo svijeće|svijeć(a|u))
+        out: 1900
+      - in: topl(a|u) bijel(a|u)
+        out: 2700
+      - in: hladn(a|u) bijel(a|u)
+        out: 4000
+      - in: dnevno svjetlo
+        out: 6500
   color:
     values:
       - in: bijel(a|o|u)

--- a/responses/hr/HassLightSet.yaml
+++ b/responses/hr/HassLightSet.yaml
@@ -4,3 +4,4 @@ responses:
     HassLightSet:
       brightness: "Jačina svjetla je postavljena"
       color: "Boja svjetla je postavljena"
+      temperature: "Temperatura boje je postavljena"

--- a/responses/hr/HassVacuumCleanArea.yaml
+++ b/responses/hr/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: hr
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Usisavanje je započeto"

--- a/rules/hr/common.yaml
+++ b/rules/hr/common.yaml
@@ -6,6 +6,7 @@ expansion_rules:
   promijeni: "podesi[te|mo]|namjesti[te|mo]|postavi[te|mo]|stavi|promijeni[te|mo]|smanji|povećaj"
   otvori: "otvori[te|mo]|[po]digni[te|mo]"
   zatvori: "zatvori[te|mo]|spusti[te|mo]|navuci"
+  here: (ovdje|tu|u ovoj sobi|u ovoj prostoriji)
   koja_je: "koja je|kolika je|kakva je|koji je|kolik(i|a|o) [je]|koliko [je]|kada je|reci [mi]|koju|kojom se"
   prognoza: "vrijeme|prognoza"
   kakvo_je: "kakvo je|koje je|kakva je"

--- a/sentences/hr/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/hr/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassClimateGetTemperature - name_only
+# example: koja je temperatura na termostatu
+# slots: {name}
+
+language: "hr"
+data:
+  - sentences:
+      - "<koja_je> <temp> [na|u|za] {name}"
+      - "koliko je stupnjeva [na|u|za] {name}"
+    example: "koja je temperatura na termostatu"
+    name_domains:
+      - "climate"
+    response: "default"

--- a/sentences/hr/HassLightSet/name_temperature.yaml
+++ b/sentences/hr/HassLightSet/name_temperature.yaml
@@ -1,0 +1,16 @@
+---
+# HassLightSet - name_temperature
+# example: postavi temperaturu boje noćnog svjetla na 2700 kelvina
+# slots: {name}, {temperature}
+
+language: "hr"
+data:
+  - sentences:
+      - "<promijeni> temperaturu [boje|svjetla] {name} [na|u] {color_temperature:temperature}[[ ](k|kelvina)]"
+      - "<promijeni> {name} [na|u] temperaturu [boje|svjetla] {color_temperature:temperature}[[ ](k|kelvina)]"
+      - "<promijeni> temperaturu [boje|svjetla] {name} [na|u] {color_temperature_names:temperature}"
+      - "<promijeni> {name} [na|u] {color_temperature_names:temperature}"
+    example: "postavi temperaturu boje noćnog svjetla na 2700 kelvina"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/hr/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/hr/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,10 @@
+---
+# HassVacuumCleanArea - context_area
+# example: usisaj ovdje
+
+language: "hr"
+data:
+  - sentences:
+      - "(usisaj|počisti|očisti) <here>"
+    example: "usisaj ovdje"
+    response: "default"

--- a/tests/hr/HassClimateGetTemperature/name_only.yaml
+++ b/tests/hr/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassClimateGetTemperature - name_only
+
+language: hr
+entities:
+  - name: Termostat ured
+    domain: climate
+    state: "22"
+    attributes:
+      current_temperature: 22
+tests:
+  - sentences:
+      - koja je temperatura na Termostat ured?
+      - kolika je temperatura Termostat ured?
+      - koliko je stupnjeva na Termostat ured?
+    slots:
+      name: Termostat ured
+    response: "22"

--- a/tests/hr/HassLightSet/name_temperature.yaml
+++ b/tests/hr/HassLightSet/name_temperature.yaml
@@ -1,0 +1,43 @@
+---
+# HassLightSet - name_temperature
+
+language: hr
+entities:
+  - name: Noćno svjetlo
+    domain: light
+tests:
+  - sentences:
+      - postavi temperaturu boje Noćno svjetlo na 2700 kelvina
+      - podesi Noćno svjetlo na temperaturu svjetla 2700 k
+    slots:
+      name: Noćno svjetlo
+      temperature: 2700
+    response: Temperatura boje je postavljena
+  - sentences:
+      - postavi temperaturu boje Noćno svjetlo na toplu bijelu
+      - namjesti Noćno svjetlo na topla bijela
+    slots:
+      name: Noćno svjetlo
+      temperature: 2700
+    response: Temperatura boje je postavljena
+  - sentences:
+      - postavi temperaturu boje Noćno svjetlo na hladnu bijelu
+      - promijeni Noćno svjetlo u hladna bijela
+    slots:
+      name: Noćno svjetlo
+      temperature: 4000
+    response: Temperatura boje je postavljena
+  - sentences:
+      - postavi temperaturu boje Noćno svjetlo na svjetlo svijeće
+      - stavi Noćno svjetlo na svijeću
+    slots:
+      name: Noćno svjetlo
+      temperature: 1900
+    response: Temperatura boje je postavljena
+  - sentences:
+      - postavi temperaturu boje Noćno svjetlo na dnevno svjetlo
+      - podesi Noćno svjetlo na dnevno svjetlo
+    slots:
+      name: Noćno svjetlo
+      temperature: 6500
+    response: Temperatura boje je postavljena

--- a/tests/hr/HassVacuumCleanArea/context_area.yaml
+++ b/tests/hr/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,13 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: hr
+areas:
+  - name: Dnevna soba
+tests:
+  - sentences:
+      - usisaj ovdje
+      - počisti tu
+      - očisti u ovoj sobi
+      - usisaj u ovoj prostoriji
+    response: Usisavanje je započeto


### PR DESCRIPTION
Adds the three slot combinations marked **usable** in `intents.yaml` that were still missing for Croatian.

## HassClimateGetTemperature / name_only

Query the temperature of a climate entity by name. Mirrors `area_only.yaml` and reuses `<koja_je>` and `<temp>`:

```
<koja_je> <temp> [na|u|za] {name}
koliko je stupnjeva [na|u|za] {name}
```

## HassLightSet / name_temperature

Set the colour temperature of a light by name. Mirrors `name_color.yaml` and reuses `<promijeni>`:

```
<promijeni> temperaturu [boje|svjetla] {name} [na|u] {color_temperature:temperature}[[ ](k|kelvina)]
<promijeni> {name} [na|u] temperaturu [boje|svjetla] {color_temperature:temperature}[[ ](k|kelvina)]
<promijeni> temperaturu [boje|svjetla] {name} [na|u] {color_temperature_names:temperature}
<promijeni> {name} [na|u] {color_temperature_names:temperature}
```

Colour temperature names, matching the Kelvin values used by the other languages that define this list. Nominative and accusative forms are both accepted, since the names follow *na*/*u*:

| Croatian | Kelvin |
| --- | --- |
| svjetlo svijeće / svijeća / svijeću | 1900 |
| topla bijela / toplu bijelu | 2700 |
| hladna bijela / hladnu bijelu | 4000 |
| dnevno svjetlo | 6500 |

## HassVacuumCleanArea / context_area

Send a vacuum to clean the voice satellite's own area. `HassVacuumCleanArea` did not exist for Croatian, so the response file is added too. Croatian had no `here` rule yet, unlike most other languages, so one is added to `rules/hr/common.yaml`:

```yaml
here: (ovdje|tu|u ovoj sobi|u ovoj prostoriji)
```

```
(usisaj|počisti|očisti) <here>
```

Only the usable combination is added; `area_only` and `name_area` are `complete`-tier and remain unimplemented.

## Changes

| File | Change |
| --- | --- |
| `sentences/hr/HassClimateGetTemperature/name_only.yaml` | new |
| `tests/hr/HassClimateGetTemperature/name_only.yaml` | new |
| `sentences/hr/HassLightSet/name_temperature.yaml` | new |
| `tests/hr/HassLightSet/name_temperature.yaml` | new |
| `sentences/hr/HassVacuumCleanArea/context_area.yaml` | new |
| `tests/hr/HassVacuumCleanArea/context_area.yaml` | new |
| `responses/hr/HassVacuumCleanArea.yaml` | new |
| `rules/hr/common.yaml` | added `here` rule |
| `lists/hr/lights.yaml` | added `color_temperature_names` |
| `responses/hr/HassLightSet.yaml` | added `temperature` key |

## Verification

- `python -m script.intentfest validate --language hr` → All good!
- `pytest tests --language hr` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)