### PR TITLE
Add missing HassIncreaseTimer slot combinations

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -2351,6 +2351,16 @@ HassIncreaseTimer:
       example: "add 1 hour and 10 minutes to my timer"
 
     # -------------------------------------------------------------------------
+
+    hours_seconds:
+      description: "Add hours and seconds to the most recent timer"
+      importance: "complete"
+      slots:
+        - "hours"
+        - "seconds"
+      example: "add 1 hour and 30 seconds to my timer"
+
+    # -------------------------------------------------------------------------
     # name
     # -------------------------------------------------------------------------
 
@@ -2389,6 +2399,32 @@ HassIncreaseTimer:
       example: "add 30 seconds to the pizza timer"
 
     # -------------------------------------------------------------------------
+
+    name_hours_minutes:
+      description: "Add hours and minutes to a timer by name"
+      importance: "complete"
+      slots:
+        - "name"
+        - "hours"
+        - "minutes"
+      wildcard_slots:
+        - "name"
+      example: "add 1 hour and 10 minutes to the pizza timer"
+
+    # -------------------------------------------------------------------------
+
+    name_hours_seconds:
+      description: "Add hours and seconds to a timer by name"
+      importance: "complete"
+      slots:
+        - "name"
+        - "hours"
+        - "seconds"
+      wildcard_slots:
+        - "name"
+      example: "add 1 hour and 30 seconds to the pizza timer"
+
+    # -------------------------------------------------------------------------
     # area
     # -------------------------------------------------------------------------
 
@@ -2419,6 +2455,39 @@ HassIncreaseTimer:
         - "area"
         - "seconds"
       example: "add 30 seconds to the kitchen timer"
+
+    # -------------------------------------------------------------------------
+
+    area_minutes_seconds:
+      description: "Add minutes and seconds to the most recent timer in an area"
+      importance: "complete"
+      slots:
+        - "area"
+        - "minutes"
+        - "seconds"
+      example: "add 10 minutes and 30 seconds to the kitchen timer"
+
+    # -------------------------------------------------------------------------
+
+    area_hours_minutes:
+      description: "Add hours and minutes to the most recent timer in an area"
+      importance: "complete"
+      slots:
+        - "area"
+        - "hours"
+        - "minutes"
+      example: "add 1 hour and 10 minutes to the kitchen timer"
+
+    # -------------------------------------------------------------------------
+
+    area_hours_seconds:
+      description: "Add hours and seconds to the most recent timer in an area"
+      importance: "complete"
+      slots:
+        - "area"
+        - "hours"
+        - "seconds"
+      example: "add 1 hour and 30 seconds to the kitchen timer"
 
     # -------------------------------------------------------------------------
     # hours + start

--- a/sentences/ru/HassIncreaseTimer/area_hours_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_hours_seconds.yaml
@@ -4,7 +4,7 @@
 language: "ru"
 data:
   - sentences:
-      - "<timer_decrease> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
-      - "<timer_decrease> таймер <in> {area} на {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы]"
-    example: "уменьши таймер на кухне на 1 час и 15 секунд"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
+      - "<timer_increase> таймер <in> {area} на {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы]"
+    example: "увеличь таймер на кухне на 1 час и 15 секунд"
     response: "default"

--- a/sentences/ru/HassIncreaseTimer/area_minutes_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_minutes_seconds.yaml
@@ -4,7 +4,7 @@
 language: "ru"
 data:
   - sentences:
-      - "<timer_decrease> {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
-      - "<timer_decrease> таймер <in> {area} на {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы]"
-    example: "уменьши таймер на кухне на 1 минуту и 15 секунд"
+      - "<timer_increase> {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
+      - "<timer_increase> таймер <in> {area} на {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы]"
+    example: "увеличь таймер на кухне на 1 минуту и 15 секунд"
     response: "default"

--- a/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
+++ b/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
@@ -5,7 +5,7 @@ language: "ru"
 data:
   - sentences:
       - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] {timer_name:name}( |-)таймер(а|у)"
