### PR TITLE
[vi] Add missing usable slot combinations

### DIFF
--- a/lists/vi/lights.yaml
+++ b/lists/vi/lights.yaml
@@ -1,5 +1,15 @@
 language: vi
 lists:
+  color_temperature_names:
+    values:
+      - in: (ánh nến|nến)
+        out: 1900
+      - in: (trắng ấm|vàng ấm)
+        out: 2700
+      - in: (trắng lạnh|trắng mát)
+        out: 4000
+      - in: (ánh sáng ban ngày|ban ngày)
+        out: 6500
   color:
     values:
       - in: trắng

--- a/lists/vi/lights.yaml
+++ b/lists/vi/lights.yaml
@@ -6,7 +6,7 @@ lists:
         out: 1900
       - in: (trắng ấm|vàng ấm)
         out: 2700
-      - in: (trắng lạnh|trắng mát)
+      - in: (trắng lạnh|trắng mát|trung tính)
         out: 4000
       - in: (ánh sáng ban ngày|ban ngày)
         out: 6500

--- a/responses/vi/HassCancelAllTimers.yaml
+++ b/responses/vi/HassCancelAllTimers.yaml
@@ -1,0 +1,16 @@
+language: vi
+responses:
+  intents:
+    HassCancelAllTimers:
+      default: >
+        {% if slots.canceled < 1: %}
+        Không có hẹn giờ nào bị hủy.
+        {% else: %}
+        Đã hủy {{ slots.canceled }} hẹn giờ.
+        {% endif %}
+      area: >
+        {% if slots.canceled < 1: %}
+        Không có hẹn giờ nào bị hủy ở {{ slots.area }}.
+        {% else: %}
+        Đã hủy {{ slots.canceled }} hẹn giờ ở {{ slots.area }}.
+        {% endif %}

--- a/responses/vi/HassCancelTimer.yaml
+++ b/responses/vi/HassCancelTimer.yaml
@@ -1,0 +1,5 @@
+language: vi
+responses:
+  intents:
+    HassCancelTimer:
+      default: "đã hủy hẹn giờ"

--- a/responses/vi/HassGetCurrentDate.yaml
+++ b/responses/vi/HassGetCurrentDate.yaml
@@ -1,0 +1,6 @@
+language: vi
+responses:
+  intents:
+    HassGetCurrentDate:
+      default: >
+        Ngày {{ slots.date.day }} tháng {{ slots.date.month }} năm {{ slots.date.year }}

--- a/responses/vi/HassGetCurrentTime.yaml
+++ b/responses/vi/HassGetCurrentTime.yaml
@@ -1,0 +1,7 @@
+language: vi
+responses:
+  intents:
+    HassGetCurrentTime:
+      default: >
+        {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+        {{ slots.time.hour }} giờ {{ minute_str }} phút

--- a/responses/vi/HassLightSet.yaml
+++ b/responses/vi/HassLightSet.yaml
@@ -4,3 +4,4 @@ responses:
     HassLightSet:
       brightness: "đã thiết lập độ sáng"
       color: "đã thiết lập màu sắc"
+      temperature: "đã thiết lập nhiệt độ màu"

--- a/responses/vi/HassPauseTimer.yaml
+++ b/responses/vi/HassPauseTimer.yaml
@@ -1,0 +1,5 @@
+language: vi
+responses:
+  intents:
+    HassPauseTimer:
+      default: "đã tạm dừng hẹn giờ"

--- a/responses/vi/HassStartTimer.yaml
+++ b/responses/vi/HassStartTimer.yaml
@@ -1,0 +1,25 @@
+language: vi
+responses:
+  intents:
+    HassStartTimer:
+      default: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ ' giờ' if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ ' phút' if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ ' giây' if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list | join(' ') %}
+        {% set name = (' tên ' ~ slots.name | trim) if slots.name is defined else '' %}
+        Đã đặt hẹn giờ {{ text }}{{ name }}
+      command: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ ' giờ' if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ ' phút' if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ ' giây' if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list | join(' ') %}
+        Lệnh sẽ được thực hiện sau {{ text }}

