### PR TITLE
[de-CH] Add missing usable slot combinations

### DIFF
--- a/lists/de-CH/lights.yaml
+++ b/lists/de-CH/lights.yaml
@@ -8,7 +8,7 @@ lists:
         out: 2700
       - in: (ch|k)a(l|u)t[ ](w(y|i|ei)ss)
         out: 4000
-      - in: (Tagesliecht|Tageslicht)
+      - in: (Tagesli[e]cht)
         out: 6500
   color:
     values:

--- a/lists/de-CH/lights.yaml
+++ b/lists/de-CH/lights.yaml
@@ -1,5 +1,15 @@
 language: de-CH
 lists:
+  color_temperature_names:
+    values:
+      - in: (Chärze[liecht]|Kerze[nlicht])
+        out: 1900
+      - in: warm[ ](wyss|wei(ss|ß))
+        out: 2700
+      - in: (ch|k)alt[ ](wyss|wei(ss|ß))
+        out: 4000
+      - in: (Tagesliecht|Tageslicht)
+        out: 6500
   color:
     values:
       - in: wyss

--- a/lists/de-CH/lights.yaml
+++ b/lists/de-CH/lights.yaml
@@ -6,7 +6,7 @@ lists:
         out: 1900
       - in: warm[ ](w(y|i|ei)ss)
         out: 2700
-      - in: (ch|k)alt[ ](wyss|wei(ss|ß))
+      - in: (ch|k)a(l|u)t[ ](w(y|i|ei)ss)
         out: 4000
       - in: (Tagesliecht|Tageslicht)
         out: 6500

--- a/lists/de-CH/lights.yaml
+++ b/lists/de-CH/lights.yaml
@@ -4,7 +4,7 @@ lists:
     values:
       - in: (Ch(ä|e)rze[liecht]|Kerze[nlicht])
         out: 1900
-      - in: warm[ ](wyss|wei(ss|ß))
+      - in: warm[ ](w(y|i|ei)ss)
         out: 2700
       - in: (ch|k)alt[ ](wyss|wei(ss|ß))
         out: 4000

--- a/lists/de-CH/lights.yaml
+++ b/lists/de-CH/lights.yaml
@@ -2,7 +2,7 @@ language: de-CH
 lists:
   color_temperature_names:
     values:
-      - in: (Chärze[liecht]|Kerze[nlicht])
+      - in: (Ch(ä|e)rze[liecht]|Kerze[nlicht])
         out: 1900
       - in: warm[ ](wyss|wei(ss|ß))
         out: 2700

--- a/responses/de-CH/HassClimateGetTemperature.yaml
+++ b/responses/de-CH/HassClimateGetTemperature.yaml
@@ -4,3 +4,4 @@ responses:
     HassClimateGetTemperature:
       default: "D Temparatur vo {{slots.name | capitalize }} isch {{ state_attr(state.entity_id, 'current_temperature') }} Grad."
       temp_area: "In {{slots.area | capitalize }} isch es {{ state_attr(state.entity_id, 'current_temperature') }} Grad."
+      temp_here: "Es isch {{ state_attr(state.entity_id, 'current_temperature') }} Grad."

--- a/responses/de-CH/HassLightSet.yaml
+++ b/responses/de-CH/HassLightSet.yaml
@@ -5,4 +5,5 @@ responses:
       brightness: "D Häuigkeit vo {{slots.name | capitalize }} isch uf {{slots.brightness}} gsetzt."
       brightness_area: "D Häuigkeit vo de Lampe im Zimmer {{slots.area | capitalize }} isch uf {{slots.brightness}} gsetzt."
       color: "D Farb vo {{slots.name | capitalize }} isch uf {{slots.color}} gänderet."
+      temperature: "D Farbtemperatur vo {{slots.name | capitalize }} isch gänderet."
       color_area: "D Farb vo de Lampe im Zimmer {{slots.area | capitalize }} isch uf {{slots.color}} gänderet."

--- a/responses/de-CH/HassMediaPause.yaml
+++ b/responses/de-CH/HassMediaPause.yaml
@@ -3,3 +3,5 @@ responses:
   intents:
     HassMediaPause:
       default: "Ha {{ slots.name | capitalize }} pousiert"
+      context: "Ha pousiert"
+      area: "Ha i {{ slots.area | capitalize }} pousiert"

