### PR TITLE
Validate rule/list references in every sentence file

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -840,7 +840,7 @@ def run() -> int:
         # (B) Un-localized example: in non-English slot-combination groups (WARN)
         validate_localized_examples(language, warnings[language])
 
-        # (C)/(D) Per-sentence checks sharing one read of sentences/<lang>/
+        # (C)/(D)/(E) Per-sentence checks sharing one read of sentences/<lang>/
         sentence_entries = load_language_sentences(language)
 
         # (C) Sentence requires a letter from the wrong script (WARN)
@@ -848,6 +848,15 @@ def run() -> int:
 
         # (D) Sentence references the opposite direction's rule (ERROR)
         validate_rule_directions(sentence_entries, errors[language])
+
+        # (E) Dangling rule/list references in sentences/<lang>/ (ERROR)
+        validate_sentence_references(
+            language,
+            sentence_entries,
+            available_list_names,
+            available_rule_names,
+            errors[language],
+        )
 
         validate_slot_combinations(
             intent_schemas,
@@ -1647,6 +1656,73 @@ def validate_rule_directions(
                             f"'{own}' references <{rule_name}>, which means "
                             f"'{opposite}': '{sentence}'"
                         )
+
+
+def collect_sentence_references(sentence: str) -> tuple[set[str], set[str]]:
+    """Return ``(rule_names, list_names)`` referenced by a sentence template.
+
+    Uses the hassil parser rather than a regex so that nesting, alternatives and
+    optionals are handled the same way the runtime handles them.
+    """
+    rule_names: set[str] = set()
+    list_names: set[str] = set()
+
+    def visitor(e: Expression, arg: Any):
+        if isinstance(e, RuleReference):
+            rule_names.add(e.rule_name)
+        elif isinstance(e, ListReference):
+            list_names.add(e.list_name)
+        return arg
+
+    _visit_expression(parse_sentence(sentence).expression, visitor, None)
+    return rule_names, list_names
+
+
+def validate_sentence_references(
+    language: str,
+    sentence_entries: list[tuple[str, str, str]],
+    available_list_names: set[str],
+    available_rule_names: set[str],
+    errors: list[str],
+) -> None:
+    """Check every sentence file in sentences/<lang>/ for dangling references.
+
+    A <rule> or {list} that resolves nowhere parses fine but can never match, so
+    the sentence is silently dead rather than broken in an obvious way.
+
+    This works from the files on disk instead of the slot combinations declared
+    in intents.yaml. validate_slot_combinations does the latter, which means a
+    sentence file whose name is not a declared combination of its intent is
+    never opened, and so its references are never checked at all. That is a real
+    gap: such files are usually copied from a neighbouring intent, which is
+    exactly when a mistyped rule or list name slips in. Walking the directory
+    also covers languages outside SLOT_COMBO_VALIDATION_LANGUAGES.
+
+    Files that *are* combo-validated get their references checked twice, once
+    here and once by allowed_rule_names/allowed_list_names in the schema. That
+    only ever duplicates a message for an already-failing file, which is a fair
+    trade for closing the gap.
+    """
+    for rel_path, _intent_name, sentence in sentence_entries:
+        try:
+            rule_refs, list_refs = collect_sentence_references(sentence)
+        except Exception:  # pylint: disable=broad-except
+            # Unparseable sentences are reported by the sentence schema.
+            continue
+
+        for rule_name in sorted(rule_refs - available_rule_names):
+            errors.append(
+                f"{rel_path}: sentence references undefined rule "
+                f"<{rule_name}> (not defined in rules/{language}/): "
+                f"'{sentence}'"
+            )
+
+        for list_name in sorted(list_refs - available_list_names):
+            errors.append(
+                f"{rel_path}: sentence references undefined list "
+                f"{{{list_name}}} (not in lists/, lists/{language}/, or "
+                f"builtin slot lists): '{sentence}'"
+            )
 
 
 def validate_localized_examples(language: str, warnings: list[str]) -> None:

--- a/tests/test_validate_sentence_references.py
+++ b/tests/test_validate_sentence_references.py
@@ -1,0 +1,199 @@
+"""Tests for validate.validate_sentence_references (dangling refs in sentences)."""
+
+import importlib
+from typing import Any
+
+import yaml
+
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+validate: Any = importlib.import_module("script.intentfest.validate")
+
+LISTS = {"name", "area", "floor", "brightness"}
+RULES = {"turn", "the"}
+
+
+def _write_sentences(sentence_dir, language, intent, combo, data):
+    combo_dir = sentence_dir / language / intent
+    combo_dir.mkdir(parents=True, exist_ok=True)
+    (combo_dir / f"{combo}.yaml").write_text(
+        yaml.safe_dump({"language": language, "data": data}, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _validate(tmp_path, monkeypatch, language="xx", lists=None, rules=None):
+    monkeypatch.setattr(validate, "SENTENCE_DIR", tmp_path)
+    monkeypatch.setattr(validate, "ROOT", tmp_path)
+    errors: list[str] = []
+    validate.validate_sentence_references(
+        language,
+        validate.load_language_sentences(language),
+        available_list_names=set(LISTS if lists is None else lists),
+        available_rule_names=set(RULES if rules is None else rules),
+        errors=errors,
+    )
+    return errors
+
+
+def test_clean_sentences_no_errors(tmp_path, monkeypatch):
+    """Sentences whose refs all resolve produce no errors."""
+    _write_sentences(
+        tmp_path,
+        "xx",
+        "HassTurnOn",
+        "name_only",
+        [{"sentences": ["<turn> on [<the>] {name}"], "response": "default"}],
+    )
+
+    assert not _validate(tmp_path, monkeypatch)
+
+
+def test_dangling_rule_reference_errors(tmp_path, monkeypatch):
+    """A <rule> not defined for the language is reported as an error."""
+    _write_sentences(
+        tmp_path,
+        "xx",
+        "HassTurnOn",
+        "name_only",
+        [{"sentences": ["<swithc> on {name}"], "response": "default"}],
+    )
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 1
+    assert "<swithc>" in errors[0]
+    assert "name_only.yaml" in errors[0]
+
+
+def test_dangling_list_reference_errors(tmp_path, monkeypatch):
+    """A {list} not available for the language is reported as an error."""
+    _write_sentences(
+        tmp_path,
+        "xx",
+        "HassLightSet",
+        "name_brightness",
+        [
+            {
+                "sentences": ["<turn> {name} to {brightnes:brightness}"],
+                "response": "default",
+            }
+        ],
+    )
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 1
+    assert "{brightnes}" in errors[0]
+
+
+def test_orphan_combo_file_is_checked(tmp_path, monkeypatch):
+    """A file whose name is not a declared slot combination is still checked.
+
+    This is the gap the check exists to close: validate_slot_combinations only
+    opens files named after a combination in intents.yaml, so a copied file with
+    a name belonging to another intent was never validated at all.
+    """
+    _write_sentences(
+        tmp_path,
+        "xx",
+        "HassIncreaseTimer",
+        "not_a_declared_combination",
+        [{"sentences": ["<timer_inccrease> {name}"], "response": "default"}],
+    )
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 1
+    assert "<timer_inccrease>" in errors[0]
+
+
+def test_block_local_expansion_rules_do_not_resolve(tmp_path, monkeypatch):
+    """A rule defined in the data block itself is still reported as dangling.
+
+    The slot-combination format has no per-block expansion_rules: the schema
+    rejects the key, and the conversion to hassil format keeps only sentences /
+    slots / metadata / requires_context / response, so such a rule would be
+    dropped before the sentence ever runs. Treating it as defined would hide a
+    reference that cannot resolve at runtime.
+    """
+    _write_sentences(
+        tmp_path,
+        "xx",
+        "HassTurnOn",
+        "name_only",
+        [
+            {
+                "expansion_rules": {"local": "(please|kindly)"},
+                "sentences": ["<local> <turn> on {name}"],
+                "response": "default",
+            }
+        ],
+    )
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 1
+    assert "<local>" in errors[0]
+
+
+def test_unicode_reference_names_resolve(tmp_path, monkeypatch):
+    """Accented rule/list names resolve (no false positives)."""
+    _write_sentences(
+        tmp_path,
+        "es",
+        "HassTurnOn",
+        "name_only",
+        [{"sentences": ["<añadir> {habitación}"], "response": "default"}],
+    )
+
+    errors = _validate(
+        tmp_path,
+        monkeypatch,
+        language="es",
+        lists={"habitación"},
+        rules={"añadir"},
+    )
+
+    assert not errors
+
+
+def test_refs_inside_alternatives_and_optionals(tmp_path, monkeypatch):
+    """Refs nested in (a|b) and [c] are reached by the parser walk."""
+    _write_sentences(
+        tmp_path,
+        "xx",
+        "HassTurnOn",
+        "name_only",
+        [
+            {
+                "sentences": ["(<turn>|<swithc>) on [{arae}] {name}"],
+                "response": "default",
+            }
+        ],
+    )
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 2
+    assert any("<swithc>" in error for error in errors)
+    assert any("{arae}" in error for error in errors)
+
+
+def test_unparseable_sentence_is_skipped(tmp_path, monkeypatch):
+    """A sentence the parser rejects is left to the sentence schema to report."""
+    _write_sentences(
+        tmp_path,
+        "xx",
+        "HassTurnOn",
+        "name_only",
+        [{"sentences": ["<turn> on {name"], "response": "default"}],
+    )
+
+    assert not _validate(tmp_path, monkeypatch)
+
+
+def test_missing_language_dir_is_noop(tmp_path, monkeypatch):
+    """A language with no sentence directory produces no errors."""
+    assert not _validate(tmp_path, monkeypatch, language="zz")


### PR DESCRIPTION
Checks every sentence file in `sentences/<lang>/` for `<rule>` and `{list}` references that resolve nowhere. Rebased onto #4104 and #4105, which changed what this PR is for — see below.

### The gap

`validate_slot_combinations` checks sentences for undefined references via `allowed_rule_names` / `allowed_list_names`, but it reaches those sentences by iterating the slot combinations declared in `intents.yaml`, and it returns early for any language outside `SLOT_COMBO_VALIDATION_LANGUAGES`. So **the 14 excluded languages get no rule/list reference checking at all**, and a sentence file whose name is not a declared combination of its intent is never opened.

The second half of that was the original motivation for this PR: all three typos fixed in #4102 (`<timer_inccrease>`, `{timer_secinds}`, `{timer_minines}`) lived in undeclared files. #4104 has since declared all 7 such files, and there are now 0 repo-wide — so that hole is closed on `main` today, and this check keeps it from reopening rather than fixing anything currently broken.

The excluded-language half is still live. On current `main`, injecting `<schaltennn>` and `<lichtxx>` into `sentences/de/HassTurnOn/area_domain.yaml` and running validation prints `All good!`. With this PR both are reported:

```
sentences/de/HassTurnOn/area_domain.yaml: sentence references undefined rule <lichtxx> (not defined in rules/de/): '<schaltennn> (<lichtxx>|<lichter>|<alle_lichter>) <area> ein'
sentences/de/HassTurnOn/area_domain.yaml: sentence references undefined rule <schaltennn> (not defined in rules/de/): '<schaltennn> (<lichtxx>|<lichter>|<alle_lichter>) <area> ein'
```

### The check

`validate_sentence_references` runs as check (E), consuming the `sentence_entries` that #4105 introduced — one shared read of `sentences/<lang>/` for checks (C), (D) and (E), since YAML parsing dominates this script's runtime and a second walk would be pure overhead.

- References are collected with the hassil parser, not a regex, so refs nested in `(a|b)` and `[c]` are found the way the runtime finds them.
- Unparseable sentences and malformed YAML are skipped — the existing schema checks already report those.
- Files that *are* combo-validated get their references checked twice. That only duplicates a message for an already-failing file, which seemed a fair trade for closing the gap.

### One behavior note

An earlier revision of this PR treated a data block's own `expansion_rules` as defining rules. It no longer does, and that is deliberate: `SLOT_COMBO_SENTENCE_SCHEMA` rejects the key, and the conversion to hassil format keeps only `sentences` / `slots` / `metadata` / `requires_context` / `response`, so a per-block rule is dropped before the sentence ever runs. A reference to one genuinely cannot resolve, so reporting it is correct. This matters for the excluded languages specifically, since `validate_slot_combinations` returns early for them and their combo files get no schema check to reject the key in the first place.

### Verification

- `python -m script.intentfest validate` (all 65 languages) reports 0 errors — no pre-existing breakage is newly surfaced.
- The injected `de` typos above fail validation with the expected messages and exit 1; reintroducing each of the three typos from #4102 individually does the same.
- 9 unit tests in `tests/test_validate_sentence_references.py`, mirroring `tests/test_validate_rule_references.py`, including cases for an undeclared-combo file and for the `expansion_rules` behavior above.
- Full suite: 14,233 passed. `black` / `isort` / `flake8` / `pylint` (10.00/10) clean; `mypy` reports the same 3 pre-existing missing-`hassil`-stub errors as `main`.

### Out of scope

This PR makes undeclared files' contents validate but does not flag the files themselves as undeclared. There are none left after #4104, so a check for that would be purely preventative, and would want a decision on error vs. warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
