### PR TITLE
[is] Add missing usable slot combinations

### DIFF
--- a/lists/is/lights.yaml
+++ b/lists/is/lights.yaml
@@ -1,5 +1,15 @@
 language: is
 lists:
+  color_temperature_names:
+    values:
+      - in: (kertaljós|kerti)
+        out: 1900
+      - in: (hlýtt hvítt|hlýhvítt)
+        out: 2700
+      - in: (kalt hvítt|kaldhvítt)
+        out: 4000
+      - in: dagsljós
+        out: 6500
   color:
     values:
       - in: hvít(t|ur|an|a|um|ri|u|s|rar)

--- a/responses/is/HassCancelAllTimers.yaml
+++ b/responses/is/HassCancelAllTimers.yaml
@@ -1,0 +1,20 @@
+language: is
+responses:
+  intents:
+    HassCancelAllTimers:
+      default: >
+        {% if slots.canceled < 1: %}
+        Engum tímamæli var hætt.
+        {% elif slots.canceled == 1: %}
+        1 tímamæli hætt.
+        {% else: %}
+        {{ slots.canceled }} tímamælum hætt.
+        {% endif %}
+      area: >
+        {% if slots.canceled < 1: %}
+        Engum tímamæli var hætt í {{ slots.area }}.
+        {% elif slots.canceled == 1: %}
+        1 tímamæli hætt í {{ slots.area }}.
+        {% else: %}
+        {{ slots.canceled }} tímamælum hætt í {{ slots.area }}.
+        {% endif %}

--- a/responses/is/HassCancelTimer.yaml
+++ b/responses/is/HassCancelTimer.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassCancelTimer:
+      default: "Hætt við tímamæli"

--- a/responses/is/HassGetCurrentDate.yaml
+++ b/responses/is/HassGetCurrentDate.yaml
@@ -1,0 +1,11 @@
+language: is
+responses:
+  intents:
+    HassGetCurrentDate:
+      default: >
+        {% set months = {
+           1: 'janúar', 2: 'febrúar', 3: 'mars', 4: 'apríl',
+           5: 'maí', 6: 'júní', 7: 'júlí', 8: 'ágúst',
+           9: 'september', 10: 'október', 11: 'nóvember', 12: 'desember'
+        } %}
+        {{ slots.date.day }}. {{ months[slots.date.month] }} {{ slots.date.year }}

--- a/responses/is/HassGetCurrentTime.yaml
+++ b/responses/is/HassGetCurrentTime.yaml
@@ -1,0 +1,7 @@
+language: is
+responses:
+  intents:
+    HassGetCurrentTime:
+      default: >
+        {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+        {{ slots.time.hour }}:{{ minute_str }}

--- a/responses/is/HassGetWeather.yaml
+++ b/responses/is/HassGetWeather.yaml
@@ -1,0 +1,24 @@
+language: is
+responses:
+  intents:
+    HassGetWeather:
+      default: >
+        {% set weather_condition = {
+          'clear': 'og heiðskírt',
+          'clear-night': 'og heiðskírt',
+          'cloudy': 'og skýjað',
+          'exceptional': 'og óvenjulegt',
+          'fog': 'með þoku',
+          'hail': 'með haglél',
+          'lightning': 'með eldingum',
+          'lightning-rainy': 'með eldingum og rigningu',
+          'partlycloudy': 'og léttskýjað',
+          'pouring': 'og hellirigning',
+          'rainy': 'og rigning',
+          'snowy': 'og snjókoma',
+          'snowy-rainy': 'með snjó og rigningu',
+          'sunny': 'og sólskin',
+          'windy': 'og hvasst',
+          'windy-variant': 'með vindi og skýjum'
+        } %}
+        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} {{ weather_condition.get((state.state | string).lower(), "") }}

--- a/responses/is/HassLightSet.yaml
+++ b/responses/is/HassLightSet.yaml
@@ -4,3 +4,4 @@ responses:
     HassLightSet:
       brightness: "Birtustig sett"
       color: "Lit breytt"
+      temperature: "Litahitastigi breytt"

--- a/responses/is/HassMediaNext.yaml
+++ b/responses/is/HassMediaNext.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassMediaNext:
+      default: "Spila næsta"