-      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] таймер(у|а) [c (именем|названием)] {timer_name:name}"
-      - "<timer_increase> таймер[у] [c (именем|названием)] {timer_name:name} на {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы]"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] таймер(у|а) [с (именем|названием)] {timer_name:name}"
+      - "<timer_increase> таймер[у] [с (именем|названием)] {timer_name:name} на {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы]"
     example: "увеличь таймер Полив на 1 час и 15 минут"
     response: "default"


### PR DESCRIPTION
Fixes the orphan sentence file in `sentences/zh-HK/HassIncreaseTimer/` — and, in the process, completes the ru fix from #4102, which turned out to be only half a fix.

### `HassIncreaseTimer` is missing six slot combinations

`HassIncreaseTimer` declared 20 slot combinations; `HassDecreaseTimer` declares 26. The six missing ones are `hours_seconds`, `name_hours_minutes`, `name_hours_seconds`, `area_minutes_seconds`, `area_hours_minutes` and `area_hours_seconds`. All six exist for Decrease, and `hours_seconds` exists for `HassStartTimer` as well, so this reads as an oversight rather than a deliberate restriction — there is nothing about adding time that makes "add 1 hour and 30 seconds" less sayable than removing it.

ru and zh-HK had **already written both sentences and tests** for exactly those combinations. They were simply never loaded:

- `load_intents_dict()` (the hassil-ready loader used by tests and Home Assistant) iterates the combinations declared in `intents.yaml` and skips files it does not find a declaration for.
- `tests/test_slot_combinations.py` generates its tests the same way.

So 16 sentences never reached the recognizer and 7 test files never ran. Declaring the combinations makes all of them live: **14,207 tests pass, up from 13,826 (+381)**.

This is also why #4102 did not actually fix ru. That PR corrected the reference typos, so the files became internally valid — but the sentences were still unreachable, because the combinations were still undeclared. Verified directly:

```
ru HassIncreaseTimer, before this PR:  0/14 sentences reach hassil
ru HassIncreaseTimer, after:          14/14
zh-HK hours_seconds:  0/2 -> 2/2
```

### Three ru bugs the newly-activated tests caught

Turning the tests on immediately failed three of them, in files that had never been exercised:

1. **`area_hours_seconds.yaml` and `area_minutes_seconds.yaml` used `<timer_decrease>`** with an `уменьши` ("decrease") example — unadapted `HassDecreaseTimer` copies. This one matters: left in place, declaring the combinations would have routed *decrease* phrasings to `HassIncreaseTimer`, so a user saying "уменьши таймер на кухне на 1 час и 15 секунд" would get time **added**. Dead sentences becoming wrong sentences is a worse outcome than dead sentences, and only the test activation surfaced it.
2. **`name_hours_minutes.yaml` wrote `[c (именем|названием)]` with a Latin `c` (U+0063)** instead of Cyrillic `с` (U+0441). The optional group could therefore never match, and the `{timer_name}` wildcard swallowed the whole phrase — `name` came out as `с названием Пицца` instead of `Пицца`. Invisible in review; the sibling `name_hours_seconds.yaml` uses the correct Cyrillic letter.

### Impact on other languages

None. The new combinations have `importance: "complete"`, which produces neither an error nor a warning when a language has no sentences for them. `python -m script.intentfest validate` across all 65 languages: **0 errors, and 1131 warnings both before and after** — byte-identical count.

### Note on the guard

This touches `intents.yaml`, so `guard-core-files` applies and CODEOWNERS routes it to @OHF-Voice/voice-ohf. That gate is working as intended here — this is a spec change affecting every language, and it deserves the review.

### Verification

- Full suite: 14,207 passed (13,826 before).
- `python -m script.intentfest validate`: 0 errors, warning count unchanged from `main`.
- Confirmed all 16 previously-dead sentences now reach `load_intents_dict()`.
- Scanned every `sentences/*/Hass*Timer/*.yaml` for the wrong-direction rule reference — the two ru files above were the only instances repo-wide.

Related: #4102 (the reference typos), #4103 (the validator check for undefined references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