--- a/responses/de-CH/HassMediaUnpause.yaml
+++ b/responses/de-CH/HassMediaUnpause.yaml
@@ -3,3 +3,5 @@ responses:
   intents:
     HassMediaUnpause:
       default: "{{slots.name | capitalize }} schpiut wyter"
+      context: "Schpiut wyter"
+      area: "{{ slots.area | capitalize }} schpiut wyter"

--- a/responses/de-CH/HassVacuumCleanArea.yaml
+++ b/responses/de-CH/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: de-CH
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Ha mit Putze agfange"

--- a/sentences/de-CH/HassClimateGetTemperature/default.yaml
+++ b/sentences/de-CH/HassClimateGetTemperature/default.yaml
@@ -1,0 +1,13 @@
+---
+# HassClimateGetTemperature - default
+# example: Wie warm isch es do
+# context_area: true
+
+language: "de-CH"
+data:
+  - sentences:
+      - "Wie (warm|cha(u|l)t) (isch es|isch's|ischs|isch) [<hier>]"
+      - "Weli Temperatur (isch es|isch's|isch|het|het ds|het's) [<hier>]"
+      - "Wie (hoch|höch) isch d Temperatur [<hier>]"
+    example: "Wie warm isch es do"
+    response: "temp_here"

--- a/sentences/de-CH/HassLightSet/name_temperature.yaml
+++ b/sentences/de-CH/HassLightSet/name_temperature.yaml
@@ -1,0 +1,16 @@
+---
+# HassLightSet - name_temperature
+# example: setz d Farbtemperatur vor Schlafzimmer Lampe uf 2700 Kelvin
+# slots:
+# - {name}
+# - {temperature}
+
+language: "de-CH"
+data:
+  - sentences:
+      - "(setz|steu|schteu|wächsle|wächslä) [(d' |d'|d )Farbtemperatur (vo|vor|vo der|vo dr|vodr) ]<name> (uf|nach) {color_temperature:temperature}[[ ](k|Kelvin)]"
+      - "(setz|steu|schteu|wächsle|wächslä) [(d' |d'|d )Farbtemperatur (vo|vor|vo der|vo dr|vodr) ]<name> (uf|nach) {color_temperature_names:temperature}"
+    example: "setz d Farbtemperatur vor Schlafzimmer Lampe uf 2700 Kelvin"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/de-CH/HassMediaPause/area_only.yaml
+++ b/sentences/de-CH/HassMediaPause/area_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaPause - area_only
+# slots: {area}
+
+language: "de-CH"
+data:
+  - sentences:
+      - "(p(a|o)usier|stop[p]|schtop[p]) [(d |ds |di |mini )](Musig|Video|Film|Ton) <area>"
+      - "[(d |ds |di |mini )](Musig|Video|Film|Ton) <area> (p(a|o)usiere|schtoppe|ahalte|aahalte)"
+      - "(p(a|o)usier|stop[p]|schtop[p]) <area>"
+    example: "pousier d Musig im Wohnzimmer"
+    response: "area"

--- a/sentences/de-CH/HassMediaPause/default.yaml
+++ b/sentences/de-CH/HassMediaPause/default.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaPause - default
+# context_area: true
+
+language: "de-CH"
+data:
+  - sentences:
+      - "(p(a|o)usier|stop[p]|schtop[p]|ahalte|aahalte)"
+      - "(p(a|o)usier|stop[p]|schtop[p]) [(d |ds |di |mini )](Musig|Video|Film|Ton) [<hier>]"
+      - "[(d |ds |di |mini )](Musig|Video|Film|Ton) [<hier> ](p(a|o)usiere|schtoppe|ahalte|aahalte)"
+    example: "pousier d Musig"
+    response: "context"

--- a/sentences/de-CH/HassMediaUnpause/area_only.yaml
+++ b/sentences/de-CH/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaUnpause - area_only
+# slots: {area}
+
+language: "de-CH"
+data:
+  - sentences:
+      - "[(d |ds |di |mini )](Musig|Video|Film|Ton) <area> ((wyter|wiiter)(schpile|mache|lose|luege)|fortsetze)"
+      - "(mach|schpiu|spiu) [(d |ds |di |mini )](Musig|Video|Film|Ton) <area> (wyter|wiiter)"
+      - "<area> ((wyter|wiiter)(schpile|mache|lose|luege)|fortsetze)"
+    example: "d Musig im Wohnzimmer wyterschpile"
+    response: "area"

