### PR TITLE
[lb] Add missing usable slot combinations

### DIFF
--- a/lists/lb/lights.yaml
+++ b/lists/lb/lights.yaml
@@ -1,5 +1,15 @@
 language: lb
 lists:
+  color_temperature_names:
+    values:
+      - in: (Käerzeliicht | Käerz)
+        out: 1900
+      - in: waarm wäiss
+        out: 2700
+      - in: kal wäiss
+        out: 4000
+      - in: Dagesliicht
+        out: 6500
   color:
     values:
       - in: wäiss

--- a/responses/lb/HassCancelAllTimers.yaml
+++ b/responses/lb/HassCancelAllTimers.yaml
@@ -1,0 +1,20 @@
+language: lb
+responses:
+  intents:
+    HassCancelAllTimers:
+      default: >
+        {% if slots.canceled < 1: %}
+        Keen Timer annulléiert.
+        {% elif slots.canceled == 1: %}
+        1 Timer annulléiert.
+        {% else: %}
+        {{ slots.canceled }} Timere annulléiert.
+        {% endif %}
+      area: >
+        {% if slots.canceled < 1: %}
+        Keen Timer am {{ slots.area }} annulléiert.
+        {% elif slots.canceled == 1: %}
+        1 Timer am {{ slots.area }} annulléiert.
+        {% else: %}
+        {{ slots.canceled }} Timere am {{ slots.area }} annulléiert.
+        {% endif %}

--- a/responses/lb/HassCancelTimer.yaml
+++ b/responses/lb/HassCancelTimer.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassCancelTimer:
+      default: "Den Timer ass annulléiert"

--- a/responses/lb/HassLightSet.yaml
+++ b/responses/lb/HassLightSet.yaml
@@ -6,3 +6,4 @@ responses:
       brightness_area: "D'Hellegkeet am {{ slots.area }} ass elo {{ slots.brightness }}"
       color: "{{ slots.name }} Faarf ass elo {{ slots.color }}"
       color_area: "D'Faarf am {{ slots.area }} ass elo {{ slots.color }}"
+      temperature: "{{ slots.name }} Faarftemperatur ass geännert"

--- a/responses/lb/HassMediaNext.yaml
+++ b/responses/lb/HassMediaNext.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassMediaNext:
+      default: "Spillt dat nächst"

--- a/responses/lb/HassMediaPause.yaml
+++ b/responses/lb/HassMediaPause.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassMediaPause:
+      default: "Pauséiert"

--- a/responses/lb/HassMediaUnpause.yaml
+++ b/responses/lb/HassMediaUnpause.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassMediaUnpause:
+      default: "Leeft weider"

--- a/responses/lb/HassNevermind.yaml
+++ b/responses/lb/HassNevermind.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/lb/HassPauseTimer.yaml
+++ b/responses/lb/HassPauseTimer.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassPauseTimer:
+      default: "Den Timer ass pauséiert"

--- a/responses/lb/HassStartTimer.yaml
+++ b/responses/lb/HassStartTimer.yaml
@@ -1,0 +1,25 @@
+language: lb
+responses:
+  intents:
+    HassStartTimer:
+      default: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ (' Stonn' if h in [ "1", 'one'] else ' Stonnen') if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ (' Minutt' if m in [ "1", 'one'] else ' Minutten') if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ (' Sekonn' if s in [ "1", 'one'] else ' Sekonnen') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' an ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' an ') %}
+        {% set name = (' mam Numm ' ~ slots.name | trim) if slots.name is defined else '' %}
+        Timer gesat op {{ text }}{{ name }}
+      command: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ (' Stonn' if h in [ "1", 'one'] else ' Stonnen') if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ (' Minutt' if m in [ "1", 'one'] else ' Minutten') if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ (' Sekonn' if s in [ "1", 'one'] else ' Sekonnen') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' an ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' an ') %}
+        De Kommando gëtt an {{ text }} ausgefouert

