### PR TITLE
[ko] Add missing usable slot combinations

### DIFF
--- a/lists/ko/lights.yaml
+++ b/lists/ko/lights.yaml
@@ -24,6 +24,16 @@ lists:
         out: pink
       - in: (하늘색|청록색|청록)
         out: turquoise
+  color_temperature_names:
+    values:
+      - in: (촛불|촛불색|캔들)
+        out: 1900
+      - in: (따뜻한 흰색|웜 화이트|전구색)
+        out: 2700
+      - in: (차가운 흰색|쿨 화이트|주백색)
+        out: 4000
+      - in: (주광색|데이라이트|햇빛색)
+        out: 6500
   brightness_level:
     values:
       - in: (최대|가장 밝게|최대치|제일 밝게)

--- a/responses/ko/HassCancelAllTimers.yaml
+++ b/responses/ko/HassCancelAllTimers.yaml
@@ -1,0 +1,20 @@
+language: ko
+responses:
+  intents:
+    HassCancelAllTimers:
+      default: >
+        {% if slots.canceled < 1: %}
+        취소된 타이머가 없습니다.
+        {% elif slots.canceled == 1: %}
+        타이머 1개를 취소했습니다.
+        {% else: %}
+        타이머 {{ slots.canceled }}개를 취소했습니다.
+        {% endif %}
+      area: >
+        {% if slots.canceled < 1: %}
+        {{ slots.area }}에서 취소된 타이머가 없습니다.
+        {% elif slots.canceled == 1: %}
+        {{ slots.area }}의 타이머 1개를 취소했습니다.
+        {% else: %}
+        {{ slots.area }}의 타이머 {{ slots.canceled }}개를 취소했습니다.
+        {% endif %}

--- a/responses/ko/HassCancelTimer.yaml
+++ b/responses/ko/HassCancelTimer.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassCancelTimer:
+      default: "타이머를 취소했습니다"

--- a/responses/ko/HassGetCurrentDate.yaml
+++ b/responses/ko/HassGetCurrentDate.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassGetCurrentDate:
+      default: "{{ slots.date.year }}년 {{ slots.date.month }}월 {{ slots.date.day }}일"

--- a/responses/ko/HassGetCurrentTime.yaml
+++ b/responses/ko/HassGetCurrentTime.yaml
@@ -1,0 +1,14 @@
+language: ko
+responses:
+  intents:
+    HassGetCurrentTime:
+      default: >
+        {% if slots.time.hour == 0: %}
+        오전 12시 {{ slots.time.minute }}분
+        {% elif slots.time.hour < 12: %}
+        오전 {{ slots.time.hour }}시 {{ slots.time.minute }}분
+        {% elif slots.time.hour == 12: %}
+        오후 12시 {{ slots.time.minute }}분
+        {% else: %}
+        오후 {{ slots.time.hour - 12 }}시 {{ slots.time.minute }}분
+        {% endif %}

--- a/responses/ko/HassGetWeather.yaml
+++ b/responses/ko/HassGetWeather.yaml
@@ -1,0 +1,24 @@
+language: ko
+responses:
+  intents:
+    HassGetWeather:
+      default: >
+        {% set weather_condition = {
+          'clear': '맑음',
+          'clear-night': '맑음',
+          'cloudy': '흐림',
+          'exceptional': '특이한 날씨',
+          'fog': '안개',
+          'hail': '우박',
+          'lightning': '번개',
+          'lightning-rainy': '번개와 비',
+          'partlycloudy': '구름 조금',
+          'pouring': '폭우',
+          'rainy': '비',
+          'snowy': '눈',
+          'snowy-rainy': '진눈깨비',
+          'sunny': '맑음',
+          'windy': '바람',
+          'windy-variant': '바람과 구름'
+        } %}
+        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }}, {{ weather_condition.get((state.state | string).lower(), "") }}

--- a/responses/ko/HassLightSet.yaml
+++ b/responses/ko/HassLightSet.yaml
@@ -4,3 +4,4 @@ responses:
     HassLightSet:
       brightness: "밝기가 설정되었습니다"
       color: "색상이 설정되었습니다"
+      temperature: "색온도가 설정되었습니다"

--- a/responses/ko/HassMediaNext.yaml
+++ b/responses/ko/HassMediaNext.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassMediaNext:
+      default: "다음으로 넘어갑니다"

--- a/responses/ko/HassMediaPause.yaml
+++ b/responses/ko/HassMediaPause.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassMediaPause:
+      default: "일시정지했습니다"

--- a/responses/ko/HassMediaUnpause.yaml
+++ b/responses/ko/HassMediaUnpause.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassMediaUnpause:
+      default: "다시 재생합니다"

--- a/responses/ko/HassNevermind.yaml
+++ b/responses/ko/HassNevermind.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassNevermind:
+      default: ""