--- a/responses/vi/HassTimerStatus.yaml
+++ b/responses/vi/HassTimerStatus.yaml
@@ -1,0 +1,90 @@
+language: vi
+responses:
+  intents:
+    HassTimerStatus:
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
+        {% if num_timers == 0: %}
+          Không có hẹn giờ nào.
+        {% elif num_active_timers == 0: %}
+          {# Không có hẹn giờ đang chạy #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            Hẹn giờ đang tạm dừng.
+          {% else: %}
+            {{ num_paused_timers }} hẹn giờ đang tạm dừng.
+          {% endif %}
+        {% else: %}
+          {# Có ít nhất một hẹn giờ đang chạy #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# Lấy hẹn giờ đang chạy sẽ kết thúc sớm nhất #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            {{ num_active_timers }} hẹn giờ đang chạy.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            1 hẹn giờ đang tạm dừng.
+          {% elif num_paused_timers > 0: %}
+            {{ num_paused_timers }} hẹn giờ đang tạm dừng.
+          {% endif %}
+        {% endif %}
+
+        {% if next_timer: %}
+          {# Có ít nhất một hẹn giờ đang chạy #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            1 giờ {{ next_timer.rounded_minutes_left }} phút
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            1 giờ
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }} giờ {{ next_timer.rounded_minutes_left }} phút
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }} giờ
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            1 phút {{ next_timer.rounded_seconds_left }} giây
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            1 phút
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }} phút {{ next_timer.rounded_seconds_left }} giây
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }} phút
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            1 giây
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }} giây
+          {% endif %}
+
+          {% if num_timers > 1: %}
+            {# Thêm thông tin để phân biệt #}
+            còn lại trên hẹn giờ
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }} giờ {{ next_timer.start_minutes }} phút
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }} giờ
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }} phút {{ next_timer.start_seconds }} giây
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }} phút
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }} giây
+            {% endif %}
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              {{ next_timer.area }}
+            {% endif %}
+
+            .
+          {% else: %}
+            còn lại.
+          {% endif %}
+        {% endif %}

--- a/responses/vi/HassUnpauseTimer.yaml
+++ b/responses/vi/HassUnpauseTimer.yaml
@@ -1,0 +1,5 @@
+language: vi
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "đã tiếp tục hẹn giờ"

--- a/responses/vi/HassVacuumCleanArea.yaml
+++ b/responses/vi/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: vi
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "đã bắt đầu dọn dẹp"

--- a/rules/vi/timers.yaml
+++ b/rules/vi/timers.yaml
@@ -1,0 +1,4 @@
+language: vi
+expansion_rules:
+  timer_set: (đặt|tạo|hẹn|bật)
+  timer_cancel: (hủy|huỷ|tắt|dừng)

--- a/sentences/vi/HassCancelAllTimers/default.yaml
+++ b/sentences/vi/HassCancelAllTimers/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelAllTimers - default
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_cancel> <all> [cái] hẹn giờ"
+    example: "hủy tất cả hẹn giờ"
+    response: "default"

--- a/sentences/vi/HassCancelTimer/default.yaml
+++ b/sentences/vi/HassCancelTimer/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - default
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_cancel> [cái] hẹn giờ"
+    example: "hủy hẹn giờ"
+    response: "default"

--- a/sentences/vi/HassCancelTimer/hours_only.yaml
+++ b/sentences/vi/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - hours_only
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_cancel> [cái] hẹn giờ {timer_hours:start_hours} giờ"
+    example: "hủy hẹn giờ 5 giờ"
+    response: "default"

--- a/sentences/vi/HassCancelTimer/minutes_only.yaml
+++ b/sentences/vi/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - minutes_only
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_cancel> [cái] hẹn giờ {timer_minutes:start_minutes} phút"
+    example: "hủy hẹn giờ 5 phút"
+    response: "default"

--- a/sentences/vi/HassCancelTimer/seconds_only.yaml
+++ b/sentences/vi/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - seconds_only
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_cancel> [cái] hẹn giờ {timer_seconds:start_seconds} giây"
+    example: "hủy hẹn giờ 5 giây"
+    response: "default"

--- a/sentences/vi/HassGetCurrentDate/default.yaml
+++ b/sentences/vi/HassGetCurrentDate/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassGetCurrentDate - default
+
+language: "vi"
+data:
+  - sentences:
+      - "[hôm nay là] ngày (mấy|bao nhiêu)"
+      - "ngày hôm nay [là ngày mấy]"
+    example: "hôm nay là ngày mấy"
+    response: "default"

--- a/sentences/vi/HassGetCurrentTime/default.yaml
+++ b/sentences/vi/HassGetCurrentTime/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassGetCurrentTime - default
+
+language: "vi"
+data:
+  - sentences:
+      - "[bây giờ là] mấy giờ [rồi]"
+      - "giờ hiện tại [là mấy giờ]"
+    example: "bây giờ là mấy giờ"
+    response: "default"