--- a/responses/lb/HassTimerStatus.yaml
+++ b/responses/lb/HassTimerStatus.yaml
@@ -1,0 +1,90 @@
+language: lb
+responses:
+  intents:
+    HassTimerStatus:
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
+        {% if num_timers == 0: %}
+          Keng Timeren.
+        {% elif num_active_timers == 0: %}
+          {# Keng aktiv Timeren #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            Den Timer ass pauséiert.
+          {% else: %}
+            {{ num_paused_timers }} pauséiert Timeren.
+          {% endif %}
+        {% else: %}
+          {# Mindestens een aktiven Timer #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# Kréi den aktiven Timer deen als éischt fäerdeg ass #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            {{ num_active_timers }} lafend Timeren.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            1 pauséierten Timer.
+          {% elif num_paused_timers > 0: %}
+            {{ num_paused_timers }} pauséiert Timeren.
+          {% endif %}
+        {% endif %}
+
+        {% if next_timer: %}
+          {# Mindestens een aktiven Timer #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            1 Stonn an {{ next_timer.rounded_minutes_left }} Minutten
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            1 Stonn
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }} Stonnen an {{ next_timer.rounded_minutes_left }} Minutten
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }} Stonnen
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            1 Minutt an {{ next_timer.rounded_seconds_left }} Sekonnen
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            1 Minutt
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }} Minutten an {{ next_timer.rounded_seconds_left }} Sekonnen
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }} Minutten
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            1 Sekonn
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }} Sekonnen
+          {% endif %}
+
+          {% if num_timers > 1: %}
+            {# Zousätzlech Informatioun fir z'ënnerscheeden #}
+            iwwreg um
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }} Stonn an {{ next_timer.start_minutes }} Minutt
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }} Stonn
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }} Minutt an {{ next_timer.start_seconds }} Sekonn
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }} Minutt
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }} Sekonn
+            {% endif %}
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              {{ next_timer.area }}
+            {% endif %}
+
+            Timer.
+          {% else: %}
+            iwwreg.
+          {% endif %}
+        {% endif %}

--- a/responses/lb/HassUnpauseTimer.yaml
+++ b/responses/lb/HassUnpauseTimer.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "Den Timer leeft weider"

--- a/responses/lb/HassVacuumCleanArea.yaml
+++ b/responses/lb/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: lb
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Fänken un ze botzen"

--- a/rules/lb/timers.yaml
+++ b/rules/lb/timers.yaml
@@ -1,0 +1,4 @@
+language: lb
+expansion_rules:
+  timer_set: (setz | stell | maach | start)
+  timer_cancel: (annulléier | stopp | briech of)