--- a/responses/ko/HassPauseTimer.yaml
+++ b/responses/ko/HassPauseTimer.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassPauseTimer:
+      default: "타이머를 일시정지했습니다"

--- a/responses/ko/HassStartTimer.yaml
+++ b/responses/ko/HassStartTimer.yaml
@@ -1,0 +1,23 @@
+language: ko
+responses:
+  intents:
+    HassStartTimer:
+      default: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = (h ~ '시간') if h else '' %}
+        {% set m_text = ((30 if m in ['half', '1/2'] else m) ~ '분') if m else '' %}
+        {% set s_text = ((30 if s in ['half', '1/2'] else s) ~ '초') if s else '' %}
+        {% set text = [ h_text, m_text, s_text] | select() | list | join(' ') %}
+        {% set name = (slots.name | trim ~ ' ') if slots.name is defined else '' %}
+        {{ name }}{{ text }} 타이머를 설정했습니다
+      command: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = (h ~ '시간') if h else '' %}
+        {% set m_text = ((30 if m in ['half', '1/2'] else m) ~ '분') if m else '' %}
+        {% set s_text = ((30 if s in ['half', '1/2'] else s) ~ '초') if s else '' %}
+        {% set text = [ h_text, m_text, s_text] | select() | list | join(' ') %}
+        {{ text }} 후에 명령을 실행합니다

--- a/responses/ko/HassTimerStatus.yaml
+++ b/responses/ko/HassTimerStatus.yaml
@@ -1,0 +1,90 @@
+language: ko
+responses:
+  intents:
+    HassTimerStatus:
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
+        {% if num_timers == 0: %}
+          타이머가 없습니다.
+        {% elif num_active_timers == 0: %}
+          {# 실행 중인 타이머 없음 #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            타이머가 일시정지되었습니다.
+          {% else: %}
+            타이머 {{ num_paused_timers }}개가 일시정지되었습니다.
+          {% endif %}
+        {% else: %}
+          {# 실행 중인 타이머가 하나 이상 #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# 가장 먼저 끝나는 타이머 #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            타이머 {{ num_active_timers }}개가 실행 중입니다.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            타이머 1개가 일시정지되었습니다.
+          {% elif num_paused_timers > 0: %}
+            타이머 {{ num_paused_timers }}개가 일시정지되었습니다.
+          {% endif %}
+        {% endif %}
+
+        {% if next_timer: %}
+          {# 실행 중인 타이머가 하나 이상 #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            1시간 {{ next_timer.rounded_minutes_left }}분
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            1시간
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }}시간 {{ next_timer.rounded_minutes_left }}분
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }}시간
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            1분 {{ next_timer.rounded_seconds_left }}초
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            1분
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }}분 {{ next_timer.rounded_seconds_left }}초
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }}분
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            1초
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }}초
+          {% endif %}
+
+          {% if num_timers > 1: %}
+            {# 구분을 위한 추가 정보 #}
+            남았습니다,
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }}시간 {{ next_timer.start_minutes }}분
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }}시간
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }}분 {{ next_timer.start_seconds }}초
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }}분
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }}초
+            {% endif %}
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              {{ next_timer.area }}
+            {% endif %}
+
+            타이머입니다.
+          {% else: %}
+            남았습니다.
+          {% endif %}
+        {% endif %}

--- a/responses/ko/HassUnpauseTimer.yaml
+++ b/responses/ko/HassUnpauseTimer.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "타이머를 다시 시작했습니다"

--- a/responses/ko/HassVacuumCleanArea.yaml
+++ b/responses/ko/HassVacuumCleanArea.yaml
@@ -1,0 +1,5 @@
+language: ko
+responses:
+  intents:
+    HassVacuumCleanArea:
+      default: "청소를 시작합니다"

--- a/rules/ko/timers.yaml
+++ b/rules/ko/timers.yaml
@@ -1,0 +1,4 @@
+language: ko
+expansion_rules:
+  timer_set: "(설정|설정해|맞춰|맞춰줘|시작|시작해|걸어|걸어줘)"
+  timer_cancel: "(취소|취소해|삭제|삭제해|없애|없애줘)"

--- a/sentences/ko/HassCancelAllTimers/default.yaml
+++ b/sentences/ko/HassCancelAllTimers/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassCancelAllTimers - default
+# example: 모든 타이머 취소
+
+language: "ko"
+data:
+  - sentences:
+      - "(<all>|전체) 타이머 <timer_cancel>"
+      - "타이머 (전부|모두) <timer_cancel>"
+    example: "모든 타이머 취소"
+    response: "default"

--- a/sentences/ko/HassCancelTimer/default.yaml
+++ b/sentences/ko/HassCancelTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassCancelTimer - default
+# example: 타이머 취소
+
+language: "ko"
+data:
+  - sentences:
+      - "[내] 타이머 <timer_cancel>"
+    example: "타이머 취소"
+    response: "default"