--- a/sentences/de-CH/HassMediaUnpause/default.yaml
+++ b/sentences/de-CH/HassMediaUnpause/default.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaUnpause - default
+# context_area: true
+
+language: "de-CH"
+data:
+  - sentences:
+      - "(wyter|wiiter)(schpile|mache|lose|luege)"
+      - "[(d |ds |di |mini )](Musig|Video|Film|Ton) [<hier> ]((wyter|wiiter)(schpile|mache|lose|luege)|fortsetze)"
+      - "(mach|schpiu|spiu) [(d |ds |di |mini )](Musig|Video|Film|Ton) [<hier> ](wyter|wiiter)"
+    example: "d Musig wyterschpile"
+    response: "context"

--- a/sentences/de-CH/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/de-CH/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,10 @@
+---
+# HassVacuumCleanArea - context_area
+# example: sug do
+
+language: "de-CH"
+data:
+  - sentences:
+      - "(sug|suge|schtoubsug|schtoubsuge|putz|putze) <hier>"
+    example: "sug do"
+    response: "default"

--- a/tests/de-CH/HassClimateGetTemperature/default.yaml
+++ b/tests/de-CH/HassClimateGetTemperature/default.yaml
@@ -1,0 +1,16 @@
+---
+# HassClimateGetTemperature - default
+
+language: de-CH
+entities:
+  - name: Thermostat
+    domain: climate
+    state: "22"
+    attributes:
+      current_temperature: 22
+tests:
+  - sentences:
+      - Wie warm isch es do
+      - Weli Temperatur isch es hie
+      - Wie hoch isch d Temperatur
+    response: Es isch 22 Grad.

--- a/tests/de-CH/HassLightSet/name_temperature.yaml
+++ b/tests/de-CH/HassLightSet/name_temperature.yaml
@@ -1,0 +1,43 @@
+---
+# HassLightSet - name_temperature
+
+language: de-CH
+entities:
+  - name: Schlafzimmer Lampe
+    domain: light
+tests:
+  - sentences:
+      - setz d Farbtemperatur vor Schlafzimmer Lampe uf 2700 Kelvin
+      - wächsle d Schlafzimmer Lampe uf 2700 k
+    slots:
+      name: Schlafzimmer Lampe
+      temperature: 2700
+    response: D Farbtemperatur vo Schlafzimmer lampe isch gänderet.
+  - sentences:
+      - setz d Farbtemperatur vor Schlafzimmer Lampe uf warmwyss
+      - wächsle d Schlafzimmer Lampe uf warm wyss
+    slots:
+      name: Schlafzimmer Lampe
+      temperature: 2700
+    response: D Farbtemperatur vo Schlafzimmer lampe isch gänderet.
+  - sentences:
+      - setz d Farbtemperatur vor Schlafzimmer Lampe uf chaltwyss
+      - wächsle d Schlafzimmer Lampe uf kalt wyss
+    slots:
+      name: Schlafzimmer Lampe
+      temperature: 4000
+    response: D Farbtemperatur vo Schlafzimmer lampe isch gänderet.
+  - sentences:
+      - setz d Farbtemperatur vor Schlafzimmer Lampe uf Chärzeliecht
+      - wächsle d Schlafzimmer Lampe uf Kerze
+    slots:
+      name: Schlafzimmer Lampe
+      temperature: 1900
+    response: D Farbtemperatur vo Schlafzimmer lampe isch gänderet.
+  - sentences:
+      - setz d Farbtemperatur vor Schlafzimmer Lampe uf Tagesliecht
+      - wächsle d Schlafzimmer Lampe uf Tageslicht
+    slots:
+      name: Schlafzimmer Lampe
+      temperature: 6500
+    response: D Farbtemperatur vo Schlafzimmer lampe isch gänderet.

--- a/tests/de-CH/HassMediaPause/area_only.yaml
+++ b/tests/de-CH/HassMediaPause/area_only.yaml
@@ -1,0 +1,19 @@
+---
+# HassMediaPause - area_only
+
+language: de-CH
+areas:
+  - name: Wohnzimmer
+entities:
+  - name: Fernseh
+    domain: media_player
+    area: Wohnzimmer
+    state: playing
+tests:
+  - sentences:
+      - pousier d Musig im Wohnzimmer
+      - d Musig im Wohnzimmer pousiere
+      - pousier im Wohnzimmer
+    slots:
+      area: Wohnzimmer
+    response: Ha i Wohnzimmer pousiert

