### PR TITLE
[cy] Add missing usable slot combinations and translate responses

### DIFF
--- a/lists/cy/lights.yaml
+++ b/lists/cy/lights.yaml
@@ -1,0 +1,42 @@
+language: cy
+lists:
+  color:
+    values:
+      - in: gwyn
+        out: white
+      - in: du
+        out: black
+      - in: coch
+        out: red
+      - in: oren
+        out: orange
+      - in: melyn
+        out: yellow
+      - in: gwyrdd
+        out: green
+      - in: glas
+        out: blue
+      - in: porffor
+        out: purple
+      - in: brown
+        out: brown
+      - in: pinc
+        out: pink
+      - in: gwyrddlas
+        out: turquoise
+  brightness_level:
+    values:
+      - in: (uchaf|mwyaf|llawn)
+        out: 100
+      - in: (isaf|lleiaf)
+        out: 1
+  color_temperature_names:
+    values:
+      - in: (golau cannwyll|cannwyll)
+        out: 1900
+      - in: gwyn cynnes
+        out: 2700
+      - in: gwyn oer
+        out: 4000
+      - in: golau dydd
+        out: 6500

--- a/responses/cy/HassCancelAllTimers.yaml
+++ b/responses/cy/HassCancelAllTimers.yaml
@@ -2,16 +2,19 @@ language: cy
 responses:
   intents:
     HassCancelAllTimers:
-      default:
-        "TODO: {% if slots.canceled < 1: %} No timers were canceled. {% elif
-        slots.canceled == 1: %} Canceled 1 timer. {% else: %} Canceled {{ slots.canceled
-        }} timers. {% endif %}
-
-        "
-      area:
-        "TODO: {% if slots.canceled < 1: %} No timers were canceled in {{ slots.area
-        }}. {% elif slots.canceled == 1: %} Canceled 1 timer in {{ slots.area }}.
-        {% else: %} Canceled {{ slots.canceled }} timers in {{ slots.area }}. {% endif
-        %}
-
-        "
+      default: >
+        {% if slots.canceled < 1: %}
+        Ni chanslwyd unrhyw amserydd.
+        {% elif slots.canceled == 1: %}
+        Canslwyd 1 amserydd.
+        {% else: %}
+        Canslwyd {{ slots.canceled }} amserydd.
+        {% endif %}
+      area: >
+        {% if slots.canceled < 1: %}
+        Ni chanslwyd unrhyw amserydd yn {{ slots.area }}.
+        {% elif slots.canceled == 1: %}
+        Canslwyd 1 amserydd yn {{ slots.area }}.
+        {% else: %}
+        Canslwyd {{ slots.canceled }} amserydd yn {{ slots.area }}.
+        {% endif %}

--- a/responses/cy/HassCancelTimer.yaml
+++ b/responses/cy/HassCancelTimer.yaml
@@ -2,4 +2,4 @@ language: cy
 responses:
   intents:
     HassCancelTimer:
-      default: "TODO: Timer cancelled"
+      default: "Amserydd wedi'i ganslo"

--- a/responses/cy/HassClimateGetTemperature.yaml
+++ b/responses/cy/HassClimateGetTemperature.yaml
@@ -2,10 +2,7 @@ language: cy
 responses:
   intents:
     HassClimateGetTemperature:
-      default:
-        "TODO: {% set current_temperature = state_attr(state.entity_id, 'current_temperature')
-        %} {% set temperature = state.state if current_temperature is none else current_temperature
-        %} {% if temperature == 1: %} {{ temperature }} degree {% else: %} {{ temperature
-        }} degrees {% endif %}
-
-        "
+      default: >
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
+        {{ temperature }} gradd

--- a/responses/cy/HassLightSet.yaml
+++ b/responses/cy/HassLightSet.yaml
@@ -2,5 +2,6 @@ language: cy
 responses:
   intents:
     HassLightSet:
-      brightness: "TODO: Brightness set"
-      color: "TODO: Color set"
+      brightness: "Disgleirdeb wedi'i osod"
+      color: "Lliw wedi'i osod"
+      temperature: "Tymheredd lliw wedi'i osod"

--- a/responses/cy/HassMediaNext.yaml
+++ b/responses/cy/HassMediaNext.yaml
@@ -2,4 +2,4 @@ language: cy
 responses:
   intents:
     HassMediaNext:
