### PR TITLE
[sl] Add missing usable slot combinations

### DIFF
--- a/responses/sl/HassVacuumCleanArea.yaml
+++ b/responses/sl/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: sl
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Začenjam čiščenje"

--- a/sentences/sl/HassMediaNext/area_only.yaml
+++ b/sentences/sl/HassMediaNext/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaNext - area_only
+# slots: {area}
+
+language: "sl"
+data:
+  - sentences:
+      - "[predvajaj] naslednj(o|i|e) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad] v {area}"
+      - "preskoči [na naslednj(i|o|a|e)] [pesem|skladbo|komad|epizodo] v {area}"
+    example: "naslednja pesem v dnevni sobi"
+    response: "default"

--- a/sentences/sl/HassMediaNext/default.yaml
+++ b/sentences/sl/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaNext - default
+# context_area: true
+
+language: "sl"
+data:
+  - sentences:
+      - "[predvajaj] naslednj(o|i|e) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad] [<here>]"
+      - "preskoči [na naslednj(i|o|a|e)] [pesem|skladbo|komad|epizodo] [<here>]"
+    example: "naslednja pesem"
+    response: "default"

--- a/sentences/sl/HassMediaPause/area_only.yaml
+++ b/sentences/sl/HassMediaPause/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaPause - area_only
+# slots: {area}
+
+language: "sl"
+data:
+  - sentences:
+      - "zaustavi [predvajanje|glasbo|video|film] v {area}"
+      - "daj [glasbo|video|film] v {area} na (pavzo|premor)"
+    example: "zaustavi glasbo v dnevni sobi"
+    response: "default"

--- a/sentences/sl/HassMediaPause/default.yaml
+++ b/sentences/sl/HassMediaPause/default.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaPause - default
+# context_area: true
+
+language: "sl"
+data:
+  - sentences:
+      - "(zaustavi|pavza|premor)"
+      - "zaustavi [predvajanje|glasbo|video|film] [<here>]"
+      - "daj [glasbo|video|film] [<here>] na (pavzo|premor)"
+    example: "zaustavi predvajanje"
+    response: "default"

--- a/sentences/sl/HassMediaUnpause/area_only.yaml
+++ b/sentences/sl/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaUnpause - area_only
+# slots: {area}
+
+language: "sl"
+data:
+  - sentences:
+      - "nadaljuj [predvajanje|glasbo|video|film] v {area}"
+      - "predvajaj (naprej|dalje) v {area}"
+    example: "nadaljuj glasbo v dnevni sobi"
+    response: "default"

--- a/sentences/sl/HassMediaUnpause/default.yaml
+++ b/sentences/sl/HassMediaUnpause/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaUnpause - default
+# context_area: true
+
+language: "sl"
+data:
+  - sentences:
+      - "nadaljuj [predvajanje|glasbo|video|film] [<here>]"
+      - "predvajaj (naprej|dalje) [<here>]"
+    example: "nadaljuj predvajanje"
+    response: "default"

--- a/sentences/sl/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/sl/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,10 @@
+---
+# HassVacuumCleanArea - context_area
+# example: posesaj tukaj
+
+language: "sl"
+data:
+  - sentences:
+      - "(posesaj|počisti|pospravi) <here>"
+    example: "posesaj tukaj"
+    response: "default"

--- a/tests/sl/HassMediaNext/area_only.yaml
+++ b/tests/sl/HassMediaNext/area_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaNext - area_only
+
+language: sl
+areas:
+  - name: Dnevna soba
+entities:
+  - name: TV
+    domain: media_player
+    area: Dnevna soba
+    state: playing
+tests:
+  - sentences:
+      - naslednjo pesem v Dnevna soba
+      - preskoči na naslednjo pesem v Dnevna soba
+    slots:
+      area: Dnevna soba
+    response: Predvajam naslednjo

--- a/tests/sl/HassMediaNext/default.yaml
+++ b/tests/sl/HassMediaNext/default.yaml
@@ -1,0 +1,14 @@
+---
+# HassMediaNext - default
+
+language: sl
+entities:
+  - name: TV
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - naslednjo pesem
+      - predvajaj naslednjo skladbo
+      - preskoči na naslednjo pesem
+    response: Predvajam naslednjo