--- a/responses/is/HassMediaPause.yaml
+++ b/responses/is/HassMediaPause.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassMediaPause:
+      default: "Í bið"

--- a/responses/is/HassMediaUnpause.yaml
+++ b/responses/is/HassMediaUnpause.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassMediaUnpause:
+      default: "Heldur áfram"

--- a/responses/is/HassNevermind.yaml
+++ b/responses/is/HassNevermind.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/is/HassPauseTimer.yaml
+++ b/responses/is/HassPauseTimer.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassPauseTimer:
+      default: "Tímamælir settur í bið"

--- a/responses/is/HassStartTimer.yaml
+++ b/responses/is/HassStartTimer.yaml
@@ -1,0 +1,25 @@
+language: is
+responses:
+  intents:
+    HassStartTimer:
+      default: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ (' klukkustund' if h in [ "1", 'one'] else ' klukkustundir') if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ (' mínúta' if m in [ "1", 'one'] else ' mínútur') if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ (' sekúnda' if s in [ "1", 'one'] else ' sekúndur') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' og ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' og ') %}
+        {% set name = (' sem heitir ' ~ slots.name | trim) if slots.name is defined else '' %}
+        Tímamælir stilltur á {{ text }}{{ name }}
+      command: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ (' klukkustund' if h in [ "1", 'one'] else ' klukkustundir') if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ (' mínúta' if m in [ "1", 'one'] else ' mínútur') if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ (' sekúnda' if s in [ "1", 'one'] else ' sekúndur') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' og ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' og ') %}
+        Skipunin verður keyrð eftir {{ text }}

--- a/responses/is/HassTimerStatus.yaml
+++ b/responses/is/HassTimerStatus.yaml
@@ -1,0 +1,90 @@
+language: is
+responses:
+  intents:
+    HassTimerStatus:
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
+        {% if num_timers == 0: %}
+          Engir tímamælar.
+        {% elif num_active_timers == 0: %}
+          {# Engir virkir tímamælar #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            Tímamælirinn er í bið.
+          {% else: %}
+            {{ num_paused_timers }} tímamælar í bið.
+          {% endif %}
+        {% else: %}
+          {# Að minnsta kosti einn virkur tímamælir #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# Sækja virkan tímamæli sem klárast fyrst #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            {{ num_active_timers }} tímamælar í gangi.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            1 tímamælir í bið.
+          {% elif num_paused_timers > 0: %}
+            {{ num_paused_timers }} tímamælar í bið.
+          {% endif %}
+        {% endif %}
+
+        {% if next_timer: %}
+          {# Að minnsta kosti einn virkur tímamælir #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            1 klukkustund og {{ next_timer.rounded_minutes_left }} mínútur
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            1 klukkustund
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }} klukkustundir og {{ next_timer.rounded_minutes_left }} mínútur
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }} klukkustundir
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            1 mínúta og {{ next_timer.rounded_seconds_left }} sekúndur
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            1 mínúta
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }} mínútur og {{ next_timer.rounded_seconds_left }} sekúndur
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }} mínútur
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            1 sekúnda
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }} sekúndur
+          {% endif %}
+
+          {% if num_timers > 1: %}
+            {# Aukaupplýsingar til aðgreiningar #}
+            eftir af
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }} klukkustundar og {{ next_timer.start_minutes }} mínútu
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }} klukkustundar
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }} mínútu og {{ next_timer.start_seconds }} sekúndu
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }} mínútu
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }} sekúndu
+            {% endif %}
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              {{ next_timer.area }}
+            {% endif %}
+
+            tímamælinum.
+          {% else: %}
+            eftir.
+          {% endif %}
+        {% endif %}

--- a/responses/is/HassUnpauseTimer.yaml
+++ b/responses/is/HassUnpauseTimer.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "Tímamælir ræstur aftur"

--- a/responses/is/HassVacuumCleanArea.yaml
+++ b/responses/is/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: is
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "Byrja að þrífa"

--- a/rules/is/timers.yaml
+++ b/rules/is/timers.yaml
@@ -1,0 +1,4 @@
+language: is
+expansion_rules:
+  timer_set: (stilltu|stilla|settu|setja|byrjaðu|byrja)
+  timer_cancel: (hættu við|hætta við|slökktu á|eyddu|eyða|stöðvaðu|stöðva)