--- a/sentences/vi/HassLightSet/name_temperature.yaml
+++ b/sentences/vi/HassLightSet/name_temperature.yaml
@@ -1,0 +1,14 @@
+---
+# HassLightSet - name_temperature
+# slots: {temperature}, {name}
+
+language: "vi"
+data:
+  - sentences:
+      - "[<set>] (nhiệt độ màu|nhiệt độ) [của] [cái] {name} [sang|lên|đến] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "[<set>] (nhiệt độ màu|nhiệt độ) [của] [cái] {name} [sang|lên|đến] {color_temperature_names:temperature}"
+      - "[<set>] [cái] {name} (sang|lên|đến) {color_temperature_names:temperature}"
+    example: "đặt nhiệt độ màu đèn phòng ngủ sang 2700 kelvin"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/vi/HassMediaNext/area_only.yaml
+++ b/sentences/vi/HassMediaNext/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaNext - area_only
+# slots: {area}
+
+language: "vi"
+data:
+  - sentences:
+      - "(bài|mục|tập) [hát] (tiếp theo|kế tiếp) <in> {area}"
+      - "chuyển sang (bài|mục|tập) [hát] (tiếp theo|kế tiếp) <in> {area}"
+    example: "bài hát tiếp theo ở phòng khách"
+    response: "default"

--- a/sentences/vi/HassMediaNext/default.yaml
+++ b/sentences/vi/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaNext - default
+# context_area: true
+
+language: "vi"
+data:
+  - sentences:
+      - "(bài|mục|tập) [hát] (tiếp theo|kế tiếp) [<here>]"
+      - "chuyển sang (bài|mục|tập) [hát] (tiếp theo|kế tiếp) [<here>]"
+    example: "bài hát tiếp theo"
+    response: "default"

--- a/sentences/vi/HassMediaPause/area_only.yaml
+++ b/sentences/vi/HassMediaPause/area_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaPause - area_only
+# slots: {area}
+
+language: "vi"
+data:
+  - sentences:
+      - "(tạm dừng|dừng) [nhạc|video|phim|phát] <in> {area}"
+    example: "tạm dừng nhạc ở phòng khách"
+    response: "default"

--- a/sentences/vi/HassMediaPause/default.yaml
+++ b/sentences/vi/HassMediaPause/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaPause - default
+# context_area: true
+
+language: "vi"
+data:
+  - sentences:
+      - "(tạm dừng|dừng) [nhạc|video|phim|phát] [<here>]"
+    example: "tạm dừng nhạc"
+    response: "default"

--- a/sentences/vi/HassMediaUnpause/area_only.yaml
+++ b/sentences/vi/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaUnpause - area_only
+# slots: {area}
+
+language: "vi"
+data:
+  - sentences:
+      - "(phát tiếp|tiếp tục|chạy tiếp) [nhạc|video|phim] <in> {area}"
+    example: "phát tiếp nhạc ở phòng khách"
+    response: "default"

--- a/sentences/vi/HassMediaUnpause/default.yaml
+++ b/sentences/vi/HassMediaUnpause/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaUnpause - default
+# context_area: true
+
+language: "vi"
+data:
+  - sentences:
+      - "(phát tiếp|tiếp tục|chạy tiếp) [nhạc|video|phim] [<here>]"
+    example: "phát tiếp nhạc"
+    response: "default"

--- a/sentences/vi/HassPauseTimer/default.yaml
+++ b/sentences/vi/HassPauseTimer/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassPauseTimer - default
+
+language: "vi"
+data:
+  - sentences:
+      - "(tạm dừng|tạm ngưng) [cái] hẹn giờ"
+    example: "tạm dừng hẹn giờ"
+    response: "default"

--- a/sentences/vi/HassStartTimer/hours_only.yaml
+++ b/sentences/vi/HassStartTimer/hours_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassStartTimer - hours_only
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_set> [hẹn giờ|đồng hồ] {timer_hours:hours} giờ"
+      - "hẹn giờ {timer_hours:hours} giờ"
+    example: "đặt hẹn giờ 5 giờ"
+    response: "default"

--- a/sentences/vi/HassStartTimer/minutes_only.yaml
+++ b/sentences/vi/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassStartTimer - minutes_only
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_set> [hẹn giờ|đồng hồ] {timer_minutes:minutes} phút"
+      - "hẹn giờ {timer_minutes:minutes} phút"
+    example: "đặt hẹn giờ 5 phút"
+    response: "default"

