### PR TITLE
Remove unreachable and inactive language leaders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -154,12 +154,6 @@ tests/lb/ @mojikosu
 rules/lb/ @mojikosu
 lists/lb/ @mojikosu
 
-sentences/lt/ @ErnestStaug
-responses/lt/ @ErnestStaug
-tests/lt/ @ErnestStaug
-rules/lt/ @ErnestStaug
-lists/lt/ @ErnestStaug
-
 sentences/lv/ @klejejs @makstech
 responses/lv/ @klejejs @makstech
 tests/lv/ @klejejs @makstech
@@ -214,11 +208,11 @@ tests/pl/ @Uriziel01 @witold-gren
 rules/pl/ @Uriziel01 @witold-gren
 lists/pl/ @Uriziel01 @witold-gren
 
-sentences/pt/ @abmantis @joaorgoncalves @nikito7
-responses/pt/ @abmantis @joaorgoncalves @nikito7
-tests/pt/ @abmantis @joaorgoncalves @nikito7
-rules/pt/ @abmantis @joaorgoncalves @nikito7
-lists/pt/ @abmantis @joaorgoncalves @nikito7
+sentences/pt/ @abmantis @joaorgoncalves
+responses/pt/ @abmantis @joaorgoncalves
+tests/pt/ @abmantis @joaorgoncalves
+rules/pt/ @abmantis @joaorgoncalves
+lists/pt/ @abmantis @joaorgoncalves
 
 sentences/pt-BR/ @luyzfernando08 @mhentschke @staticdev
 responses/pt-BR/ @luyzfernando08 @mhentschke @staticdev
@@ -267,12 +261,6 @@ responses/sw/ @BCorbeek
 tests/sw/ @BCorbeek
 rules/sw/ @BCorbeek
 lists/sw/ @BCorbeek
-
-sentences/ta/ @soan1d
-responses/ta/ @soan1d
-tests/ta/ @soan1d
-rules/ta/ @soan1d
-lists/ta/ @soan1d
 
 sentences/tr/ @alpdmrel
 responses/tr/ @alpdmrel

--- a/languages.yaml
+++ b/languages.yaml
@@ -453,8 +453,6 @@ lb:
         cloud: false
 lt:
   nativeName: Lietuvių
-  leaders:
-    - ErnestStaug
   support:
     LT:
       speech-to-text:
@@ -597,7 +595,6 @@ pt:
   nativeName: Português
   leaders:
     - joaorgoncalves
-    - nikito7
     - abmantis
   support:
     PT:
@@ -722,8 +719,6 @@ sw:
         cloud: true
 ta:
   nativeName: தமிழ்
-  leaders:
-    - soan1d
 te:
   nativeName: తెలుగు
   support:


### PR DESCRIPTION
## Background

`main` currently has **125 CODEOWNERS validation errors**, all "Unknown owner ... make sure @X exists and has write access":

```bash
gh api "repos/OHF-Voice/intents/codeowners/errors?ref=main" --jq '.errors | length'
```

They come from 25 distinct owners in the `leaders:` lists in `languages.yaml` (25 owners x 5 paths each). GitHub **silently ignores** a CODEOWNERS entry whose owner lacks write access, so these leaders were never receiving review requests on PRs touching their own language — the per-language ownership was already dead for them.

Root cause: all 25 are missing from `@OHF-Voice/language-leaders`, are not org members, are not direct repo collaborators, and have no pending invitations. They were listed in `languages.yaml` but never onboarded. The team roster is exactly the 53 non-erroring leaders plus `@balloob` and `@synesthesiam`, which confirms it. `git blame` shows the gap spans 2023-01-05 through 2026-08-03, so this is a standing process defect rather than a one-time slip.

## This PR

Removes the three owners who should **not** simply be invited:

| Language | Leader | Reason |
|---|---|---|
| `lt` | `ErnestStaug` | GitHub account no longer exists — `GET /users/ErnestStaug` returns 404, so this one cannot be fixed by an invitation |
| `ta` | `soan1d` | Never opened a PR against this repo |
| `pt` | `nikito7` | Opened #1214 "Remove myself" in 2023 (closed unmerged), still listed |

`lt` and `ta` now have no `leaders:` key. `leaders` is `vol.Optional` in `validate.py`, and `language_table.py` renders a missing value as "(position open)" — the right signal for recruiting replacements.

`CODEOWNERS` is regenerated; `python3 -m script.intentfest codeowners --check` passes.

This drops the error count from **125 to 110**.

## Follow-up (not in this PR)

The other 22 erroring owners are real, active leaders — several have merged PRs this year. They need to be **added to `@OHF-Voice/language-leaders`**, which is an org membership change and is being handled separately:

`AalianKhan` `BCorbeek` `DrHaque` `alpdmrel` `arunshekher` `chatziko` `chuk-a` `cvladan` `eantonya` `fadamsen` `gabimarchidan` `haim-b` `halecivo` `limitless00net` `mhentschke` `mojikosu` `mrdarrengriffin` `nagyrobi` `poltalashka` `skynetua` `swonge` `urtzai`

Note that an invited user sits at `state: pending` until they accept, and a pending invitee has no write access — so CODEOWNERS keeps ignoring them until then. The error count will drain gradually, not all at once.

Even after that, **13 languages currently have zero effective code owners**: `bn` `eu` `ko` `lb` `lt` `ml` `mn` `sw` `ta` `tr` `uk` `ur` `zh-HK`.

## Preventing regression

Worth adding, once the backlog reaches zero:

1. **A scheduled job against `main`** — the important one. The failure mode where someone leaves the org and their ownership silently dies involves *no repo change at all*, so a PR-triggered check can never catch it.
2. **A PR gate** on PRs touching `languages.yaml` / `CODEOWNERS`, validating the *proposed* CODEOWNERS via the merge ref (verified working):

   ```bash
   gh api "repos/OHF-Voice/intents/codeowners/errors?ref=refs/pull/${PR_NUMBER}/merge" --jq '.errors | length'
   ```

   This must not be enabled until the count actually reaches 0, or it fails every open PR.

`intentfest codeowners --check` itself should stay offline and deterministic so contributors can keep running it locally — the resolution check belongs in a separate authenticated CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)