--- a/sentences/is/HassCancelAllTimers/default.yaml
+++ b/sentences/is/HassCancelAllTimers/default.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_cancel> (alla|öll) tímamælana"
+    example: "hættu við alla tímamælana"
+    response: "default"

--- a/sentences/is/HassCancelTimer/default.yaml
+++ b/sentences/is/HassCancelTimer/default.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_cancel> tímamælinn"
+    example: "hættu við tímamælinn"
+    response: "default"

--- a/sentences/is/HassCancelTimer/hours_only.yaml
+++ b/sentences/is/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_cancel> {timer_hours:start_hours} klukkustund[ir|a] tímamælinn"
+    example: "hættu við 5 mínútna tímamælinn"
+    response: "default"

--- a/sentences/is/HassCancelTimer/minutes_only.yaml
+++ b/sentences/is/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_cancel> {timer_minutes:start_minutes} mínút(u|na|ur) tímamælinn"
+    example: "hættu við 5 mínútna tímamælinn"
+    response: "default"

--- a/sentences/is/HassCancelTimer/seconds_only.yaml
+++ b/sentences/is/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_cancel> {timer_seconds:start_seconds} sekúnd(u|na|ur) tímamælinn"
+    example: "hættu við 5 mínútna tímamælinn"
+    response: "default"

--- a/sentences/is/HassGetCurrentDate/default.yaml
+++ b/sentences/is/HassGetCurrentDate/default.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(hvaða|hver) [er] dagsetning[in] [í dag]"
+      - "hvaða dagur er í dag"
+    example: "hver er dagsetningin"
+    response: "default"

--- a/sentences/is/HassGetCurrentTime/default.yaml
+++ b/sentences/is/HassGetCurrentTime/default.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "hvað er klukkan [núna]"
+      - "hver er tíminn [núna]"
+    example: "hvað er klukkan"
+    response: "default"

--- a/sentences/is/HassGetWeather/default.yaml
+++ b/sentences/is/HassGetWeather/default.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "hvernig er veðrið [núna]"
+      - "hvað er veðrið"
+    example: "hvernig er veðrið"
+    response: "default"

--- a/sentences/is/HassGetWeather/name_only.yaml
+++ b/sentences/is/HassGetWeather/name_only.yaml
@@ -1,0 +1,10 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "hvernig er veðrið (í|á) {name}"
+      - "hvað er veðrið (í|á) {name}"
+    example: "hvernig er veðrið í Reykjavík"
+    name_domains:
+      - "weather"
+    response: "default"

--- a/sentences/is/HassLightSet/name_temperature.yaml
+++ b/sentences/is/HassLightSet/name_temperature.yaml
@@ -1,0 +1,10 @@
+---
+language: is
+data:
+  - sentences:
+      - "<set> litahitastig[ið] [(á|í)] {name} í {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<set> litahitastig[ið] [(á|í)] {name} í {color_temperature_names:temperature}"
+    example: "stilltu litahitastigið á náttlampann í 2700 kelvin"
+    name_domains:
+      - light
+    response: temperature

--- a/sentences/is/HassMediaNext/area_only.yaml
+++ b/sentences/is/HassMediaNext/area_only.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "næsta (lag|lagið|atriði|þátt) í {area}"
+    example: "næsta lag í stofunni"
+    response: "default"

--- a/sentences/is/HassMediaNext/default.yaml
+++ b/sentences/is/HassMediaNext/default.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "næsta (lag|lagið|atriði|þátt) [<here>]"
+      - "hoppaðu yfir [í næsta lag] [<here>]"
+    example: "næsta lag"
+    response: "default"

--- a/sentences/is/HassMediaNext/name_only.yaml
+++ b/sentences/is/HassMediaNext/name_only.yaml
@@ -1,0 +1,9 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "næsta (lag|lagið|atriði|þátt) á {name}"
+    example: "næsta lag á sjónvarpinu"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/is/HassMediaPause/area_only.yaml
+++ b/sentences/is/HassMediaPause/area_only.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(gerðu hlé á|settu í bið|stöðvaðu) [tónlistinni|myndbandinu|myndinni|spilun] í {area}"
+    example: "stöðvaðu tónlistinni í stofunni"
+    response: "default"

