### PR TITLE
Improve color temperature sentences in french

### DIFF
--- a/lists/fr/lights.yaml
+++ b/lists/fr/lights.yaml
@@ -1,16 +1,6 @@
 ---
 language: fr
 lists:
-  color_temperature_names:
-    values:
-      - in: (lumière de bougie|bougie)
-        out: 1900
-      - in: blanc chaud
-        out: 2700
-      - in: blanc froid
-        out: 4000
-      - in: lumière du jour
-        out: 6500
   color:
     values:
       - in: (blanc|blanche)
@@ -33,3 +23,13 @@ lists:
         out: brown
       - in: rose
         out: pink
+  color_temperature_names:
+    values:
+      - in: (lumière de bougie|bougie)
+        out: 1900
+      - in: blanc chaud
+        out: 2700
+      - in: (blanc froid|blanc neutre)
+        out: 4000
+      - in: lumière du jour
+        out: 6500

--- a/rules/fr/common.yaml
+++ b/rules/fr/common.yaml
@@ -2,6 +2,7 @@ language: fr
 expansion_rules:
   pourcent: (%| %| pourcent| pour cent)
   degres: (°| °| degré| degrés)
+  kelvin: "[ ](k|kelvin[s])"
   le: (le |la |les |l')
   au: (au |à la |aux |à l')
   mon: (mon |ma |mes)

--- a/rules/fr/nouns.yaml
+++ b/rules/fr/nouns.yaml
@@ -1,6 +1,7 @@
 language: fr
 expansion_rules:
   lumiere: (lumière[s]|lampe[s]|ampoule[s]|éclairage[s])
+  temperature_couleur: température [(de|de la) couleur]
   ventilateur: "[le ](ventilateur|ventilo|brasseur d'air)"
   ventilateurs: "[les ](ventilateurs|ventilos|brasseurs d'air)"
   media: (morceau|chanson|musique|élément|podcast|film|vidéo|épisode|radio|média)

--- a/sentences/fr/HassLightSet/name_temperature.yaml
+++ b/sentences/fr/HassLightSet/name_temperature.yaml
@@ -3,10 +3,10 @@
 language: fr
 data:
   - sentences:
-      - "<regle> la température [de couleur] [<de>] [<le>]{name} [à] {color_temperature:temperature}[[ ](k|kelvin)]"
-      - "<regle> [<le>]{name} [à] [une] température [de couleur] [de] {color_temperature:temperature}[[ ](k|kelvin)]"
-      - "<regle> la température [de couleur] [<de>] [<le>]{name} (à|en) {color_temperature_names:temperature}"
-      - "<regle> [<le>]{name} (à|en) [une] température [de couleur] [de] {color_temperature_names:temperature}"
+      - "<regle> [la] <temperature_couleur> [<de>] [<le>]{name} [à|sur] {color_temperature:temperature}[<kelvin>]"
+      - "(<regle>|<allume>) [<le>]{name} [à|sur] {color_temperature:temperature}<kelvin>"
+      - "<regle> [la] <temperature_couleur> [<de>] [<le>]{name} (à|en|sur) {color_temperature_names:temperature}"
+      - "(<regle>|<allume>) [<le>]{name} (à|en|sur) {color_temperature_names:temperature}"
     name_domains:
       - "light"
     example: "règle la température de couleur de la lampe de chevet à 2700 kelvin"

--- a/tests/fr/HassLightSet/name_temperature.yaml
+++ b/tests/fr/HassLightSet/name_temperature.yaml
@@ -1,49 +1,43 @@
 ---
 # HassLightSet - name_temperature
-
 language: fr
 entities:
-  - name: Lampe de chevet
-    domain: light
+  - name: "lampe de chevet"
+    domain: "light"
 tests:
   - sentences:
-      - règle la température de couleur de la lampe de chevet à 2700 kelvin
-      - mets la température de la lampe de chevet à 2700 K
-      - règle la lampe de chevet à une température de couleur de 2700 kelvin
-      - change la lampe de chevet à température 2700
+      - "règle la température de couleur de la lampe de chevet à 2700 kelvin"
+      - "règle la température de la couleur de la lampe de chevet à 2700 K"
+      - "mets la température de la lampe de chevet sur 2700"
+      - "mets la lampe de chevet à 2700 kelvins"
+      - "règle la température de couleur de la lampe de chevet en blanc chaud"
+      - "mets la lampe de chevet en blanc chaud"
+      - "allume la lampe de chevet en blanc chaud"
     slots:
       temperature: 2700
-      name: Lampe de chevet
-    response: Température de couleur réglée
+      name: "lampe de chevet"
+    response: "Température de couleur réglée"
 
   - sentences:
-      - règle la température de couleur de la lampe de chevet en blanc chaud
-      - mets la lampe de chevet en température de couleur blanc chaud
-    slots:
-      temperature: 2700
-      name: Lampe de chevet
-    response: Température de couleur réglée
-
-  - sentences:
-      - règle la température de la lampe de chevet à blanc froid
-      - ajuste la lampe de chevet à une température de blanc froid
+      - "règle la température de la lampe de chevet en blanc froid"
+      - "mets la lampe de chevet en blanc neutre"
     slots:
       temperature: 4000
-      name: Lampe de chevet
-    response: Température de couleur réglée
+      name: "lampe de chevet"
+    response: "Température de couleur réglée"
 
   - sentences:
-      - mets la température de couleur de la lampe de chevet en lumière de bougie
-      - change la lampe de chevet en température de bougie
+      - "mets la température de couleur de la lampe de chevet en lumière de bougie"
+      - "règle la lampe de chevet en bougie"
     slots:
       temperature: 1900
-      name: Lampe de chevet
-    response: Température de couleur réglée
+      name: "lampe de chevet"
+    response: "Température de couleur réglée"
 
   - sentences:
-      - règle la température de couleur de la lampe de chevet en lumière du jour
-      - mets la lampe de chevet à une température de lumière du jour
+      - "règle la température de couleur de la lampe de chevet en lumière du jour"
+      - "mets la lampe de chevet en lumière du jour"
     slots:
       temperature: 6500
-      name: Lampe de chevet
-    response: Température de couleur réglée
+      name: "lampe de chevet"
+    response: "Température de couleur réglée"


### PR DESCRIPTION
## Proposed change

Cleans up the French color temperature sentences, which had grown hard to read and matched phrasings nobody would say out loud.

New ways to say it: "mets la lampe de chevet à 2700 K", "mets la lampe de chevet en blanc chaud", and "blanc neutre" for 4000 K.