--- a/sentences/ko/HassCancelTimer/hours_only.yaml
+++ b/sentences/ko/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassCancelTimer - hours_only
+# example: 1시간 타이머 취소
+# slots: {start_hours}
+
+language: "ko"
+data:
+  - sentences:
+      - "{timer_hours:start_hours}시간[짜리] 타이머 <timer_cancel>"
+    example: "1시간 타이머 취소"
+    response: "default"

--- a/sentences/ko/HassCancelTimer/minutes_only.yaml
+++ b/sentences/ko/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassCancelTimer - minutes_only
+# example: 5분 타이머 취소
+# slots: {start_minutes}
+
+language: "ko"
+data:
+  - sentences:
+      - "{timer_minutes:start_minutes}분[짜리] 타이머 <timer_cancel>"
+    example: "5분 타이머 취소"
+    response: "default"

--- a/sentences/ko/HassCancelTimer/seconds_only.yaml
+++ b/sentences/ko/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassCancelTimer - seconds_only
+# example: 30초 타이머 취소
+# slots: {start_seconds}
+
+language: "ko"
+data:
+  - sentences:
+      - "{timer_seconds:start_seconds}초[짜리] 타이머 <timer_cancel>"
+    example: "30초 타이머 취소"
+    response: "default"

--- a/sentences/ko/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/ko/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,15 @@
+---
+# HassClimateGetTemperature - name_only
+# example: 온도조절기 온도 몇 도야
+# slots: {name}
+
+language: "ko"
+data:
+  - sentences:
+      - "{name}[의] <temp> 몇 도야"
+      - "{name}[의] <temp> (알아|알려줘|말해줘)"
+      - "{name}[의] <temp> <what_is>"
+    example: "온도조절기 온도 몇 도야"
+    name_domains:
+      - "climate"
+    response: "default"

--- a/sentences/ko/HassGetCurrentDate/default.yaml
+++ b/sentences/ko/HassGetCurrentDate/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassGetCurrentDate - default
+# example: 오늘 날짜 뭐야
+
+language: "ko"
+data:
+  - sentences:
+      - "[오늘] 날짜 (뭐야|알려줘|말해줘)"
+      - "오늘 (며칠이야|며칠이지|며칠인가요)"
+    example: "오늘 날짜 뭐야"
+    response: "default"

--- a/sentences/ko/HassGetCurrentTime/default.yaml
+++ b/sentences/ko/HassGetCurrentTime/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassGetCurrentTime - default
+# example: 지금 몇 시야
+
+language: "ko"
+data:
+  - sentences:
+      - "[지금] (몇 시야|몇 시지|몇 시인가요)"
+      - "[지금] 시간 (알려줘|말해줘|뭐야)"
+    example: "지금 몇 시야"
+    response: "default"

--- a/sentences/ko/HassGetWeather/default.yaml
+++ b/sentences/ko/HassGetWeather/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassGetWeather - default
+# example: 오늘 날씨 어때
+
+language: "ko"
+data:
+  - sentences:
+      - "[오늘] [바깥] 날씨 (어때|어때요|알려줘|말해줘)"
+      - "[오늘] 날씨 <what_is>"
+    example: "오늘 날씨 어때"
+    response: "default"

--- a/sentences/ko/HassGetWeather/name_only.yaml
+++ b/sentences/ko/HassGetWeather/name_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassGetWeather - name_only
+# example: 서울 날씨 어때
+# slots: {name}
+
+language: "ko"
+data:
+  - sentences:
+      - "{name}[의] 날씨 (어때|어때요|알려줘|말해줘)"
+      - "{name}[의] 날씨 <what_is>"
+    example: "서울 날씨 어때"
+    name_domains:
+      - "weather"
+    response: "default"

--- a/sentences/ko/HassLightSet/name_temperature.yaml
+++ b/sentences/ko/HassLightSet/name_temperature.yaml
@@ -1,0 +1,14 @@
+---
+# HassLightSet - name_temperature
+# example: 침실 무드등 색온도 2700 켈빈으로 설정
+# slots: {name}, {temperature}
+
+language: "ko"
+data:
+  - sentences:
+      - "{name}[의] 색온도 {color_temperature:temperature}[ ][k|켈빈][로|으로] [<set>]"
+      - "{name}[의] 색온도 {color_temperature_names:temperature}[로|으로] [<set>]"
+    example: "침실 무드등 색온도 2700 켈빈으로 설정"
+    name_domains:
+      - "light"
+    response: "temperature"

--- a/sentences/ko/HassMediaNext/area_only.yaml
+++ b/sentences/ko/HassMediaNext/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaNext - area_only
+# example: 거실 다음 곡
+# slots: {area}
+
+language: "ko"
+data:
+  - sentences:
+      - "{area}[의|에서] 다음 (곡|노래|트랙|화) [재생|틀어|틀어줘]"
+    example: "거실 다음 곡"
+    response: "default"

