### PR TITLE
[ru] Fix undefined rule/list references in HassIncreaseTimer

### DIFF
--- a/sentences/ru/HassIncreaseTimer/area_hours_minutes.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_hours_minutes.yaml
@@ -4,7 +4,7 @@
 language: "ru"
 data:
   - sentences:
-      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minines:minutes} минут[у|ы][ у] таймер(а|у) <in> {area}"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы][ у] таймер(а|у) <in> {area}"
       - "<timer_increase> таймер <in> {area} на {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы]"
     example: "увеличь таймер на кухне на 1 час и 15 минут"
     response: "default"

--- a/sentences/ru/HassIncreaseTimer/area_hours_minutes.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_hours_minutes.yaml
@@ -1,5 +1,5 @@
 ---
-# HassDecreaseTimer - area_hours_minutes
+# HassIncreaseTimer - area_hours_minutes
 
 language: "ru"
 data:

--- a/sentences/ru/HassIncreaseTimer/area_hours_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_hours_seconds.yaml
@@ -1,5 +1,5 @@
 ---
-# HassDecreaseTimer - area_hours_seconds
+# HassIncreaseTimer - area_hours_seconds
 
 language: "ru"
 data:

--- a/sentences/ru/HassIncreaseTimer/area_minutes_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_minutes_seconds.yaml
@@ -1,5 +1,5 @@
 ---
-# HassDecreaseTimer - area_minutes_seconds
+# HassIncreaseTimer - area_minutes_seconds
 
 language: "ru"
 data:

--- a/sentences/ru/HassIncreaseTimer/hours_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/hours_seconds.yaml
@@ -1,10 +1,10 @@
 ---
-# HassDecreaseTimer - hours_seconds
+# HassIncreaseTimer - hours_seconds
 
 language: "ru"
 data:
   - sentences:
-      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_secinds:seconds} секунд[у|ы][ у] таймер(а|у)"
-      - "<timer_increase> таймер на {timer_hours:hours} час[а|ов][ и] {timer_secinds:seconds} секунд[у|ы]"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у)"
+      - "<timer_increase> таймер на {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы]"
     example: "увеличь таймер на 1 час и 15 секунд"
     response: "default"

--- a/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
+++ b/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
@@ -1,5 +1,5 @@
 ---
-# HassDecreaseTimer - name_hours_minutes
+# HassIncreaseTimer - name_hours_minutes
 
 language: "ru"
 data:

--- a/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
+++ b/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
@@ -4,8 +4,8 @@
 language: "ru"
 data:
   - sentences:
-      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minines:minutes} минут[у|ы] [у] {timer_name:name}( |-)таймер(а|у)"
-      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minines:minutes} минут[у|ы] [у] таймер(у|а) [c (именем|названием)] {timer_name:name}"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] {timer_name:name}( |-)таймер(а|у)"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] таймер(у|а) [c (именем|названием)] {timer_name:name}"
       - "<timer_increase> таймер[у] [c (именем|названием)] {timer_name:name} на {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы]"
     example: "увеличь таймер Полив на 1 час и 15 минут"
     response: "default"

--- a/sentences/ru/HassIncreaseTimer/name_hours_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/name_hours_seconds.yaml
@@ -1,11 +1,11 @@
 ---
-# HassDecreaseTimer - name_hours_seconds
+# HassIncreaseTimer - name_hours_seconds
 
 language: "ru"
 data:
   - sentences:
-      - "<timer_inccrease> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] {timer_name:name}( |-)таймер(у|а)"
-      - "<timer_inccrease> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(у|а)[ с (именем|названием)] {timer_name:name}"
-      - "<timer_inccrease> таймер[у][ с (именем|названием)] {timer_name:name} на {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы]"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] {timer_name:name}( |-)таймер(у|а)"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(у|а)[ с (именем|названием)] {timer_name:name}"
+      - "<timer_increase> таймер[у][ с (именем|названием)] {timer_name:name} на {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы]"
     example: "увеличь таймер Полив на 1 час и 15 секунд"
     response: "default"


### PR DESCRIPTION
Undefined rule/list references in `sentences/ru/HassIncreaseTimer/`, all copy-paste artifacts from `HassDecreaseTimer`:

| Typo | Correct | File(s) |
|---|---|---|
| `<timer_inccrease>` | `<timer_increase>` (`rules/ru/timers.yaml`) | `name_hours_seconds.yaml` |
| `{timer_secinds:seconds}` | `{timer_seconds:seconds}` (`lists/timers.yaml`) | `hours_seconds.yaml` |
| `{timer_minines:minutes}` | `{timer_minutes:minutes}` (`lists/timers.yaml`) | `area_hours_minutes.yaml`, `name_hours_minutes.yaml` |

Every one of these references resolves nowhere, so the affected sentences were dead — they could never match. Also corrects `# HassDecreaseTimer` header comments to `# HassIncreaseTimer` in six files (cosmetic).

`ru` test suite passes (348 tests).

### Why this wasn't caught

`validate.py` already checks sentences for undefined rule and list references (`allowed_rule_names` / `allowed_list_names`), and `ru` is in `SLOT_COMBO_VALIDATION_LANGUAGES`. But those checks run from `validate_slot_combinations`, which iterates the slot combinations declared in `intents.yaml` and opens `<combo_name>.yaml` for each. All six affected files have names that are **not** slot combinations of `HassIncreaseTimer` (`hours_seconds`, `name_hours_seconds`, `name_hours_minutes`, `area_hours_minutes`, `area_hours_seconds`, `area_minutes_seconds` — they are combos of `HassDecreaseTimer`, which is where they were copied from). Orphan files are never opened, so they are never validated at all.

That is why all three typos live in orphan files and nowhere else in the repo: those are exactly the files validation cannot see.

A follow-up PR adds a file-driven reference check that scans every sentence file regardless of whether its combo is declared, which catches this class directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