--- a/sentences/is/HassMediaPause/default.yaml
+++ b/sentences/is/HassMediaPause/default.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(gerðu hlé á|settu í bið|stöðvaðu) [tónlistinni|myndbandinu|myndinni|spilun] [<here>]"
+      - "(gerðu hlé|pása) [<here>]"
+    example: "gerðu hlé á tónlistinni"
+    response: "default"

--- a/sentences/is/HassMediaPause/name_only.yaml
+++ b/sentences/is/HassMediaPause/name_only.yaml
@@ -1,0 +1,9 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(gerðu hlé á|settu í bið|stöðvaðu) {name}"
+    example: "stöðvaðu sjónvarpið"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/is/HassMediaUnpause/area_only.yaml
+++ b/sentences/is/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(haltu áfram með|spilaðu áfram) [tónlistinni|myndbandinu|myndinni|spilun] í {area}"
+    example: "haltu áfram með tónlistinni í stofunni"
+    response: "default"

--- a/sentences/is/HassMediaUnpause/default.yaml
+++ b/sentences/is/HassMediaUnpause/default.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(haltu áfram með|spilaðu áfram) [tónlistinni|myndbandinu|myndinni|spilun] [<here>]"
+    example: "haltu áfram með tónlistinni"
+    response: "default"

--- a/sentences/is/HassMediaUnpause/name_only.yaml
+++ b/sentences/is/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,9 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(haltu áfram með|spilaðu áfram) {name}"
+    example: "haltu áfram með sjónvarpið"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/is/HassNevermind/default.yaml
+++ b/sentences/is/HassNevermind/default.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(ekkert|gleymdu því|hættu við|sleppum því|skiptir ekki máli)"
+    example: "gleymdu því"
+    response: "default"

--- a/sentences/is/HassPauseTimer/default.yaml
+++ b/sentences/is/HassPauseTimer/default.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(gerðu hlé á|setja í bið|settu í bið|bíddu með) tímamælinn"
+    example: "gerðu hlé á tímamælinn"
+    response: "default"

--- a/sentences/is/HassStartTimer/hours_only.yaml
+++ b/sentences/is/HassStartTimer/hours_only.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_set> tímamæli á {timer_hours:hours} klukkustund[ir]"
+      - "tímamælir á {timer_hours:hours} klukkustund[ir]"
+    example: "stilltu tímamæli á 5 mínútur"
+    response: "default"

--- a/sentences/is/HassStartTimer/minutes_only.yaml
+++ b/sentences/is/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_set> tímamæli á {timer_minutes:minutes} mínút(a|ur)"
+      - "tímamælir á {timer_minutes:minutes} mínút(a|ur)"
+    example: "stilltu tímamæli á 5 mínútur"
+    response: "default"

--- a/sentences/is/HassStartTimer/seconds_only.yaml
+++ b/sentences/is/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "<timer_set> tímamæli á {timer_seconds:seconds} sekúnd(a|ur)"
+      - "tímamælir á {timer_seconds:seconds} sekúnd(a|ur)"
+    example: "stilltu tímamæli á 5 mínútur"
+    response: "default"

--- a/sentences/is/HassTimerStatus/default.yaml
+++ b/sentences/is/HassTimerStatus/default.yaml
@@ -1,0 +1,8 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "hvað er (mikið|langt) eftir [af tímamælinum]"
+      - "hversu langur tími er eftir [af tímamælinum]"
+    example: "hvað er mikið eftir"
+    response: "default"

--- a/sentences/is/HassUnpauseTimer/default.yaml
+++ b/sentences/is/HassUnpauseTimer/default.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(haltu áfram með|halda áfram með|ræstu aftur) tímamælinn"
+    example: "haltu áfram með tímamælinn"
+    response: "default"

--- a/sentences/is/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/is/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,7 @@
+---
+language: "is"
+data:
+  - sentences:
+      - "(ryksugaðu|þrífðu|hreinsaðu) <here>"
+    example: "ryksugaðu hérna"
+    response: "default"