--- a/sentences/ko/HassMediaNext/default.yaml
+++ b/sentences/ko/HassMediaNext/default.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaNext - default
+# example: 다음 곡
+# context_area: true
+
+language: "ko"
+data:
+  - sentences:
+      - "[<here>] 다음 (곡|노래|트랙|화) [재생|틀어|틀어줘]"
+      - "[<here>] 다음 (곡|노래|트랙|화)[으로|로] 넘겨[줘]"
+    example: "다음 곡"
+    response: "default"

--- a/sentences/ko/HassMediaNext/name_only.yaml
+++ b/sentences/ko/HassMediaNext/name_only.yaml
@@ -1,0 +1,13 @@
+---
+# HassMediaNext - name_only
+# example: 티비 다음 곡
+# slots: {name}
+
+language: "ko"
+data:
+  - sentences:
+      - "{name}[에서] 다음 (곡|노래|트랙|화) [재생|틀어|틀어줘]"
+    example: "티비 다음 곡"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/ko/HassMediaPause/area_only.yaml
+++ b/sentences/ko/HassMediaPause/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaPause - area_only
+# example: 거실 음악 일시정지
+# slots: {area}
+
+language: "ko"
+data:
+  - sentences:
+      - "{area}[의|에서] (음악|영상|비디오) (일시정지|일시 정지|일시정지해|멈춰|정지|정지해)"
+    example: "거실 음악 일시정지"
+    response: "default"

--- a/sentences/ko/HassMediaPause/default.yaml
+++ b/sentences/ko/HassMediaPause/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaPause - default
+# example: 일시정지
+# context_area: true
+
+language: "ko"
+data:
+  - sentences:
+      - "[<here>] [음악|영상|비디오] (일시정지|일시 정지|일시정지해|멈춰|정지|정지해)"
+    example: "일시정지"
+    response: "default"

--- a/sentences/ko/HassMediaPause/name_only.yaml
+++ b/sentences/ko/HassMediaPause/name_only.yaml
@@ -1,0 +1,13 @@
+---
+# HassMediaPause - name_only
+# example: 티비 일시정지
+# slots: {name}
+
+language: "ko"
+data:
+  - sentences:
+      - "{name} (일시정지|일시 정지|일시정지해|멈춰|정지|정지해)"
+    example: "티비 일시정지"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/ko/HassMediaUnpause/area_only.yaml
+++ b/sentences/ko/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaUnpause - area_only
+# example: 거실 음악 다시 재생
+# slots: {area}
+
+language: "ko"
+data:
+  - sentences:
+      - "{area}[의|에서] (음악|영상|비디오) (다시 재생|계속 재생|이어서 재생|재개|재개해|계속해)"
+    example: "거실 음악 다시 재생"
+    response: "default"

--- a/sentences/ko/HassMediaUnpause/default.yaml
+++ b/sentences/ko/HassMediaUnpause/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassMediaUnpause - default
+# example: 다시 재생
+# context_area: true
+
+language: "ko"
+data:
+  - sentences:
+      - "[<here>] [음악|영상|비디오] (다시 재생|계속 재생|이어서 재생|재개|재개해|계속해)"
+    example: "다시 재생"
+    response: "default"

--- a/sentences/ko/HassMediaUnpause/name_only.yaml
+++ b/sentences/ko/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,13 @@
+---
+# HassMediaUnpause - name_only
+# example: 티비 다시 재생
+# slots: {name}
+
+language: "ko"
+data:
+  - sentences:
+      - "{name} (다시 재생|계속 재생|이어서 재생|재개|재개해|계속해)"
+    example: "티비 다시 재생"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/ko/HassNevermind/default.yaml
+++ b/sentences/ko/HassNevermind/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassNevermind - default
+# example: 아니야
+
+language: "ko"
+data:
+  - sentences:
+      - "(아니야|아니에요|괜찮아|괜찮습니다|됐어|됐어요|신경 쓰지 마|아무것도 아니야)"
+    example: "아니야"
+    response: "default"

--- a/sentences/ko/HassPauseTimer/default.yaml
+++ b/sentences/ko/HassPauseTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassPauseTimer - default
+# example: 타이머 일시정지
+
+language: "ko"
+data:
+  - sentences:
+      - "[내] 타이머 (일시정지|일시 정지|일시정지해|멈춰|정지|정지해)"
+    example: "타이머 일시정지"
+    response: "default"

--- a/sentences/ko/HassStartTimer/hours_only.yaml
+++ b/sentences/ko/HassStartTimer/hours_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassStartTimer - hours_only
+# example: 1시간 타이머 설정
+# slots: {hours}
+
+language: "ko"
+data:
+  - sentences:
+      - "{timer_hours:hours}시간[짜리] 타이머 [<timer_set>]"
+      - "타이머 {timer_hours:hours}시간[으로] <timer_set>"
+    example: "1시간 타이머 설정"
+    response: "default"