-      default: "TODO: Playing next"
+      default: "Yn chwarae'r nesaf"

--- a/responses/cy/HassMediaPause.yaml
+++ b/responses/cy/HassMediaPause.yaml
@@ -2,4 +2,4 @@ language: cy
 responses:
   intents:
     HassMediaPause:
-      default: "TODO: Paused"
+      default: "Wedi oedi"

--- a/responses/cy/HassMediaUnpause.yaml
+++ b/responses/cy/HassMediaUnpause.yaml
@@ -2,4 +2,4 @@ language: cy
 responses:
   intents:
     HassMediaUnpause:
-      default: "TODO: Resumed"
+      default: "Yn parhau"

--- a/responses/cy/HassNevermind.yaml
+++ b/responses/cy/HassNevermind.yaml
@@ -2,4 +2,4 @@ language: cy
 responses:
   intents:
     HassNevermind:
-      default: "TODO: "
+      default: ""

--- a/responses/cy/HassPauseTimer.yaml
+++ b/responses/cy/HassPauseTimer.yaml
@@ -2,4 +2,4 @@ language: cy
 responses:
   intents:
     HassPauseTimer:
-      default: "TODO: Timer paused"
+      default: "Amserydd wedi'i oedi"

--- a/responses/cy/HassTimerStatus.yaml
+++ b/responses/cy/HassTimerStatus.yaml
@@ -2,47 +2,89 @@ language: cy
 responses:
   intents:
     HassTimerStatus:
-      default:
-        "TODO: {% set num_timers = slots.timers | length %}\n{% set active_timers\
-        \ = slots.timers | selectattr('is_active') | list %}\n{% set num_active_timers\
-        \ = active_timers | length %}\n{% set paused_timers = slots.timers | rejectattr('is_active')\
-        \ | list %}\n{% set num_paused_timers = paused_timers | length %}\n{% set\
-        \ next_timer = None %}\n\n{% if num_timers == 0: %}\n  No timers.\n{% elif\
-        \ num_active_timers == 0: %}\n  {# No active timers #}\n  {% if num_paused_timers\
-        \ == 1: %}\n    {% set next_timer = paused_timers[0] %}\n    Timer is paused.\n\
-        \  {% else: %}\n    {{ num_paused_timers }} paused timers.\n  {% endif %}\n\
-        {% else: %}\n  {# At least one active timer #}\n  {% if num_active_timers\
-        \ == 1: %}\n    {% set next_timer = active_timers[0] %}\n  {% else: %}\n \
-        \   {# Get active timer that will finish soonest #}\n    {% set sorted_timers\
-        \ = active_timers | sort(attribute='total_seconds_left') %}\n    {% set next_timer\
-        \ = sorted_timers[0] %}\n    {{ num_active_timers }} running timers.\n  {%\
-        \ endif %}\n\n  {% if num_paused_timers == 1: %}\n    1 paused timer.\n  {%\
-        \ elif num_paused_timers > 0: %}\n    {{ num_paused_timers }} paused timers.\n\
-        \  {% endif %}\n{% endif %}\n\n{% if next_timer: %}\n  {# At least one active\
-        \ timer #}\n  {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left\
-        \ > 0): %}\n    1 hour and {{ next_timer.rounded_minutes_left }} minutes\n\
-        \  {% elif (next_timer.rounded_hours_left == 1): %}\n    1 hour\n  {% elif\
-        \ (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left\
-        \ > 0): %}\n    {{ next_timer.rounded_hours_left }} hours and {{ next_timer.rounded_minutes_left\
-        \ }} minutes\n  {% elif (next_timer.rounded_hours_left > 1): %}\n    {{ next_timer.rounded_hours_left\
-        \ }} hours\n  {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left\
-        \ > 0): %}\n    1 minute and {{ next_timer.rounded_seconds_left }} seconds\n\
-        \  {% elif (next_timer.rounded_minutes_left == 1): %}\n    1 minute\n  {%\
-        \ elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left\
-        \ > 0): %}\n    {{ next_timer.rounded_minutes_left }} minutes and {{ next_timer.rounded_seconds_left\
-        \ }} seconds\n  {% elif (next_timer.rounded_minutes_left > 1): %}\n    {{\
-        \ next_timer.rounded_minutes_left }} minutes\n  {% elif (next_timer.rounded_seconds_left\
-        \ == 1): %}\n    1 second\n  {% elif (next_timer.rounded_seconds_left > 1):\
-        \ %}\n    {{ next_timer.rounded_seconds_left }} seconds\n  {% endif %}\n\n\
-        \  {% if num_timers > 1: %}\n    {# Give some extra information to disambiguate\
-        \ #}\n    left on\n    {% if (next_timer.start_hours > 0) and (next_timer.start_minutes\
-        \ > 0): %}\n      {{ next_timer.start_hours }} hour and {{ next_timer.start_minutes\
-        \ }} minute\n    {% elif (next_timer.start_hours > 0): %}\n      {{ next_timer.start_hours\
-        \ }} hour\n    {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds\
-        \ > 0): %}\n      {{ next_timer.start_minutes }} minute and {{ next_timer.start_seconds\
-        \ }} second\n    {% elif (next_timer.start_minutes > 0): %}\n      {{ next_timer.start_minutes\
-        \ }} minute\n    {% elif (next_timer.start_seconds > 0): %}\n      {{ next_timer.start_seconds\
-        \ }} second\n    {% endif %}\n\n    {% if next_timer.name: %}\n      {{ next_timer.name\
-        \ }}\n    {% elif next_timer.area: %}\n      {{ next_timer.area }}\n    {%\
-        \ endif %}\n\n    timer.\n  {% else: %}\n    left.\n  {% endif %}\n{% endif\
-        \ %}\n"
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
+        {% if num_timers == 0: %}
+          Dim amseryddion.
+        {% elif num_active_timers == 0: %}
+          {# Dim amseryddion gweithredol #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            Mae'r amserydd wedi'i oedi.
+          {% else: %}
+            {{ num_paused_timers }} amserydd wedi'u hoedi.
+          {% endif %}
+        {% else: %}
+          {# O leiaf un amserydd gweithredol #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# Cael yr amserydd gweithredol a fydd yn gorffen gyntaf #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            {{ num_active_timers }} amserydd yn rhedeg.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            1 amserydd wedi'i oedi.
+          {% elif num_paused_timers > 0: %}
+            {{ num_paused_timers }} amserydd wedi'u hoedi.
+          {% endif %}
+        {% endif %}
+
+        {% if next_timer: %}
+          {# O leiaf un amserydd gweithredol #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            1 awr a {{ next_timer.rounded_minutes_left }} munud
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            1 awr
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }} awr a {{ next_timer.rounded_minutes_left }} munud
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }} awr
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            1 munud a {{ next_timer.rounded_seconds_left }} eiliad
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            1 munud
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }} munud a {{ next_timer.rounded_seconds_left }} eiliad
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }} munud
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            1 eiliad
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }} eiliad
+          {% endif %}
+
+          {% if num_timers > 1: %}
+            {# Rhoi gwybodaeth ychwanegol i wahaniaethu #}
+            ar ôl ar yr
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }} awr a {{ next_timer.start_minutes }} munud
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }} awr
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }} munud a {{ next_timer.start_seconds }} eiliad
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }} munud
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }} eiliad
+            {% endif %}
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              {{ next_timer.area }}
+            {% endif %}
+
+            amserydd.
+          {% else: %}
+            ar ôl.
+          {% endif %}
+        {% endif %}

--- a/responses/cy/HassUnpauseTimer.yaml
+++ b/responses/cy/HassUnpauseTimer.yaml
@@ -2,4 +2,4 @@ language: cy
 responses:
   intents:
     HassUnpauseTimer:
-      default: "TODO: Timer resumed"
+      default: "Amserydd wedi ailddechrau"

--- a/responses/cy/HassVacuumCleanArea.yaml
+++ b/responses/cy/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: cy
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Yn dechrau glanhau"

--- a/rules/cy/timers.yaml
+++ b/rules/cy/timers.yaml
@@ -1,3 +1,4 @@
 language: cy
 expansion_rules:
   amser_gosod: ((c|g|ngh|ch)ychwyna|[g|ng]osoda|(c|g|ngh|ch)reua|(d|dd|n)echreua|(c|g|ngh|ch)ychwyn|[g|ng]osod|(c|g|ngh|ch)reu|(d|dd|n)echrau|(c|g|ngh|ch)ychwynwch|[g|ng]osodwch|(c|g|ngh|ch)reuwch|(d|dd|n)echreuwch)