--- a/sentences/vi/HassStartTimer/seconds_only.yaml
+++ b/sentences/vi/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassStartTimer - seconds_only
+
+language: "vi"
+data:
+  - sentences:
+      - "<timer_set> [hẹn giờ|đồng hồ] {timer_seconds:seconds} giây"
+      - "hẹn giờ {timer_seconds:seconds} giây"
+    example: "đặt hẹn giờ 5 giây"
+    response: "default"

--- a/sentences/vi/HassTimerStatus/default.yaml
+++ b/sentences/vi/HassTimerStatus/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassTimerStatus - default
+
+language: "vi"
+data:
+  - sentences:
+      - "còn bao (nhiêu|lâu) [thời gian] [nữa] [trên [cái] hẹn giờ]"
+      - "[cái] hẹn giờ còn bao lâu"
+    example: "còn bao lâu nữa"
+    response: "default"

--- a/sentences/vi/HassUnpauseTimer/default.yaml
+++ b/sentences/vi/HassUnpauseTimer/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassUnpauseTimer - default
+
+language: "vi"
+data:
+  - sentences:
+      - "(tiếp tục|chạy tiếp) [cái] hẹn giờ"
+    example: "tiếp tục hẹn giờ"
+    response: "default"

--- a/sentences/vi/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/vi/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,9 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: "vi"
+data:
+  - sentences:
+      - "(dọn dẹp|hút bụi|lau dọn) <here>"
+    example: "hút bụi ở đây"
+    response: "default"

--- a/tests/vi/HassCancelAllTimers/default.yaml
+++ b/tests/vi/HassCancelAllTimers/default.yaml
@@ -1,0 +1,12 @@
+---
+language: vi
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+  - start_minutes: 10
+    total_seconds_left: 600
+tests:
+  - sentences:
+      - hủy tất cả hẹn giờ
+      - dừng mọi hẹn giờ
+    response: Đã hủy 2 hẹn giờ.

--- a/tests/vi/HassCancelTimer/default.yaml
+++ b/tests/vi/HassCancelTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: vi
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - hủy hẹn giờ
+      - dừng cái hẹn giờ
+    response: đã hủy hẹn giờ

--- a/tests/vi/HassCancelTimer/hours_only.yaml
+++ b/tests/vi/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,11 @@
+---
+language: vi
+timers:
+  - start_hours: 1
+    total_seconds_left: 3600
+tests:
+  - sentences:
+      - hủy hẹn giờ 1 giờ
+    slots:
+      start_hours: 1
+    response: đã hủy hẹn giờ

--- a/tests/vi/HassCancelTimer/minutes_only.yaml
+++ b/tests/vi/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,11 @@
+---
+language: vi
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - hủy hẹn giờ 5 phút
+    slots:
+      start_minutes: 5
+    response: đã hủy hẹn giờ

--- a/tests/vi/HassCancelTimer/seconds_only.yaml
+++ b/tests/vi/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,11 @@
+---
+language: vi
+timers:
+  - start_seconds: 30
+    total_seconds_left: 30
+tests:
+  - sentences:
+      - hủy hẹn giờ 30 giây
+    slots:
+      start_seconds: 30
+    response: đã hủy hẹn giờ

--- a/tests/vi/HassGetCurrentDate/default.yaml
+++ b/tests/vi/HassGetCurrentDate/default.yaml
@@ -1,0 +1,7 @@
+---
+language: vi
+tests:
+  - sentences:
+      - hôm nay là ngày mấy
+      - ngày hôm nay là ngày mấy
+    response: Ngày 17 tháng 9 năm 2013

--- a/tests/vi/HassGetCurrentTime/default.yaml
+++ b/tests/vi/HassGetCurrentTime/default.yaml
@@ -1,0 +1,7 @@
+---
+language: vi
+tests:
+  - sentences:
+      - bây giờ là mấy giờ
+      - giờ hiện tại là mấy giờ
+    response: 1 giờ 02 phút