--- a/sentences/ko/HassStartTimer/minutes_only.yaml
+++ b/sentences/ko/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassStartTimer - minutes_only
+# example: 5분 타이머 설정
+# slots: {minutes}
+
+language: "ko"
+data:
+  - sentences:
+      - "{timer_minutes:minutes}분[짜리] 타이머 [<timer_set>]"
+      - "타이머 {timer_minutes:minutes}분[으로] <timer_set>"
+    example: "5분 타이머 설정"
+    response: "default"

--- a/sentences/ko/HassStartTimer/seconds_only.yaml
+++ b/sentences/ko/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassStartTimer - seconds_only
+# example: 30초 타이머 설정
+# slots: {seconds}
+
+language: "ko"
+data:
+  - sentences:
+      - "{timer_seconds:seconds}초[짜리] 타이머 [<timer_set>]"
+      - "타이머 {timer_seconds:seconds}초[로] <timer_set>"
+    example: "30초 타이머 설정"
+    response: "default"

--- a/sentences/ko/HassTimerStatus/default.yaml
+++ b/sentences/ko/HassTimerStatus/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassTimerStatus - default
+# example: 타이머 얼마나 남았어
+
+language: "ko"
+data:
+  - sentences:
+      - "[타이머] (얼마나 남았어|얼마 남았어|얼마나 남았나요)"
+      - "타이머 (상태|확인|어때)"
+    example: "타이머 얼마나 남았어"
+    response: "default"

--- a/sentences/ko/HassUnpauseTimer/default.yaml
+++ b/sentences/ko/HassUnpauseTimer/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassUnpauseTimer - default
+# example: 타이머 다시 시작
+
+language: "ko"
+data:
+  - sentences:
+      - "[내] 타이머 (다시 시작|다시 시작해|재개|재개해|계속|계속해)"
+    example: "타이머 다시 시작"
+    response: "default"

--- a/sentences/ko/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/ko/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,11 @@
+---
+# HassVacuumCleanArea - context_area
+# example: 여기 청소해
+# context_area: true
+
+language: "ko"
+data:
+  - sentences:
+      - "<here> (청소|청소해|청소기 돌려|청소기 돌려줘)"
+    example: "여기 청소해"
+    response: "default"

--- a/tests/ko/HassCancelAllTimers/default.yaml
+++ b/tests/ko/HassCancelAllTimers/default.yaml
@@ -1,0 +1,15 @@
+---
+# HassCancelAllTimers - default
+
+language: "ko"
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+  - start_minutes: 10
+    total_seconds_left: 600
+tests:
+  - sentences:
+      - "모든 타이머 취소"
+      - "전체 타이머 삭제"
+      - "타이머 모두 취소해"
+    response: "타이머 2개를 취소했습니다."

--- a/tests/ko/HassCancelTimer/default.yaml
+++ b/tests/ko/HassCancelTimer/default.yaml
@@ -1,0 +1,13 @@
+---
+# HassCancelTimer - default
+
+language: "ko"
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - "타이머 취소"
+      - "내 타이머 취소해"
+      - "타이머 삭제"
+    response: "타이머를 취소했습니다"

--- a/tests/ko/HassCancelTimer/hours_only.yaml
+++ b/tests/ko/HassCancelTimer/hours_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassCancelTimer - hours_only
+
+language: "ko"
+timers:
+  - start_hours: 1
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - "1시간 타이머 취소"
+      - "1시간짜리 타이머 삭제해"
+    slots:
+      start_hours: 1
+    response: "타이머를 취소했습니다"

--- a/tests/ko/HassCancelTimer/minutes_only.yaml
+++ b/tests/ko/HassCancelTimer/minutes_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassCancelTimer - minutes_only
+
+language: "ko"
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - "5분 타이머 취소"
+      - "5분짜리 타이머 삭제해"
+    slots:
+      start_minutes: 5
+    response: "타이머를 취소했습니다"

--- a/tests/ko/HassCancelTimer/seconds_only.yaml
+++ b/tests/ko/HassCancelTimer/seconds_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassCancelTimer - seconds_only
+
+language: "ko"
+timers:
+  - start_seconds: 30
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - "30초 타이머 취소"
+      - "30초짜리 타이머 삭제해"
+    slots:
+      start_seconds: 30
+    response: "타이머를 취소했습니다"

--- a/tests/ko/HassClimateGetTemperature/name_only.yaml
+++ b/tests/ko/HassClimateGetTemperature/name_only.yaml
@@ -1,0 +1,19 @@
+---
+# HassClimateGetTemperature - name_only
+
+language: "ko"
+entities:
+  - name: "온도조절기"
+    domain: "climate"
+    state: "20"
+    attributes:
+      current_temperature: 20
+
+tests:
+  - sentences:
+      - "온도조절기 온도 몇 도야"
+      - "온도조절기의 온도 알려줘"
+      - "온도조절기 온도 뭐야"
+    slots:
+      name: "온도조절기"
+    response: "20입니다"