+  amser_canslo: ((c|g|ngh|ch)anslo|(c|g|ngh|ch)ansla|diddymu|stopia|stopio|atal)

--- a/sentences/cy/HassCancelAllTimers/default.yaml
+++ b/sentences/cy/HassCancelAllTimers/default.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "<amser_canslo>[ <y>|<y>] <pob> amserydd"
+    example: "canslo pob amserydd"
+    response: "default"

--- a/sentences/cy/HassCancelTimer/default.yaml
+++ b/sentences/cy/HassCancelTimer/default.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "<amser_canslo>[ <y>|<y>] amserydd"
+    example: "canslo'r amserydd"
+    response: "default"

--- a/sentences/cy/HassCancelTimer/hours_only.yaml
+++ b/sentences/cy/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "<amser_canslo>[ <y>|<y>] amserydd {timer_hours:start_hours}( |-)awr"
+    example: "canslo'r amserydd 5 awr"
+    response: "default"

--- a/sentences/cy/HassCancelTimer/minutes_only.yaml
+++ b/sentences/cy/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "<amser_canslo>[ <y>|<y>] amserydd {timer_minutes:start_minutes}( |-)munud"
+    example: "canslo'r amserydd 5 munud"
+    response: "default"

--- a/sentences/cy/HassCancelTimer/seconds_only.yaml
+++ b/sentences/cy/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "<amser_canslo>[ <y>|<y>] amserydd {timer_seconds:start_seconds}( |-)eiliad"
+    example: "canslo'r amserydd 5 eiliad"
+    response: "default"

--- a/sentences/cy/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/cy/HassClimateGetTemperature/area_only.yaml
@@ -1,0 +1,8 @@
+---
+language: cy
+data:
+  - sentences:
+      - "beth (yw|ydy)['r] tymheredd <yn> [<y>] {area}"
+      - "pa mor (gynnes|oer) (yw|ydy) hi <yn> [<y>] {area}"
+    example: "beth yw'r tymheredd yn y gegin"
+    response: "default"

--- a/sentences/cy/HassClimateGetTemperature/default.yaml
+++ b/sentences/cy/HassClimateGetTemperature/default.yaml
@@ -1,0 +1,8 @@
+---
+language: cy
+data:
+  - sentences:
+      - "beth (yw|ydy)['r] tymheredd [<yma>]"
+      - "pa mor (gynnes|oer) (yw|ydy) hi [<yma>]"
+    example: "beth yw'r tymheredd"
+    response: "default"

--- a/sentences/cy/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/cy/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,9 @@
+---
+language: cy
+data:
+  - sentences:
+      - "beth (yw|ydy) tymheredd[ <y>|<y>] {name}"
+    example: "beth yw tymheredd y thermostat"
+    name_domains:
+      - "climate"
+    response: "default"

--- a/sentences/cy/HassLightSet/name_brightness.yaml
+++ b/sentences/cy/HassLightSet/name_brightness.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(gosoda|gosod|newidia|rho) disgleirdeb[ <y>|<y>] {name} i {brightness}[[ ]%| y cant]"
+      - "(gosoda|gosod|newidia|rho)[ <y>|<y>] {name} i ddisgleirdeb {brightness}[[ ]%| y cant]"
+      - "(gosoda|gosod|newidia|rho) disgleirdeb[ <y>|<y>] {name} i'r {brightness_level:brightness}"
+    example: "gosoda disgleirdeb y lamp i 50%"
+    name_domains:
+      - "light"
+    response: "brightness"

--- a/sentences/cy/HassLightSet/name_color.yaml
+++ b/sentences/cy/HassLightSet/name_color.yaml
@@ -1,0 +1,10 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(gosoda|gosod|newidia|rho)[ <y>|<y>] {name} i {color}"
+      - "(gosoda|gosod|newidia|rho) lliw[ <y>|<y>] {name} i {color}"
+    example: "gosoda lliw y lamp i goch"
+    name_domains:
+      - "light"
+    response: "color"