--- a/tests/is/HassCancelAllTimers/default.yaml
+++ b/tests/is/HassCancelAllTimers/default.yaml
@@ -1,0 +1,12 @@
+---
+language: is
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+  - start_minutes: 10
+    total_seconds_left: 600
+tests:
+  - sentences:
+      - hættu við alla tímamælana
+      - stöðvaðu öll tímamælana
+    response: 2 tímamælum hætt.

--- a/tests/is/HassCancelTimer/default.yaml
+++ b/tests/is/HassCancelTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: is
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - hættu við tímamælinn
+      - stöðvaðu tímamælinn
+    response: Hætt við tímamæli

--- a/tests/is/HassCancelTimer/hours_only.yaml
+++ b/tests/is/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,11 @@
+---
+language: is
+timers:
+  - start_hours: 1
+    total_seconds_left: 3600
+tests:
+  - sentences:
+      - hættu við 1 klukkustunda tímamælinn
+    slots:
+      start_hours: 1
+    response: Hætt við tímamæli

--- a/tests/is/HassCancelTimer/minutes_only.yaml
+++ b/tests/is/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,11 @@
+---
+language: is
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - hættu við 5 mínútna tímamælinn
+    slots:
+      start_minutes: 5
+    response: Hætt við tímamæli

--- a/tests/is/HassCancelTimer/seconds_only.yaml
+++ b/tests/is/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,11 @@
+---
+language: is
+timers:
+  - start_seconds: 30
+    total_seconds_left: 30
+tests:
+  - sentences:
+      - hættu við 30 sekúndna tímamælinn
+    slots:
+      start_seconds: 30
+    response: Hætt við tímamæli

--- a/tests/is/HassGetCurrentDate/default.yaml
+++ b/tests/is/HassGetCurrentDate/default.yaml
@@ -1,0 +1,7 @@
+---
+language: is
+tests:
+  - sentences:
+      - hver er dagsetningin
+      - hvaða dagur er í dag
+    response: 17. september 2013

--- a/tests/is/HassGetCurrentTime/default.yaml
+++ b/tests/is/HassGetCurrentTime/default.yaml
@@ -1,0 +1,7 @@
+---
+language: is
+tests:
+  - sentences:
+      - hvað er klukkan
+      - hver er tíminn
+    response: "1:02"

--- a/tests/is/HassGetWeather/default.yaml
+++ b/tests/is/HassGetWeather/default.yaml
@@ -1,0 +1,14 @@
+---
+language: is
+entities:
+  - name: Heima
+    domain: weather
+    state: sunny
+    attributes:
+      temperature: 12
+      temperature_unit: "°C"
+tests:
+  - sentences:
+      - hvernig er veðrið
+      - hvað er veðrið
+    response: 12 °C og sólskin

--- a/tests/is/HassGetWeather/name_only.yaml
+++ b/tests/is/HassGetWeather/name_only.yaml
@@ -1,0 +1,16 @@
+---
+language: is
+entities:
+  - name: Reykjavík
+    domain: weather
+    state: rainy
+    attributes:
+      temperature: 8
+      temperature_unit: "°C"
+tests:
+  - sentences:
+      - hvernig er veðrið í Reykjavík
+      - hvað er veðrið á Reykjavík
+    slots:
+      name: Reykjavík
+    response: 8 °C og rigning

--- a/tests/is/HassLightSet/name_temperature.yaml
+++ b/tests/is/HassLightSet/name_temperature.yaml
@@ -1,0 +1,37 @@
+---
+language: is
+entities:
+  - name: Náttlamp(i|inn|a|ann|anum|ans)
+    domain: light
+tests:
+  - sentences:
+      - stilltu litahitastigið á Náttlampann í 2700 kelvin
+      - breyttu litahitastigið á Náttlampanum í 2700
+    slots:
+      name: Náttlamp(i|inn|a|ann|anum|ans)
+      temperature: 2700
+    response: Litahitastigi breytt
+  - sentences:
+      - stilltu litahitastigið á Náttlampann í hlýtt hvítt
+    slots:
+      name: Náttlamp(i|inn|a|ann|anum|ans)
+      temperature: 2700
+    response: Litahitastigi breytt
+  - sentences:
+      - stilltu litahitastigið á Náttlampann í kalt hvítt
+    slots:
+      name: Náttlamp(i|inn|a|ann|anum|ans)
+      temperature: 4000
+    response: Litahitastigi breytt
+  - sentences:
+      - stilltu litahitastigið á Náttlampann í kertaljós
+    slots:
+      name: Náttlamp(i|inn|a|ann|anum|ans)
+      temperature: 1900
+    response: Litahitastigi breytt
+  - sentences:
+      - stilltu litahitastigið á Náttlampann í dagsljós
+    slots:
+      name: Náttlamp(i|inn|a|ann|anum|ans)
+      temperature: 6500
+    response: Litahitastigi breytt