--- a/sentences/lb/HassCancelAllTimers/default.yaml
+++ b/sentences/lb/HassCancelAllTimers/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelAllTimers - default
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_cancel> <all> [d'] Timeren"
+    example: "annulléier all Timeren"
+    response: "default"

--- a/sentences/lb/HassCancelTimer/default.yaml
+++ b/sentences/lb/HassCancelTimer/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - default
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_cancel> [den] Timer"
+    example: "annulléier den Timer"
+    response: "default"

--- a/sentences/lb/HassCancelTimer/hours_only.yaml
+++ b/sentences/lb/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - hours_only
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_cancel> [den] {timer_hours:start_hours} Stonn[en] Timer"
+    example: "annulléier den 5 Stonn[en] Timer"
+    response: "default"

--- a/sentences/lb/HassCancelTimer/minutes_only.yaml
+++ b/sentences/lb/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - minutes_only
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_cancel> [den] {timer_minutes:start_minutes} Minutt[en] Timer"
+    example: "annulléier den 5 Minutt[en] Timer"
+    response: "default"

--- a/sentences/lb/HassCancelTimer/seconds_only.yaml
+++ b/sentences/lb/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - seconds_only
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_cancel> [den] {timer_seconds:start_seconds} Sekonn[en] Timer"
+    example: "annulléier den 5 Sekonn[en] Timer"
+    response: "default"

--- a/sentences/lb/HassLightSet/name_temperature.yaml
+++ b/sentences/lb/HassLightSet/name_temperature.yaml
@@ -1,0 +1,13 @@
+---
+# HassLightSet - name_temperature
+
+language: lb
+data:
+  - sentences:
+      - "<maach> [<the>] [d']{name} [Faarftemperatur] op {color_temperature:temperature}[[ ](k|Kelvin)]"
+      - "<maach> [[d']Faarftemperatur] (vu | vun | vum) [<the>] [d']{name} op {color_temperature:temperature}[[ ](k|Kelvin)]"
+      - "<maach> [<the>] [d']{name} [Faarftemperatur] op {color_temperature_names:temperature}"
+    example: "Maach d'Luucht op 2700 Kelvin"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/lb/HassMediaNext/area_only.yaml
+++ b/sentences/lb/HassMediaNext/area_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaNext - area_only
+# slots: {area}
+
+language: "lb"
+data:
+  - sentences:
+      - "nächst (Lidd|Titel|Episod) <in> [<the>] {area}"
+    example: "nächst Lidd am Wunnzëmmer"
+    response: "default"

--- a/sentences/lb/HassMediaNext/default.yaml
+++ b/sentences/lb/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaNext - default
+# context_area: true
+
+language: "lb"
+data:
+  - sentences:
+      - "nächst (Lidd|Titel|Episod) [<here>]"
+      - "spring op dat nächst [Lidd|Titel|Episod] [<here>]"
+    example: "nächst Lidd"
+    response: "default"

--- a/sentences/lb/HassMediaNext/name_only.yaml
+++ b/sentences/lb/HassMediaNext/name_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaNext - name_only
+# slots: {name}
+
+language: "lb"
+data:
+  - sentences:
+      - "nächst (Lidd|Titel|Episod) op [<the>] [d']{name}"
+    example: "nächst Lidd op dem Fernseh"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/lb/HassMediaPause/area_only.yaml
+++ b/sentences/lb/HassMediaPause/area_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaPause - area_only
+# slots: {area}
+
+language: "lb"
+data:
+  - sentences:
+      - "pauséier [d'](Musek|Video|Film|Ofspillen) <in> [<the>] {area}"
+    example: "pauséier d'Musek am Wunnzëmmer"
+    response: "default"

--- a/sentences/lb/HassMediaPause/default.yaml
+++ b/sentences/lb/HassMediaPause/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaPause - default
+# context_area: true
+
+language: "lb"
+data:
+  - sentences:
+      - "pauséier [d'](Musek|Video|Film|Ofspillen) [<here>]"
+      - "pauséier [<here>]"
+    example: "pauséier d'Musek"
+    response: "default"

--- a/sentences/lb/HassMediaPause/name_only.yaml
+++ b/sentences/lb/HassMediaPause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaPause - name_only
+# slots: {name}
+
+language: "lb"
+data:
+  - sentences:
+      - "pauséier [<the>] [d']{name}"
+    example: "pauséier den Fernseh"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/lb/HassMediaUnpause/area_only.yaml
+++ b/sentences/lb/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaUnpause - area_only
+# slots: {area}
+
+language: "lb"
+data:
+  - sentences:
+      - "(maach|loos) [d'](Musek|Video|Film|Ofspillen) <in> [<the>] {area} weider"
+    example: "maach d'Musek am Wunnzëmmer weider"
+    response: "default"

--- a/sentences/lb/HassMediaUnpause/default.yaml
+++ b/sentences/lb/HassMediaUnpause/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaUnpause - default
+# context_area: true
+
+language: "lb"
+data:
+  - sentences:
+      - "(maach|loos) [d'](Musek|Video|Film|Ofspillen) [<here>] weider"
+    example: "maach d'Musek weider"
+    response: "default"

--- a/sentences/lb/HassMediaUnpause/name_only.yaml
+++ b/sentences/lb/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaUnpause - name_only
+# slots: {name}
+
+language: "lb"
+data:
+  - sentences:
+      - "(maach|loos) [<the>] [d']{name} weider"
+    example: "maach den Fernseh weider"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/lb/HassNevermind/default.yaml
+++ b/sentences/lb/HassNevermind/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassNevermind - default
+
+language: "lb"
+data:
+  - sentences:
+      - "(egal|vergiess et|net wichteg|ofbriechen|loos et sinn)"
+    example: "egal"
+    response: "default"

--- a/sentences/lb/HassPauseTimer/default.yaml
+++ b/sentences/lb/HassPauseTimer/default.yaml
@@ -1,0 +1,9 @@
+---
+# HassPauseTimer - default
+
+language: "lb"
+data:
+  - sentences:
+      - "pauséier [den] Timer"
+    example: "pauséier den Timer"
+    response: "default"

--- a/sentences/lb/HassStartTimer/hours_only.yaml
+++ b/sentences/lb/HassStartTimer/hours_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassStartTimer - hours_only
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_set> [en] Timer op {timer_hours:hours} Stonn[en]"
+      - "<timer_set> [en] {timer_hours:hours} Stonn[en] Timer"
+    example: "setz en Timer op 5 Stonn[en]"
+    response: "default"

--- a/sentences/lb/HassStartTimer/minutes_only.yaml
+++ b/sentences/lb/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassStartTimer - minutes_only
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_set> [en] Timer op {timer_minutes:minutes} Minutt[en]"
+      - "<timer_set> [en] {timer_minutes:minutes} Minutt[en] Timer"
+    example: "setz en Timer op 5 Minutt[en]"
+    response: "default"

--- a/sentences/lb/HassStartTimer/seconds_only.yaml
+++ b/sentences/lb/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassStartTimer - seconds_only
+
+language: "lb"
+data:
+  - sentences:
+      - "<timer_set> [en] Timer op {timer_seconds:seconds} Sekonn[en]"
+      - "<timer_set> [en] {timer_seconds:seconds} Sekonn[en] Timer"
+    example: "setz en Timer op 5 Sekonn[en]"
+    response: "default"

--- a/sentences/lb/HassTimerStatus/default.yaml
+++ b/sentences/lb/HassTimerStatus/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassTimerStatus - default
+
+language: "lb"
+data:
+  - sentences:
+      - "wéi vill Zäit ass nach iwwreg [um Timer]"
+      - "wéi laang leeft den Timer nach"
+    example: "wéi vill Zäit ass nach iwwreg"
+    response: "default"

--- a/sentences/lb/HassUnpauseTimer/default.yaml
+++ b/sentences/lb/HassUnpauseTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassUnpauseTimer - default
+
+language: "lb"
+data:
+  - sentences:
+      - "(maach|loos) [den] Timer weider"
+      - "setz [den] Timer fort"
+    example: "maach den Timer weider"
+    response: "default"

--- a/sentences/lb/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/lb/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,9 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: "lb"
+data:
+  - sentences:
+      - "(botz|sauber|stëbssaug) <here>"
+    example: "botz hei"
+    response: "default"

--- a/tests/lb/HassCancelAllTimers/default.yaml
+++ b/tests/lb/HassCancelAllTimers/default.yaml
@@ -1,0 +1,12 @@
+---
+language: lb
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+  - start_minutes: 10
+    total_seconds_left: 600
+tests:
+  - sentences:
+      - annulléier all Timeren
+      - stopp alleguer d' Timeren
+    response: 2 Timere annulléiert.

--- a/tests/lb/HassCancelTimer/default.yaml
+++ b/tests/lb/HassCancelTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: lb
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - annulléier den Timer
+      - stopp den Timer
+    response: Den Timer ass annulléiert

--- a/tests/lb/HassCancelTimer/hours_only.yaml
+++ b/tests/lb/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,11 @@
+---
+language: lb
+timers:
+  - start_hours: 1
+    total_seconds_left: 3600
+tests:
+  - sentences:
+      - annulléier den 1 Stonn Timer
+    slots:
+      start_hours: 1
+    response: Den Timer ass annulléiert

--- a/tests/lb/HassCancelTimer/minutes_only.yaml
+++ b/tests/lb/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,11 @@
+---
+language: lb
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - annulléier den 5 Minutten Timer
+    slots:
+      start_minutes: 5
+    response: Den Timer ass annulléiert

--- a/tests/lb/HassCancelTimer/seconds_only.yaml
+++ b/tests/lb/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,11 @@
+---
+language: lb
+timers:
+  - start_seconds: 30
+    total_seconds_left: 30
+tests:
+  - sentences:
+      - annulléier den 30 Sekonnen Timer
+    slots:
+      start_seconds: 30
+    response: Den Timer ass annulléiert

--- a/tests/lb/HassLightSet/name_temperature.yaml
+++ b/tests/lb/HassLightSet/name_temperature.yaml
@@ -1,0 +1,37 @@
+---
+language: lb
+entities:
+  - name: Luucht
+    domain: light
+tests:
+  - sentences:
+      - Maach d'Luucht op 2700 Kelvin
+      - Maach d'Faarftemperatur vun der Luucht op 2700 Kelvin
+    slots:
+      name: Luucht
+      temperature: 2700
+    response: Luucht Faarftemperatur ass geännert
+  - sentences:
+      - Maach d'Luucht op waarm wäiss
+    slots:
+      name: Luucht
+      temperature: 2700
+    response: Luucht Faarftemperatur ass geännert
+  - sentences:
+      - Maach d'Luucht op kal wäiss
+    slots:
+      name: Luucht
+      temperature: 4000
+    response: Luucht Faarftemperatur ass geännert
+  - sentences:
+      - Maach d'Luucht op Käerzeliicht
+    slots:
+      name: Luucht
+      temperature: 1900
+    response: Luucht Faarftemperatur ass geännert
+  - sentences:
+      - Maach d'Luucht op Dagesliicht
+    slots:
+      name: Luucht
+      temperature: 6500
+    response: Luucht Faarftemperatur ass geännert

--- a/tests/lb/HassMediaNext/area_only.yaml
+++ b/tests/lb/HassMediaNext/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: lb
+areas:
+  - name: Wunnzëmmer
+entities:
+  - name: Fernseh
+    domain: media_player
+    area: Wunnzëmmer
+    state: playing
+tests:
+  - sentences:
+      - nächst Lidd am Wunnzëmmer
+    slots:
+      area: Wunnzëmmer
+    response: Spillt dat nächst

--- a/tests/lb/HassMediaNext/default.yaml
+++ b/tests/lb/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+---
+language: lb
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - nächst Lidd
+      - spring op dat nächst
+    response: Spillt dat nächst

--- a/tests/lb/HassMediaNext/name_only.yaml
+++ b/tests/lb/HassMediaNext/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: lb
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - nächst Lidd op dem Fernseh
+    slots:
+      name: Fernseh
+    response: Spillt dat nächst

--- a/tests/lb/HassMediaPause/area_only.yaml
+++ b/tests/lb/HassMediaPause/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: lb
+areas:
+  - name: Wunnzëmmer
+entities:
+  - name: Fernseh
+    domain: media_player
+    area: Wunnzëmmer
+    state: playing
+tests:
+  - sentences:
+      - pauséier d'Musek am Wunnzëmmer
+    slots:
+      area: Wunnzëmmer
+    response: Pauséiert

--- a/tests/lb/HassMediaPause/default.yaml
+++ b/tests/lb/HassMediaPause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: lb
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - pauséier d'Musek
+      - pauséier hei
+    response: Pauséiert

--- a/tests/lb/HassMediaPause/name_only.yaml
+++ b/tests/lb/HassMediaPause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: lb
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - pauséier den Fernseh
+    slots:
+      name: Fernseh
+    response: Pauséiert

--- a/tests/lb/HassMediaUnpause/area_only.yaml
+++ b/tests/lb/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: lb
+areas:
+  - name: Wunnzëmmer
+entities:
+  - name: Fernseh
+    domain: media_player
+    area: Wunnzëmmer
+    state: paused
+tests:
+  - sentences:
+      - maach d'Musek am Wunnzëmmer weider
+    slots:
+      area: Wunnzëmmer
+    response: Leeft weider

--- a/tests/lb/HassMediaUnpause/default.yaml
+++ b/tests/lb/HassMediaUnpause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: lb
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - maach d'Musek weider
+      - loos d'Film hei weider
+    response: Leeft weider

--- a/tests/lb/HassMediaUnpause/name_only.yaml
+++ b/tests/lb/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: lb
+entities:
+  - name: Fernseh
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - maach den Fernseh weider
+    slots:
+      name: Fernseh
+    response: Leeft weider

--- a/tests/lb/HassNevermind/default.yaml
+++ b/tests/lb/HassNevermind/default.yaml
@@ -1,0 +1,8 @@
+---
+language: lb
+tests:
+  - sentences:
+      - egal
+      - vergiess et
+      - net wichteg
+    response: ""

--- a/tests/lb/HassPauseTimer/default.yaml
+++ b/tests/lb/HassPauseTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: lb
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - pauséier den Timer
+      - pauséier Timer
+    response: Den Timer ass pauséiert

--- a/tests/lb/HassStartTimer/hours_only.yaml
+++ b/tests/lb/HassStartTimer/hours_only.yaml
@@ -1,0 +1,9 @@
+---
+language: lb
+tests:
+  - sentences:
+      - setz en Timer op 1 Stonn
+      - setz en 1 Stonn Timer
+    slots:
+      hours: 1
+    response: Timer gesat op 1 Stonn

--- a/tests/lb/HassStartTimer/minutes_only.yaml
+++ b/tests/lb/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,9 @@
+---
+language: lb
+tests:
+  - sentences:
+      - setz en Timer op 5 Minutten
+      - stell en 5 Minutten Timer
+    slots:
+      minutes: 5
+    response: Timer gesat op 5 Minutten

--- a/tests/lb/HassStartTimer/seconds_only.yaml
+++ b/tests/lb/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+---
+language: lb
+tests:
+  - sentences:
+      - setz en Timer op 30 Sekonnen
+      - stell en 30 Sekonnen Timer
+    slots:
+      seconds: 30
+    response: Timer gesat op 30 Sekonnen

--- a/tests/lb/HassTimerStatus/default.yaml
+++ b/tests/lb/HassTimerStatus/default.yaml
@@ -1,0 +1,14 @@
+---
+language: lb
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - wéi vill Zäit ass nach iwwreg
+      - wéi laang leeft den Timer nach
+    response: 5 Minutten iwwreg.

--- a/tests/lb/HassUnpauseTimer/default.yaml
+++ b/tests/lb/HassUnpauseTimer/default.yaml
@@ -1,0 +1,11 @@
+---
+language: lb
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+    is_active: false
+tests:
+  - sentences:
+      - maach den Timer weider
+      - setz den Timer fort
+    response: Den Timer leeft weider

--- a/tests/lb/HassVacuumCleanArea/context_area.yaml
+++ b/tests/lb/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,9 @@
+---
+language: lb
+areas:
+  - name: Wunnzëmmer
+tests:
+  - sentences:
+      - botz hei
+      - stëbssaug an dësem Raum
+    response: Fänken un ze botzen


### PR DESCRIPTION
Adds the 23 slot combinations marked **usable** in `intents.yaml` that were still missing for Luxembourgish. Luxembourgish previously had only lights, climate, state, weather, date and time — no timers, no media, no vacuum.

## Combinations added

| Intent | Combos |
| --- | --- |
| `HassStartTimer` | `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelTimer` | `default`, `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelAllTimers` / `HassPauseTimer` / `HassUnpauseTimer` / `HassTimerStatus` | `default` |
| `HassNevermind` | `default` |
| `HassLightSet` | `name_temperature` |
| `HassMediaNext` / `HassMediaPause` / `HassMediaUnpause` | `default`, `name_only`, `area_only` |
| `HassVacuumCleanArea` | `context_area` |

## New response files

Nine: `HassStartTimer`, `HassCancelTimer`, `HassCancelAllTimers`, `HassPauseTimer`, `HassUnpauseTimer`, `HassTimerStatus`, `HassMediaNext`, `HassMediaPause`, `HassMediaUnpause`, `HassNevermind`, `HassVacuumCleanArea`.

The `HassStartTimer` and `HassTimerStatus` Jinja templates keep the English structure, including the singular/plural branching, with Stonn/Stonnen, Minutt/Minutten, Sekonn/Sekonnen.

## New rule file

`rules/lb/timers.yaml`:

```yaml
timer_set: (setz | stell | maach | start)
timer_cancel: (annulléier | stopp | briech of)
```

## Note on elision

The media templates write the article as `[d'](Musek|Video|Film|Ofspillen)` — adjacent, with no space — matching how the existing `HassLightSet`/`HassTurnOn` sentences write `[d']{name}`. Writing it as a separate `[d'|de]` token does not match d'Musek.

## Colour temperature names

| Luxembourgish | Kelvin |
| --- | --- |
| Käerzeliicht / Käerz | 1900 |
| waarm wäiss | 2700 |
| kal wäiss | 4000 |
| Dagesliicht | 6500 |

## Verification

- `python -m script.intentfest validate --language lb` → All good!
- `pytest tests --language lb` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)