--- a/sentences/cy/HassLightSet/name_temperature.yaml
+++ b/sentences/cy/HassLightSet/name_temperature.yaml
@@ -1,0 +1,10 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(gosoda|gosod|newidia|rho) tymheredd [lliw][ <y>|<y>] {name} i {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "(gosoda|gosod|newidia|rho) tymheredd [lliw][ <y>|<y>] {name} i {color_temperature_names:temperature}"
+    example: "gosoda tymheredd lliw y lamp i 2700 kelvin"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/cy/HassMediaNext/area_only.yaml
+++ b/sentences/cy/HassMediaNext/area_only.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "[<y>] (trac|gân|cân|bennod|pennod) nesaf <yn> [<y>] {area}"
+    example: "y trac nesaf yn y gegin"
+    response: "default"

--- a/sentences/cy/HassMediaNext/default.yaml
+++ b/sentences/cy/HassMediaNext/default.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "[<y>] (trac|gân|cân|bennod|pennod) nesaf [<yma>]"
+    example: "y trac nesaf"
+    response: "default"

--- a/sentences/cy/HassMediaNext/name_only.yaml
+++ b/sentences/cy/HassMediaNext/name_only.yaml
@@ -1,0 +1,9 @@
+---
+language: cy
+data:
+  - sentences:
+      - "[<y>] (trac|gân|cân|bennod|pennod) nesaf ar[ <y>|<y>] {name}"
+    example: "y trac nesaf ar y teledu"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/cy/HassMediaPause/area_only.yaml
+++ b/sentences/cy/HassMediaPause/area_only.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(oedia|oedi|stopia)[ <y>|<y>] (cerddoriaeth|gerddoriaeth|fideo|ffilm) <yn> [<y>] {area}"
+    example: "oedi'r gerddoriaeth yn y gegin"
+    response: "default"

--- a/sentences/cy/HassMediaPause/default.yaml
+++ b/sentences/cy/HassMediaPause/default.yaml
@@ -1,0 +1,8 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(oedia|oedi|stopia)[ <y>|<y>] (cerddoriaeth|gerddoriaeth|fideo|ffilm) [<yma>]"
+      - "(oedia|oedi|stopia) [<yma>]"
+    example: "oedi'r gerddoriaeth"
+    response: "default"

--- a/sentences/cy/HassMediaPause/name_only.yaml
+++ b/sentences/cy/HassMediaPause/name_only.yaml
@@ -1,0 +1,9 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(oedia|oedi|stopia)[ <y>|<y>] {name}"
+    example: "oedi'r teledu"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/cy/HassMediaUnpause/area_only.yaml
+++ b/sentences/cy/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(ailddechreua|ailddechrau|parhau â|parha â)[ <y>|<y>] (cerddoriaeth|gerddoriaeth|fideo|ffilm) <yn> [<y>] {area}"
+    example: "ailddechrau'r gerddoriaeth yn y gegin"
+    response: "default"

--- a/sentences/cy/HassMediaUnpause/default.yaml
+++ b/sentences/cy/HassMediaUnpause/default.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(ailddechreua|ailddechrau|parhau â|parha â)[ <y>|<y>] (cerddoriaeth|gerddoriaeth|fideo|ffilm) [<yma>]"
+    example: "ailddechrau'r gerddoriaeth"
+    response: "default"

--- a/sentences/cy/HassMediaUnpause/name_only.yaml
+++ b/sentences/cy/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,9 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(ailddechreua|ailddechrau|parhau â|parha â)[ <y>|<y>] {name}"
+    example: "ailddechrau'r teledu"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/cy/HassNevermind/default.yaml
+++ b/sentences/cy/HassNevermind/default.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(dim ots|anghofia (fe|hi)|paid â phoeni|gad e)"
+    example: "dim ots"
+    response: "default"

--- a/sentences/cy/HassPauseTimer/default.yaml
+++ b/sentences/cy/HassPauseTimer/default.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(oedia|oedi|seibia)[ <y>|<y>] amserydd"
+    example: "oedi'r amserydd"
+    response: "default"

--- a/sentences/cy/HassTimerStatus/default.yaml
+++ b/sentences/cy/HassTimerStatus/default.yaml
@@ -1,0 +1,8 @@
+---
+language: cy
+data:
+  - sentences:
+      - "faint o amser sydd ar ôl [ar[ <y>|<y>] amserydd]"
+      - "pa mor hir sydd ar ôl [ar[ <y>|<y>] amserydd]"
+    example: "faint o amser sydd ar ôl"
+    response: "default"

--- a/sentences/cy/HassUnpauseTimer/default.yaml
+++ b/sentences/cy/HassUnpauseTimer/default.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(ailddechreua|ailddechrau|parhau â|parha â)[ <y>|<y>] amserydd"
+    example: "ailddechrau'r amserydd"
+    response: "default"

--- a/sentences/cy/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/cy/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,7 @@
+---
+language: cy
+data:
+  - sentences:
+      - "(glanha|glanhau|sugna llwch|sugno llwch) <yma>"
+    example: "glanhau yma"
+    response: "default"

--- a/tests/cy/HassCancelAllTimers/default.yaml
+++ b/tests/cy/HassCancelAllTimers/default.yaml
@@ -1,0 +1,12 @@
+---
+language: cy
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+  - start_minutes: 10
+    total_seconds_left: 600
+tests:
+  - sentences:
+      - canslo pob amserydd
+      - stopio holl amserydd
+    response: Canslwyd 2 amserydd.

--- a/tests/cy/HassCancelTimer/default.yaml
+++ b/tests/cy/HassCancelTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: cy
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - canslo'r amserydd
+      - stopio'r amserydd
+    response: Amserydd wedi'i ganslo

--- a/tests/cy/HassCancelTimer/hours_only.yaml
+++ b/tests/cy/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+timers:
+  - start_hours: 1
+    total_seconds_left: 3600
+tests:
+  - sentences:
+      - canslo'r amserydd 1 awr
+    slots:
+      start_hours: 1
+    response: Amserydd wedi'i ganslo

--- a/tests/cy/HassCancelTimer/minutes_only.yaml
+++ b/tests/cy/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - canslo'r amserydd 5 munud
+    slots:
+      start_minutes: 5
+    response: Amserydd wedi'i ganslo

--- a/tests/cy/HassCancelTimer/seconds_only.yaml
+++ b/tests/cy/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+timers:
+  - start_seconds: 30
+    total_seconds_left: 30
+tests:
+  - sentences:
+      - canslo'r amserydd 30 eiliad
+    slots:
+      start_seconds: 30
+    response: Amserydd wedi'i ganslo

--- a/tests/cy/HassClimateGetTemperature/area_only.yaml
+++ b/tests/cy/HassClimateGetTemperature/area_only.yaml
@@ -1,0 +1,18 @@
+---
+language: cy
+areas:
+  - name: Cegin
+entities:
+  - name: thermostat
+    domain: climate
+    area: Cegin
+    state: "22"
+    attributes:
+      current_temperature: 22
+tests:
+  - sentences:
+      - beth yw'r tymheredd yn Cegin
+      - pa mor gynnes yw hi yn Cegin
+    slots:
+      area: Cegin
+    response: 22 gradd

--- a/tests/cy/HassClimateGetTemperature/default.yaml
+++ b/tests/cy/HassClimateGetTemperature/default.yaml
@@ -1,0 +1,13 @@
+---
+language: cy
+entities:
+  - name: thermostat
+    domain: climate
+    state: "22"
+    attributes:
+      current_temperature: 22
+tests:
+  - sentences:
+      - beth yw'r tymheredd
+      - pa mor gynnes yw hi yma
+    response: 22 gradd

--- a/tests/cy/HassClimateGetTemperature/name_only.yaml
+++ b/tests/cy/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,14 @@
+---
+language: cy
+entities:
+  - name: thermostat
+    domain: climate
+    state: "22"
+    attributes:
+      current_temperature: 22
+tests:
+  - sentences:
+      - beth yw tymheredd y thermostat
+    slots:
+      name: thermostat
+    response: 22 gradd

--- a/tests/cy/HassLightSet/name_brightness.yaml
+++ b/tests/cy/HassLightSet/name_brightness.yaml
@@ -1,0 +1,19 @@
+---
+language: cy
+entities:
+  - name: lamp
+    domain: light
+tests:
+  - sentences:
+      - gosoda disgleirdeb y lamp i 50%
+      - rho'r lamp i ddisgleirdeb 50 y cant
+    slots:
+      name: lamp
+      brightness: 50
+    response: Disgleirdeb wedi'i osod
+  - sentences:
+      - gosoda disgleirdeb y lamp i'r uchaf
+    slots:
+      name: lamp
+      brightness: 100
+    response: Disgleirdeb wedi'i osod

--- a/tests/cy/HassLightSet/name_color.yaml
+++ b/tests/cy/HassLightSet/name_color.yaml
@@ -1,0 +1,13 @@
+---
+language: cy
+entities:
+  - name: lamp
+    domain: light
+tests:
+  - sentences:
+      - gosoda lliw y lamp i coch
+      - newidia'r lamp i coch
+    slots:
+      name: lamp
+      color: red
+    response: Lliw wedi'i osod

--- a/tests/cy/HassLightSet/name_temperature.yaml
+++ b/tests/cy/HassLightSet/name_temperature.yaml
@@ -1,0 +1,36 @@
+---
+language: cy
+entities:
+  - name: lamp
+    domain: light
+tests:
+  - sentences:
+      - gosoda tymheredd lliw y lamp i 2700 kelvin
+    slots:
+      name: lamp
+      temperature: 2700
+    response: Tymheredd lliw wedi'i osod
+  - sentences:
+      - gosoda tymheredd lliw y lamp i gwyn cynnes
+    slots:
+      name: lamp
+      temperature: 2700
+    response: Tymheredd lliw wedi'i osod
+  - sentences:
+      - gosoda tymheredd y lamp i gwyn oer
+    slots:
+      name: lamp
+      temperature: 4000
+    response: Tymheredd lliw wedi'i osod
+  - sentences:
+      - gosoda tymheredd y lamp i golau cannwyll
+    slots:
+      name: lamp
+      temperature: 1900
+    response: Tymheredd lliw wedi'i osod
+  - sentences:
+      - gosoda tymheredd y lamp i golau dydd
+    slots:
+      name: lamp
+      temperature: 6500
+    response: Tymheredd lliw wedi'i osod

--- a/tests/cy/HassMediaNext/area_only.yaml
+++ b/tests/cy/HassMediaNext/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: cy
+areas:
+  - name: Cegin
+entities:
+  - name: teledu
+    domain: media_player
+    area: Cegin
+    state: playing
+tests:
+  - sentences:
+      - y trac nesaf yn Cegin
+    slots:
+      area: Cegin
+    response: Yn chwarae'r nesaf

--- a/tests/cy/HassMediaNext/default.yaml
+++ b/tests/cy/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+entities:
+  - name: teledu
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - y trac nesaf
+      - y gân nesaf yma
+    response: Yn chwarae'r nesaf

--- a/tests/cy/HassMediaNext/name_only.yaml
+++ b/tests/cy/HassMediaNext/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: cy
+entities:
+  - name: teledu
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - y trac nesaf ar y teledu
+    slots:
+      name: teledu
+    response: Yn chwarae'r nesaf

--- a/tests/cy/HassMediaPause/area_only.yaml
+++ b/tests/cy/HassMediaPause/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: cy
+areas:
+  - name: Cegin
+entities:
+  - name: teledu
+    domain: media_player
+    area: Cegin
+    state: playing
+tests:
+  - sentences:
+      - oedi'r gerddoriaeth yn Cegin
+    slots:
+      area: Cegin
+    response: Wedi oedi

--- a/tests/cy/HassMediaPause/default.yaml
+++ b/tests/cy/HassMediaPause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+entities:
+  - name: teledu
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - oedi'r gerddoriaeth
+      - stopia yma
+    response: Wedi oedi

--- a/tests/cy/HassMediaPause/name_only.yaml
+++ b/tests/cy/HassMediaPause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: cy
+entities:
+  - name: teledu
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - oedi'r teledu
+    slots:
+      name: teledu
+    response: Wedi oedi

--- a/tests/cy/HassMediaUnpause/area_only.yaml
+++ b/tests/cy/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: cy
+areas:
+  - name: Cegin
+entities:
+  - name: teledu
+    domain: media_player
+    area: Cegin
+    state: paused
+tests:
+  - sentences:
+      - ailddechrau'r gerddoriaeth yn Cegin
+    slots:
+      area: Cegin
+    response: Yn parhau

--- a/tests/cy/HassMediaUnpause/default.yaml
+++ b/tests/cy/HassMediaUnpause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+entities:
+  - name: teledu
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - ailddechrau'r gerddoriaeth
+      - parhau â'r ffilm yma
+    response: Yn parhau

--- a/tests/cy/HassMediaUnpause/name_only.yaml
+++ b/tests/cy/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: cy
+entities:
+  - name: teledu
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - ailddechrau'r teledu
+    slots:
+      name: teledu
+    response: Yn parhau

--- a/tests/cy/HassNevermind/default.yaml
+++ b/tests/cy/HassNevermind/default.yaml
@@ -1,0 +1,8 @@
+---
+language: cy
+tests:
+  - sentences:
+      - dim ots
+      - anghofia fe
+      - paid â phoeni
+    response: ""

--- a/tests/cy/HassPauseTimer/default.yaml
+++ b/tests/cy/HassPauseTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: cy
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - oedi'r amserydd
+      - seibia'r amserydd
+    response: Amserydd wedi'i oedi

--- a/tests/cy/HassTimerStatus/default.yaml
+++ b/tests/cy/HassTimerStatus/default.yaml
@@ -1,0 +1,14 @@
+---
+language: cy
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - faint o amser sydd ar ôl
+      - pa mor hir sydd ar ôl
+    response: 5 munud ar ôl.

--- a/tests/cy/HassUnpauseTimer/default.yaml
+++ b/tests/cy/HassUnpauseTimer/default.yaml
@@ -1,0 +1,11 @@
+---
+language: cy
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+    is_active: false
+tests:
+  - sentences:
+      - ailddechrau'r amserydd
+      - parhau â'r amserydd
+    response: Amserydd wedi ailddechrau

--- a/tests/cy/HassVacuumCleanArea/context_area.yaml
+++ b/tests/cy/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,9 @@
+---
+language: cy
+areas:
+  - name: Cegin
+tests:
+  - sentences:
+      - glanhau yma
+      - sugno llwch yn fan hyn
+    response: Yn dechrau glanhau


### PR DESCRIPTION
Adds the 25 slot combinations marked **usable** in `intents.yaml` that were still missing for Welsh.

> [!NOTE]
> Welsh has no language leader listed in `languages.yaml`. I have followed the mutation-aware patterns already in `rules/cy/` and `sentences/cy/`, but a native speaker should check the wording — particularly the mutations after the verbs — before merge.

## Translated responses

Eleven Welsh response files were untranslated English scaffolding prefixed with `TODO:`, and every one backs a combination added here, so leaving them would have meant committing tests that assert English as correct Welsh:

| File | Now |
| --- | --- |
| `HassLightSet` | Disgleirdeb / Lliw / Tymheredd lliw wedi'i osod |
| `HassClimateGetTemperature` | `{{ temperature }} gradd` |
| `HassMediaPause` / `HassMediaUnpause` / `HassMediaNext` | Wedi oedi / Yn parhau / Yn chwarae'r nesaf |
| `HassCancelTimer` / `HassPauseTimer` / `HassUnpauseTimer` | Amserydd wedi'i ganslo / …'i oedi / …ailddechrau |
| `HassCancelAllTimers` | Canslwyd N amserydd. (with `canceled` branching and `area`) |
| `HassTimerStatus` | full template ported |
| `HassNevermind` | empty, as in `en` |

Welsh takes a **singular** noun after a numeral (5 munud, 22 gradd), so the English singular/plural branching collapses in the climate and timer templates.

The remaining `TODO:` files in `responses/cy/` belong to intents with no missing usable combination and are left untouched.

## New list file

Welsh had no `lists/cy/lights.yaml`, which is why `HassLightSet` had no sentences at all despite the response file existing. Adds `color` (11 values), `brightness_level` and `color_temperature_names`:

| Welsh | Kelvin |
| --- | --- |
| golau cannwyll / cannwyll | 1900 |
| gwyn cynnes | 2700 |
| gwyn oer | 4000 |
| golau dydd | 6500 |

## New rule

`amser_canslo` added to `rules/cy/timers.yaml`, alongside the existing `amser_gosod`, with the usual soft-mutation alternatives:

```yaml
amser_canslo: ((c|g|ngh|ch)anslo|(c|g|ngh|ch)ansla|diddymu|stopia|stopio|atal)
```

## Note on the definite article

Templates write the article as `[ <y>|<y>]` rather than `[<y>]`, following the existing `HassMediaSearchAndPlay` sentences. `<y>` expands to `(y|yr|'r)`, and the `'r` clitic must attach to the preceding word — `[<y>]` inserts a space and fails to match canslo'r amserydd.

## Verification

- `python -m script.intentfest validate --language cy` → All good!
- `pytest tests --language cy` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)