--- a/tests/is/HassMediaNext/area_only.yaml
+++ b/tests/is/HassMediaNext/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: is
+areas:
+  - name: stofa
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    area: stofa
+    state: playing
+tests:
+  - sentences:
+      - næsta lag í stofa
+    slots:
+      area: stofa
+    response: Spila næsta

--- a/tests/is/HassMediaNext/default.yaml
+++ b/tests/is/HassMediaNext/default.yaml
@@ -1,0 +1,11 @@
+---
+language: is
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - næsta lag
+      - hoppaðu yfir
+    response: Spila næsta

--- a/tests/is/HassMediaNext/name_only.yaml
+++ b/tests/is/HassMediaNext/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: is
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - næsta lag á Sjónvarpinu
+    slots:
+      name: Sjónvarp[ið|inu|sins]
+    response: Spila næsta

--- a/tests/is/HassMediaPause/area_only.yaml
+++ b/tests/is/HassMediaPause/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: is
+areas:
+  - name: stofa
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    area: stofa
+    state: playing
+tests:
+  - sentences:
+      - stöðvaðu tónlistinni í stofa
+    slots:
+      area: stofa
+    response: Í bið

--- a/tests/is/HassMediaPause/default.yaml
+++ b/tests/is/HassMediaPause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: is
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - gerðu hlé á tónlistinni
+      - pása hérna
+    response: Í bið

--- a/tests/is/HassMediaPause/name_only.yaml
+++ b/tests/is/HassMediaPause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: is
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    state: playing
+tests:
+  - sentences:
+      - stöðvaðu Sjónvarpið
+    slots:
+      name: Sjónvarp[ið|inu|sins]
+    response: Í bið

--- a/tests/is/HassMediaUnpause/area_only.yaml
+++ b/tests/is/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,15 @@
+---
+language: is
+areas:
+  - name: stofa
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    area: stofa
+    state: paused
+tests:
+  - sentences:
+      - haltu áfram með tónlistinni í stofa
+    slots:
+      area: stofa
+    response: Heldur áfram

--- a/tests/is/HassMediaUnpause/default.yaml
+++ b/tests/is/HassMediaUnpause/default.yaml
@@ -1,0 +1,11 @@
+---
+language: is
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - haltu áfram með tónlistinni
+      - spilaðu áfram hérna
+    response: Heldur áfram

--- a/tests/is/HassMediaUnpause/name_only.yaml
+++ b/tests/is/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,12 @@
+---
+language: is
+entities:
+  - name: Sjónvarp[ið|inu|sins]
+    domain: media_player
+    state: paused
+tests:
+  - sentences:
+      - haltu áfram með Sjónvarpið
+    slots:
+      name: Sjónvarp[ið|inu|sins]
+    response: Heldur áfram

--- a/tests/is/HassNevermind/default.yaml
+++ b/tests/is/HassNevermind/default.yaml
@@ -1,0 +1,8 @@
+---
+language: is
+tests:
+  - sentences:
+      - gleymdu því
+      - ekkert
+      - sleppum því
+    response: ""

--- a/tests/is/HassPauseTimer/default.yaml
+++ b/tests/is/HassPauseTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+language: is
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - gerðu hlé á tímamælinn
+      - settu í bið tímamælinn
+    response: Tímamælir settur í bið

--- a/tests/is/HassStartTimer/hours_only.yaml
+++ b/tests/is/HassStartTimer/hours_only.yaml
@@ -1,0 +1,9 @@
+---
+language: is
+tests:
+  - sentences:
+      - stilltu tímamæli á 1 klukkustund
+      - tímamælir á 1 klukkustund
+    slots:
+      hours: 1
+    response: Tímamælir stilltur á 1 klukkustund