--- a/tests/sl/HassMediaPause/area_only.yaml
+++ b/tests/sl/HassMediaPause/area_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaPause - area_only
+
+language: sl
+areas:
+  - name: Dnevna soba
+entities:
+  - name: TV
+    domain: media_player
+    area: Dnevna soba
+    state: playing
+tests:
+  - sentences:
+      - zaustavi glasbo v Dnevna soba
+      - daj glasbo v Dnevna soba na pavzo
+    slots:
+      area: Dnevna soba
+    response: Zaustavljeno

--- a/tests/sl/HassMediaPause/default.yaml
+++ b/tests/sl/HassMediaPause/default.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaPause - default
+
+language: sl
+entities:
+  - name: TV
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - zaustavi
+      - pavza
+      - zaustavi predvajanje
+      - daj glasbo na pavzo
+    response: Zaustavljeno

--- a/tests/sl/HassMediaUnpause/area_only.yaml
+++ b/tests/sl/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaUnpause - area_only
+
+language: sl
+areas:
+  - name: Dnevna soba
+entities:
+  - name: TV
+    domain: media_player
+    area: Dnevna soba
+    state: paused
+tests:
+  - sentences:
+      - nadaljuj glasbo v Dnevna soba
+      - predvajaj naprej v Dnevna soba
+    slots:
+      area: Dnevna soba
+    response: Nadaljevano

--- a/tests/sl/HassMediaUnpause/default.yaml
+++ b/tests/sl/HassMediaUnpause/default.yaml
@@ -1,0 +1,13 @@
+---
+# HassMediaUnpause - default
+
+language: sl
+entities:
+  - name: TV
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - nadaljuj predvajanje
+      - predvajaj naprej
+    response: Nadaljevano

--- a/tests/sl/HassVacuumCleanArea/context_area.yaml
+++ b/tests/sl/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,12 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: sl
+areas:
+  - name: Dnevna soba
+tests:
+  - sentences:
+      - posesaj tukaj
+      - počisti tu
+      - pospravi v tem prostoru
+    response: Začenjam čiščenje


### PR DESCRIPTION
Adds the seven slot combinations marked **usable** in `intents.yaml` that were still missing for Slovenian. Each of the three media intents had only `name_only`; this adds the context-area and area variants.

## Combinations added

| Intent | Combo |
| --- | --- |
| `HassMediaNext` | `default`, `area_only` |
| `HassMediaPause` | `default`, `area_only` |
| `HassMediaUnpause` | `default`, `area_only` |
| `HassVacuumCleanArea` | `context_area` |

## Sentences

The wording follows the existing `name_only.yaml` for each intent. The context-area variants reuse the existing `<here>` rule from `rules/sl/common.yaml`; the area variants take `v {area}`:

```
# HassMediaPause
(zaustavi|pavza|premor)
zaustavi [predvajanje|glasbo|video|film] [<here>]
daj [glasbo|video|film] [<here>] na (pavzo|premor)
zaustavi [predvajanje|glasbo|video|film] v {area}

# HassMediaUnpause
nadaljuj [predvajanje|glasbo|video|film] [<here>]
predvajaj (naprej|dalje) [<here>]

# HassMediaNext
[predvajaj] naslednj(o|i|e) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad] [<here>]
preskoči [na naslednj(i|o|a|e)] [pesem|skladbo|komad|epizodo] [<here>]

# HassVacuumCleanArea
(posesaj|počisti|pospravi) <here>
```

## Responses

The Slovenian media responses (Zaustavljeno, Nadaljevano, Predvajam naslednjo) interpolate no slots, so the new combinations reuse the existing `default` key and no response files change. `responses/sl/HassVacuumCleanArea.yaml` is new — the intent did not exist for Slovenian.

Only usable combinations are added; `HassVacuumCleanArea`'s `area_only`/`name_area` are `complete`-tier and remain unimplemented.

## Verification

- `python -m script.intentfest validate --language sl` → All good!
- `pytest tests --language sl` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)