--- a/tests/ko/HassGetCurrentDate/default.yaml
+++ b/tests/ko/HassGetCurrentDate/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassGetCurrentDate - default
+
+language: "ko"
+tests:
+  - sentences:
+      - "날짜 뭐야"
+      - "오늘 날짜 알려줘"
+      - "오늘 며칠이야"
+    response: "2013년 9월 17일"

--- a/tests/ko/HassGetCurrentTime/default.yaml
+++ b/tests/ko/HassGetCurrentTime/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassGetCurrentTime - default
+
+language: "ko"
+tests:
+  - sentences:
+      - "몇 시야"
+      - "지금 몇 시야"
+      - "시간 알려줘"
+      - "지금 시간 뭐야"
+    response: "오전 1시 2분"

--- a/tests/ko/HassGetWeather/default.yaml
+++ b/tests/ko/HassGetWeather/default.yaml
@@ -1,0 +1,18 @@
+---
+# HassGetWeather - default
+
+language: "ko"
+entities:
+  - name: "우리 집"
+    domain: "weather"
+    state: "rainy"
+    attributes:
+      temperature: 20
+      temperature_unit: "°C"
+
+tests:
+  - sentences:
+      - "날씨 어때"
+      - "오늘 바깥 날씨 알려줘"
+      - "오늘 날씨 뭐야"
+    response: "20 °C, 비"

--- a/tests/ko/HassGetWeather/name_only.yaml
+++ b/tests/ko/HassGetWeather/name_only.yaml
@@ -1,0 +1,31 @@
+---
+# HassGetWeather - name_only
+
+language: "ko"
+entities:
+  - name: "서울"
+    domain: "weather"
+    state: "rainy"
+    attributes:
+      temperature: 20
+      temperature_unit: "°C"
+  - name: "부산"
+    domain: "weather"
+    state: "sunny"
+    attributes:
+      temperature: 25
+      temperature_unit: "°C"
+
+tests:
+  - sentences:
+      - "서울 날씨 어때"
+      - "서울의 날씨 뭐야"
+    slots:
+      name: "서울"
+    response: "20 °C, 비"
+
+  - sentences:
+      - "부산 날씨 알려줘"
+    slots:
+      name: "부산"
+    response: "25 °C, 맑음"

--- a/tests/ko/HassLightSet/name_temperature.yaml
+++ b/tests/ko/HassLightSet/name_temperature.yaml
@@ -1,0 +1,45 @@
+---
+# HassLightSet - name_temperature
+
+language: "ko"
+entities:
+  - name: "침실 무드등"
+    domain: "light"
+
+tests:
+  - sentences:
+      - "침실 무드등 색온도 2700 켈빈으로 설정"
+      - "침실 무드등의 색온도 2700으로 변경"
+      - "침실 무드등 색온도 2700k로 맞춰"
+    slots:
+      name: "침실 무드등"
+      temperature: 2700
+    response: "색온도가 설정되었습니다"
+
+  - sentences:
+      - "침실 무드등 색온도 촛불로 설정"
+    slots:
+      name: "침실 무드등"
+      temperature: 1900
+    response: "색온도가 설정되었습니다"
+
+  - sentences:
+      - "침실 무드등 색온도 따뜻한 흰색으로 설정"
+    slots:
+      name: "침실 무드등"
+      temperature: 2700
+    response: "색온도가 설정되었습니다"
+
+  - sentences:
+      - "침실 무드등 색온도 차가운 흰색으로 설정"
+    slots:
+      name: "침실 무드등"
+      temperature: 4000
+    response: "색온도가 설정되었습니다"
+
+  - sentences:
+      - "침실 무드등 색온도 주광색으로 설정"
+    slots:
+      name: "침실 무드등"
+      temperature: 6500
+    response: "색온도가 설정되었습니다"

--- a/tests/ko/HassMediaNext/area_only.yaml
+++ b/tests/ko/HassMediaNext/area_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaNext - area_only
+
+language: "ko"
+areas:
+  - name: "거실"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    area: "거실"
+    state: "playing"
+tests:
+  - sentences:
+      - "거실 다음 곡"
+      - "거실에서 다음 노래 틀어줘"
+    slots:
+      area: "거실"
+    response: "다음으로 넘어갑니다"

--- a/tests/ko/HassMediaNext/default.yaml
+++ b/tests/ko/HassMediaNext/default.yaml
@@ -1,0 +1,14 @@
+---
+# HassMediaNext - default
+
+language: "ko"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    state: "playing"
+tests:
+  - sentences:
+      - "다음 곡"
+      - "여기 다음 노래 재생"
+      - "다음 트랙으로 넘겨줘"
+    response: "다음으로 넘어갑니다"