--- a/tests/de-CH/HassMediaPause/default.yaml
+++ b/tests/de-CH/HassMediaPause/default.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaPause - default
+
+language: de-CH
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - pousier
+      - stop
+      - pousier d Musig
+      - d Musig pousiere
+    response: Ha pousiert

--- a/tests/de-CH/HassMediaUnpause/area_only.yaml
+++ b/tests/de-CH/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,19 @@
+---
+# HassMediaUnpause - area_only
+
+language: de-CH
+areas:
+  - name: Wohnzimmer
+entities:
+  - name: Fernseh
+    domain: media_player
+    area: Wohnzimmer
+    state: paused
+tests:
+  - sentences:
+      - d Musig im Wohnzimmer wyterschpile
+      - mach d Musig im Wohnzimmer wyter
+      - im Wohnzimmer wyterschpile
+    slots:
+      area: Wohnzimmer
+    response: Wohnzimmer schpiut wyter

--- a/tests/de-CH/HassMediaUnpause/default.yaml
+++ b/tests/de-CH/HassMediaUnpause/default.yaml
@@ -1,0 +1,14 @@
+---
+# HassMediaUnpause - default
+
+language: de-CH
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - wyterschpile
+      - d Musig wyterschpile
+      - mach d Musig wyter
+    response: Schpiut wyter

--- a/tests/de-CH/HassVacuumCleanArea/context_area.yaml
+++ b/tests/de-CH/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,12 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: de-CH
+areas:
+  - name: Wohnzimmer
+tests:
+  - sentences:
+      - sug do
+      - schtoubsug hie
+      - putz i dem Ruum
+    response: Ha mit Putze agfange


### PR DESCRIPTION
Adds the seven slot combinations marked **usable** in `intents.yaml` that were still missing for Swiss German.

> [!NOTE]
> This is the largest single-language batch so far and it involves inventing dialect wording rather than translating. I have followed the spellings already used in `sentences/de-CH/` and `rules/de-CH/` (`pousier`, `schpiut`, `wyss`, `Chärze`, `wyter`), but a native speaker should sanity-check the phrasings before merge.

## Combinations added

| Intent | Combo |
| --- | --- |
| `HassClimateGetTemperature` | `default` |
| `HassLightSet` | `name_temperature` |
| `HassMediaPause` | `default`, `area_only` |
| `HassMediaUnpause` | `default`, `area_only` |
| `HassVacuumCleanArea` | `context_area` |

## Response keys

The existing `HassMediaPause`/`HassMediaUnpause` `default` responses interpolate `{{ slots.name }}`, which is not available in the `default` (context-area) and `area_only` combinations. Rather than change the existing key, new keys are added alongside it — the same pattern `HassClimateGetTemperature` already uses with `temp_area`:

| Intent | New key | Text |
| --- | --- | --- |
| `HassMediaPause` | `context` | Ha pousiert |
| `HassMediaPause` | `area` | Ha i {{ slots.area \| capitalize }} pousiert |
| `HassMediaUnpause` | `context` | Schpiut wyter |
| `HassMediaUnpause` | `area` | {{ slots.area \| capitalize }} schpiut wyter |
| `HassClimateGetTemperature` | `temp_here` | Es isch … Grad. |
| `HassLightSet` | `temperature` | D Farbtemperatur vo … isch gänderet. |

`responses/de-CH/HassVacuumCleanArea.yaml` is new — the intent did not exist for Swiss German.

## Colour temperature names

`lists/de-CH/lights.yaml` gains `color_temperature_names`, accepting both the Swiss and the standard German spellings so either is recognised:

| Swiss German | Kelvin |
| --- | --- |
| Chärze / Chärzeliecht / Kerze / Kerzenlicht | 1900 |
| warm wyss / warmweiss | 2700 |
| chalt wyss / kaltweiss | 4000 |
| Tagesliecht / Tageslicht | 6500 |

## Notes

- Swiss German has no `media_type` rule (unlike `de`), so the media words (Musig, Video, Film, Ton) are inlined.
- The existing `<hier>`, `<area>` and `<name>` rules are reused throughout; no rule files are changed.
- Only usable combinations are added — `HassVacuumCleanArea`'s `area_only`/`name_area` are `complete`-tier and remain unimplemented.

## Verification

- `python -m script.intentfest validate --language de-CH` → All good!
- `pytest tests --language de-CH` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)