--- a/tests/vi/HassLightSet/name_temperature.yaml
+++ b/tests/vi/HassLightSet/name_temperature.yaml
@@ -1,0 +1,38 @@
+---
+language: vi
+entities:
+  - name: đèn phòng ngủ
+    domain: light
+tests:
+  - sentences:
+      - đặt nhiệt độ màu đèn phòng ngủ sang 2700 kelvin
+      - thay đổi nhiệt độ của đèn phòng ngủ đến 2700
+    slots:
+      name: đèn phòng ngủ
+      temperature: 2700
+    response: đã thiết lập nhiệt độ màu
+  - sentences:
+      - đặt nhiệt độ màu đèn phòng ngủ sang trắng ấm
+      - đặt đèn phòng ngủ sang vàng ấm
+    slots:
+      name: đèn phòng ngủ
+      temperature: 2700
+    response: đã thiết lập nhiệt độ màu
+  - sentences:
+      - đặt nhiệt độ màu đèn phòng ngủ sang trắng lạnh
+    slots:
+      name: đèn phòng ngủ
+      temperature: 4000
+    response: đã thiết lập nhiệt độ màu
+  - sentences:
+      - đặt nhiệt độ màu đèn phòng ngủ sang ánh nến
+    slots:
+      name: đèn phòng ngủ
+      temperature: 1900
+    response: đã thiết lập nhiệt độ màu
+  - sentences:
+      - đặt nhiệt độ màu đèn phòng ngủ sang ánh sáng ban ngày
+    slots:
+      name: đèn phòng ngủ
+      temperature: 6500
+    response: đã thiết lập nhiệt độ màu

--- a/tests/vi/HassLightSet/name_temperature.yaml
+++ b/tests/vi/HassLightSet/name_temperature.yaml
@@ -20,6 +20,7 @@ tests:
     response: đã thiết lập nhiệt độ màu
   - sentences:
       - đặt nhiệt độ màu đèn phòng ngủ sang trắng lạnh
+      - đặt nhiệt độ màu đèn phòng ngủ sang trung tính
     slots:
       name: đèn phòng ngủ
       temperature: 4000

--- a/tests/vi/HassMediaNext/area_only.yaml
+++ b/tests/vi/HassMediaNext/area_only.yaml
@@ -1,0 +1,16 @@
+---
+language: vi
+areas:
+  - name: phòng khách
+entities:
+  - name: TV
+    domain: media_player
+    area: phòng khách
+    state: playing
+tests:
+  - sentences:
+      - bài hát tiếp theo ở phòng khách
+      - chuyển sang bài kế tiếp trong phòng khách
+    slots:
+      area: phòng khách
+    response: Đang chuyển sang mục tiếp theo

--- a/tests/vi/HassMediaNext/default.yaml
+++ b/tests/vi/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+---
+language: vi
+entities:
+  - name: TV
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - bài hát tiếp theo
+      - chuyển sang bài kế tiếp
+    response: Đang chuyển sang mục tiếp theo

--- a/tests/vi/HassMediaPause/area_only.yaml
+++ b/tests/vi/HassMediaPause/area_only.yaml
@@ -1,0 +1,16 @@
+---
+language: vi
+areas:
+  - name: phòng khách
+entities:
+  - name: TV
+    domain: media_player
+    area: phòng khách
+    state: playing
+tests:
+  - sentences:
+      - tạm dừng nhạc ở phòng khách
+      - dừng phim trong phòng khách
+    slots:
+      area: phòng khách
+    response: đã tạm dừng

--- a/tests/vi/HassMediaPause/default.yaml
+++ b/tests/vi/HassMediaPause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: vi
+entities:
+  - name: TV
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - tạm dừng nhạc
+      - dừng phim ở đây
+    response: đã tạm dừng

--- a/tests/vi/HassMediaUnpause/area_only.yaml
+++ b/tests/vi/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,16 @@
+---
+language: vi
+areas:
+  - name: phòng khách
+entities:
+  - name: TV
+    domain: media_player
+    area: phòng khách
+    state: paused
+tests:
+  - sentences:
+      - phát tiếp nhạc ở phòng khách
+      - tiếp tục phim trong phòng khách
+    slots:
+      area: phòng khách
+    response: đã phát tiếp

--- a/tests/vi/HassMediaUnpause/default.yaml
+++ b/tests/vi/HassMediaUnpause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: vi
+entities:
+  - name: TV
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - phát tiếp nhạc
+      - tiếp tục phim ở đây
+    response: đã phát tiếp

--- a/tests/vi/HassPauseTimer/default.yaml
+++ b/tests/vi/HassPauseTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: vi
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - tạm dừng hẹn giờ
+      - tạm ngưng cái hẹn giờ
+    response: đã tạm dừng hẹn giờ