--- a/tests/ko/HassMediaNext/name_only.yaml
+++ b/tests/ko/HassMediaNext/name_only.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaNext - name_only
+
+language: "ko"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    state: "playing"
+tests:
+  - sentences:
+      - "티비 다음 곡"
+      - "티비에서 다음 노래 틀어줘"
+    slots:
+      name: "티비"
+    response: "다음으로 넘어갑니다"

--- a/tests/ko/HassMediaPause/area_only.yaml
+++ b/tests/ko/HassMediaPause/area_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaPause - area_only
+
+language: "ko"
+areas:
+  - name: "거실"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    area: "거실"
+    state: "playing"
+tests:
+  - sentences:
+      - "거실 음악 일시정지"
+      - "거실의 영상 멈춰"
+    slots:
+      area: "거실"
+    response: "일시정지했습니다"

--- a/tests/ko/HassMediaPause/default.yaml
+++ b/tests/ko/HassMediaPause/default.yaml
@@ -1,0 +1,14 @@
+---
+# HassMediaPause - default
+
+language: "ko"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    state: "playing"
+tests:
+  - sentences:
+      - "일시정지"
+      - "음악 멈춰"
+      - "여기 영상 정지해"
+    response: "일시정지했습니다"

--- a/tests/ko/HassMediaPause/name_only.yaml
+++ b/tests/ko/HassMediaPause/name_only.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaPause - name_only
+
+language: "ko"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    state: "playing"
+tests:
+  - sentences:
+      - "티비 일시정지"
+      - "티비 멈춰"
+    slots:
+      name: "티비"
+    response: "일시정지했습니다"

--- a/tests/ko/HassMediaUnpause/area_only.yaml
+++ b/tests/ko/HassMediaUnpause/area_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaUnpause - area_only
+
+language: "ko"
+areas:
+  - name: "거실"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    area: "거실"
+    state: "paused"
+tests:
+  - sentences:
+      - "거실 음악 다시 재생"
+      - "거실의 영상 재개"
+    slots:
+      area: "거실"
+    response: "다시 재생합니다"

--- a/tests/ko/HassMediaUnpause/default.yaml
+++ b/tests/ko/HassMediaUnpause/default.yaml
@@ -1,0 +1,14 @@
+---
+# HassMediaUnpause - default
+
+language: "ko"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    state: "paused"
+tests:
+  - sentences:
+      - "다시 재생"
+      - "음악 계속해"
+      - "여기 영상 재개"
+    response: "다시 재생합니다"

--- a/tests/ko/HassMediaUnpause/name_only.yaml
+++ b/tests/ko/HassMediaUnpause/name_only.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaUnpause - name_only
+
+language: "ko"
+entities:
+  - name: "티비"
+    domain: "media_player"
+    state: "paused"
+tests:
+  - sentences:
+      - "티비 다시 재생"
+      - "티비 계속해"
+    slots:
+      name: "티비"
+    response: "다시 재생합니다"

--- a/tests/ko/HassNevermind/default.yaml
+++ b/tests/ko/HassNevermind/default.yaml
@@ -1,0 +1,11 @@
+---
+# HassNevermind - default
+
+language: "ko"
+tests:
+  - sentences:
+      - "아니야"
+      - "괜찮아"
+      - "됐어"
+      - "신경 쓰지 마"
+    response: ""

--- a/tests/ko/HassPauseTimer/default.yaml
+++ b/tests/ko/HassPauseTimer/default.yaml
@@ -1,0 +1,13 @@
+---
+# HassPauseTimer - default
+
+language: "ko"
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+tests:
+  - sentences:
+      - "타이머 일시정지"
+      - "내 타이머 멈춰"
+      - "타이머 정지해"
+    response: "타이머를 일시정지했습니다"

--- a/tests/ko/HassStartTimer/hours_only.yaml
+++ b/tests/ko/HassStartTimer/hours_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassStartTimer - hours_only
+
+language: "ko"
+tests:
+  - sentences:
+      - "1시간 타이머 설정"
+      - "1시간짜리 타이머"
+      - "타이머 1시간으로 맞춰줘"
+    slots:
+      hours: 1
+    response: "1시간 타이머를 설정했습니다"

--- a/tests/ko/HassStartTimer/minutes_only.yaml
+++ b/tests/ko/HassStartTimer/minutes_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassStartTimer - minutes_only
+
+language: "ko"
+tests:
+  - sentences:
+      - "5분 타이머 설정"
+      - "5분짜리 타이머"
+      - "타이머 5분으로 맞춰줘"
+    slots:
+      minutes: 5
+    response: "5분 타이머를 설정했습니다"