--- a/tests/is/HassStartTimer/minutes_only.yaml
+++ b/tests/is/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,9 @@
+---
+language: is
+tests:
+  - sentences:
+      - stilltu tímamæli á 5 mínútur
+      - tímamælir á 5 mínútur
+    slots:
+      minutes: 5
+    response: Tímamælir stilltur á 5 mínútur

--- a/tests/is/HassStartTimer/seconds_only.yaml
+++ b/tests/is/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,9 @@
+---
+language: is
+tests:
+  - sentences:
+      - stilltu tímamæli á 30 sekúndur
+      - tímamælir á 30 sekúndur
+    slots:
+      seconds: 30
+    response: Tímamælir stilltur á 30 sekúndur

--- a/tests/is/HassTimerStatus/default.yaml
+++ b/tests/is/HassTimerStatus/default.yaml
@@ -1,0 +1,14 @@
+---
+language: is
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - hvað er mikið eftir
+      - hversu langur tími er eftir
+    response: 5 mínútur eftir.

--- a/tests/is/HassUnpauseTimer/default.yaml
+++ b/tests/is/HassUnpauseTimer/default.yaml
@@ -1,0 +1,11 @@
+---
+language: is
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+    is_active: false
+tests:
+  - sentences:
+      - haltu áfram með tímamælinn
+      - ræstu aftur tímamælinn
+    response: Tímamælir ræstur aftur

--- a/tests/is/HassVacuumCleanArea/context_area.yaml
+++ b/tests/is/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,9 @@
+---
+language: is
+areas:
+  - name: stofa
+tests:
+  - sentences:
+      - ryksugaðu hérna
+      - þrífðu inni
+    response: Byrja að þrífa


### PR DESCRIPTION
Adds the 27 slot combinations marked **usable** in `intents.yaml` that were still missing for Icelandic. Icelandic previously had only lights, climate, state and on/off.

> [!NOTE]
> Please have a native speaker check the wording before merge — this adds whole intent families rather than following existing Icelandic sentences.

## Combinations added

| Intent | Combos |
| --- | --- |
| `HassStartTimer` | `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelTimer` | `default`, `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelAllTimers` / `HassPauseTimer` / `HassUnpauseTimer` / `HassTimerStatus` | `default` |
| `HassGetCurrentDate` / `HassGetCurrentTime` / `HassNevermind` | `default` |
| `HassGetWeather` | `default`, `name_only` |
| `HassLightSet` | `name_temperature` |
| `HassMediaNext` / `HassMediaPause` / `HassMediaUnpause` | `default`, `name_only`, `area_only` |
| `HassVacuumCleanArea` | `context_area` |

## Declension

The `{name}` templates deliberately do **not** add case endings. Icelandic entity names in this repo carry their own declension in the fixture name — the existing `tests/is/HassLightSet/name_color.yaml` uses `Náttlamp(i|inn|a|ann|anum|ans)` — so the new tests follow that convention rather than appending suffixes in the sentence template.

`HassTimerStatus` and `HassCancelTimer` refer to a timer's original duration, which takes the genitive (`klukkustundar`, `mínútu`, `sekúndu`); those forms are set separately from the nominative used by `HassStartTimer`.

## New response files

Twelve: the six timer intents, the three media intents, `HassGetCurrentDate`, `HassGetCurrentTime`, `HassGetWeather`, `HassNevermind` and `HassVacuumCleanArea`. `HassGetCurrentTime` renders 24-hour (`13:02`); Icelandic does not use AM/PM.

## New rule file

`rules/is/timers.yaml` — `timer_set`, `timer_cancel`. The existing `<here>` rule is reused.

## Colour temperature names

| Icelandic | Kelvin |
| --- | --- |
| kertaljós / kerti | 1900 |
| hlýtt hvítt / hlýhvítt | 2700 |
| kalt hvítt / kaldhvítt | 4000 |
| dagsljós | 6500 |

## Verification

- `python -m script.intentfest validate --language is` → All good!
- `pytest tests --language is` → 249 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)