--- a/tests/vi/HassStartTimer/hours_only.yaml
+++ b/tests/vi/HassStartTimer/hours_only.yaml
@@ -1,0 +1,9 @@
+---
+language: vi
+tests:
+  - sentences:
+      - đặt hẹn giờ 1 giờ
+      - hẹn giờ 1 giờ
+    slots:
+      hours: 1
+    response: Đã đặt hẹn giờ 1 giờ

--- a/tests/vi/HassStartTimer/minutes_only.yaml
+++ b/tests/vi/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,9 @@
+---
+language: vi
+tests:
+  - sentences:
+      - đặt hẹn giờ 5 phút
+      - hẹn giờ 5 phút
+    slots:
+      minutes: 5
+    response: Đã đặt hẹn giờ 5 phút

--- a/tests/vi/HassStartTimer/seconds_only.yaml
+++ b/tests/vi/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+---
+language: vi
+tests:
+  - sentences:
+      - đặt hẹn giờ 30 giây
+      - hẹn giờ 30 giây
+    slots:
+      seconds: 30
+    response: Đã đặt hẹn giờ 30 giây

--- a/tests/vi/HassTimerStatus/default.yaml
+++ b/tests/vi/HassTimerStatus/default.yaml
@@ -1,0 +1,14 @@
+---
+language: vi
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - còn bao lâu nữa
+      - cái hẹn giờ còn bao lâu
+    response: 5 phút còn lại.

--- a/tests/vi/HassUnpauseTimer/default.yaml
+++ b/tests/vi/HassUnpauseTimer/default.yaml
@@ -1,0 +1,11 @@
+---
+language: vi
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+    is_active: false
+tests:
+  - sentences:
+      - tiếp tục hẹn giờ
+      - chạy tiếp cái hẹn giờ
+    response: đã tiếp tục hẹn giờ

--- a/tests/vi/HassVacuumCleanArea/context_area.yaml
+++ b/tests/vi/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,9 @@
+---
+language: vi
+areas:
+  - name: phòng khách
+tests:
+  - sentences:
+      - hút bụi ở đây
+      - dọn dẹp chỗ này
+    response: đã bắt đầu dọn dẹp


### PR DESCRIPTION
Adds the 21 slot combinations marked **usable** in `intents.yaml` that were still missing for Vietnamese. Vietnamese had no timer support at all, so most of this is the usable timer family.

## Combinations added

| Intent | Combos |
| --- | --- |
| `HassStartTimer` | `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelTimer` | `default`, `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelAllTimers` / `HassPauseTimer` / `HassUnpauseTimer` / `HassTimerStatus` | `default` |
| `HassGetCurrentDate` / `HassGetCurrentTime` | `default` |
| `HassLightSet` | `name_temperature` |
| `HassMediaNext` / `HassMediaPause` / `HassMediaUnpause` | `default`, `area_only` |
| `HassVacuumCleanArea` | `context_area` |

## New response files

Nine intents had no Vietnamese response file: `HassStartTimer`, `HassCancelTimer`, `HassCancelAllTimers`, `HassPauseTimer`, `HassUnpauseTimer`, `HassTimerStatus`, `HassGetCurrentDate`, `HassGetCurrentTime`, `HassVacuumCleanArea`.

Two simplifications versus the English templates, both because Vietnamese has no grammatical number and no AM/PM convention in everyday speech:

- The timer templates drop the singular/plural branching (`5 phút`, never `5 phúts`). The `half`/`1/2` handling is kept.
- `HassGetCurrentTime` renders 24-hour (`13 giờ 02 phút`) rather than the English 12-hour AM/PM branching.
- `HassGetCurrentDate` renders `Ngày D tháng M năm YYYY`, so no month-name or ordinal table is needed.

## New rule file

`rules/vi/timers.yaml`:

```yaml
timer_set: (đặt|tạo|hẹn|bật)
timer_cancel: (hủy|huỷ|tắt|dừng)
```

Note `dừng` is in `timer_cancel`, so `HassPauseTimer` deliberately uses `(tạm dừng|tạm ngưng)` rather than plain `dừng` — otherwise "dừng cái hẹn giờ" is ambiguous between cancel and pause and the recognizer picks cancel.

## Colour temperature names

| Vietnamese | Kelvin |
| --- | --- |
| ánh nến / nến | 1900 |
| trắng ấm / vàng ấm | 2700 |
| trắng lạnh / trắng mát | 4000 |
| ánh sáng ban ngày / ban ngày | 6500 |

## Verification

- `python -m script.intentfest validate --language vi` → All good!
- `pytest tests --language vi` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)