--- a/tests/ko/HassStartTimer/seconds_only.yaml
+++ b/tests/ko/HassStartTimer/seconds_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassStartTimer - seconds_only
+
+language: "ko"
+tests:
+  - sentences:
+      - "30초 타이머 설정"
+      - "30초짜리 타이머"
+      - "타이머 30초로 맞춰줘"
+    slots:
+      seconds: 30
+    response: "30초 타이머를 설정했습니다"

--- a/tests/ko/HassTimerStatus/default.yaml
+++ b/tests/ko/HassTimerStatus/default.yaml
@@ -1,0 +1,17 @@
+---
+# HassTimerStatus - default
+
+language: "ko"
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - "얼마나 남았어"
+      - "타이머 얼마 남았어"
+      - "타이머 상태"
+    response: "5분 남았습니다."

--- a/tests/ko/HassUnpauseTimer/default.yaml
+++ b/tests/ko/HassUnpauseTimer/default.yaml
@@ -1,0 +1,14 @@
+---
+# HassUnpauseTimer - default
+
+language: "ko"
+timers:
+  - start_minutes: 5
+    total_seconds_left: 300
+    is_active: false
+tests:
+  - sentences:
+      - "타이머 다시 시작"
+      - "내 타이머 재개"
+      - "타이머 계속해"
+    response: "타이머를 다시 시작했습니다"

--- a/tests/ko/HassVacuumCleanArea/context_area.yaml
+++ b/tests/ko/HassVacuumCleanArea/context_area.yaml
@@ -1,0 +1,12 @@
+---
+# HassVacuumCleanArea - context_area
+
+language: "ko"
+areas:
+  - name: "거실"
+tests:
+  - sentences:
+      - "여기 청소해"
+      - "이 방 청소기 돌려"
+      - "이 공간 청소"
+    response: "청소를 시작합니다"


### PR DESCRIPTION
Adds the 28 slot combinations marked **usable** in `intents.yaml` that were still missing for Korean. Korean previously had on/off, get state, climate set/get (default + area) and light brightness/color, but no timers, no media transport, and no date/time/weather.

> [!NOTE]
> Please have a native speaker check the wording before merge. Korean has no language leader in `languages.yaml`, and this adds whole intent families rather than extending existing Korean sentences. The verb sets (`설정/맞춰/걸어` for starting a timer, `취소/삭제/없애` for cancelling) and the color-temperature names in particular are worth a second opinion.

## Combinations added

| Intent | Combos |
| --- | --- |
| `HassStartTimer` | `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelTimer` | `default`, `hours_only`, `minutes_only`, `seconds_only` |
| `HassCancelAllTimers` / `HassPauseTimer` / `HassUnpauseTimer` / `HassTimerStatus` | `default` |
| `HassMediaNext` / `HassMediaPause` / `HassMediaUnpause` | `default`, `name_only`, `area_only` |
| `HassClimateGetTemperature` | `name_only` |
| `HassLightSet` | `name_temperature` |
| `HassGetCurrentDate` / `HassGetCurrentTime` | `default` |
| `HassGetWeather` | `default`, `name_only` |
| `HassNevermind` | `default` |
| `HassVacuumCleanArea` | `context_area` |

## Response files

Existing Korean responses were already translated (no English or `TODO:` leftovers), so nothing had to be re-translated. Newly **created**:

`HassCancelAllTimers`, `HassCancelTimer`, `HassPauseTimer`, `HassUnpauseTimer`, `HassStartTimer`, `HassTimerStatus`, `HassMediaNext`, `HassMediaPause`, `HassMediaUnpause`, `HassNevermind`, `HassVacuumCleanArea`, `HassGetCurrentDate`, `HassGetCurrentTime`, `HassGetWeather`.

Modified:

- `responses/ko/HassLightSet.yaml` — new `temperature` key (`색온도가 설정되었습니다`).

`HassStartTimer` and `HassTimerStatus` are ports of the English Jinja with only the human-readable text replaced. Korean does not mark plural on these duration nouns, so the singular/plural branches collapse to one form, and durations are joined by juxtaposition (`1시간 30분`) rather than with a conjunction. Date renders as `2013년 9월 17일`, time as `오전 1시 2분`.

## Other new files

- `rules/ko/timers.yaml` — `timer_set`, `timer_cancel`. (`here` and `all` already existed in `rules/ko/common.yaml`.)
- `lists/ko/lights.yaml` — adds `color_temperature_names` (촛불 1900, 따뜻한 흰색 2700, 차가운 흰색 4000, 주광색 6500). `color` was already present.

`timer_cancel` deliberately excludes 멈춰/정지 so it cannot swallow `HassPauseTimer`, and excludes 꺼/끄기 so it cannot collide with `HassTurnOff`.

`sentences/ko/_common.yaml` declares 해주세요/주세요/해줘 as skip words; none of the new templates depend on those tokens standing alone, so no skip-word interaction here.

## Verification

- `python -m script.intentfest validate --language ko` → `All good!`
- `python -m pytest tests --language ko -q` → `249 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
