### PR TITLE
Validate sentence scripts and rule directions

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -2351,6 +2351,16 @@ HassIncreaseTimer:
       example: "add 1 hour and 10 minutes to my timer"
 
     # -------------------------------------------------------------------------
+
+    hours_seconds:
+      description: "Add hours and seconds to the most recent timer"
+      importance: "complete"
+      slots:
+        - "hours"
+        - "seconds"
+      example: "add 1 hour and 30 seconds to my timer"
+
+    # -------------------------------------------------------------------------
     # name
     # -------------------------------------------------------------------------
 
@@ -2389,6 +2399,32 @@ HassIncreaseTimer:
       example: "add 30 seconds to the pizza timer"
 
     # -------------------------------------------------------------------------
+
+    name_hours_minutes:
+      description: "Add hours and minutes to a timer by name"
+      importance: "complete"
+      slots:
+        - "name"
+        - "hours"
+        - "minutes"
+      wildcard_slots:
+        - "name"
+      example: "add 1 hour and 10 minutes to the pizza timer"
+
+    # -------------------------------------------------------------------------
+
+    name_hours_seconds:
+      description: "Add hours and seconds to a timer by name"
+      importance: "complete"
+      slots:
+        - "name"
+        - "hours"
+        - "seconds"
+      wildcard_slots:
+        - "name"
+      example: "add 1 hour and 30 seconds to the pizza timer"
+
+    # -------------------------------------------------------------------------
     # area
     # -------------------------------------------------------------------------
 
@@ -2419,6 +2455,39 @@ HassIncreaseTimer:
         - "area"
         - "seconds"
       example: "add 30 seconds to the kitchen timer"
+
+    # -------------------------------------------------------------------------
+
+    area_minutes_seconds:
+      description: "Add minutes and seconds to the most recent timer in an area"
+      importance: "complete"
+      slots:
+        - "area"
+        - "minutes"
+        - "seconds"
+      example: "add 10 minutes and 30 seconds to the kitchen timer"
+
+    # -------------------------------------------------------------------------
+
+    area_hours_minutes:
+      description: "Add hours and minutes to the most recent timer in an area"
+      importance: "complete"
+      slots:
+        - "area"
+        - "hours"
+        - "minutes"
+      example: "add 1 hour and 10 minutes to the kitchen timer"
+
+    # -------------------------------------------------------------------------
+
+    area_hours_seconds:
+      description: "Add hours and seconds to the most recent timer in an area"
+      importance: "complete"
+      slots:
+        - "area"
+        - "hours"
+        - "seconds"
+      example: "add 1 hour and 30 seconds to the kitchen timer"
 
     # -------------------------------------------------------------------------
     # hours + start

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -6,9 +6,11 @@ import argparse
 import itertools
 import json
 import re
+import unicodedata
 from collections import Counter, defaultdict
 from collections.abc import Callable, Collection
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 from unittest.mock import MagicMock
@@ -23,6 +25,7 @@ from hassil import (
     Group,
     ListReference,
     RuleReference,
+    TextChunk,
     parse_sentence,
 )
 from voluptuous.humanize import validate_with_humanized_errors
@@ -113,6 +116,51 @@ IMPORTANCE_LEVELS = {"required", "usable", "complete", "optional"}
 # would silently drop them and mis-flag live references as dangling).
 RULE_REF_RE = re.compile(r"<(\w+)>")
 LIST_REF_RE = re.compile(r"\{(\w+)(?::\w+)?\}")
+
+# Scripts recognised when working out which one a language is written in. Only
+# the prefix of the Unicode character name is needed to classify a letter.
+SCRIPT_NAME_PREFIXES = (
+    "LATIN",
+    "CYRILLIC",
+    "GREEK",
+    "HEBREW",
+    "ARABIC",
+    "ARMENIAN",
+    "GEORGIAN",
+    "DEVANAGARI",
+    "BENGALI",
+    "TAMIL",
+    "TELUGU",
+    "KANNADA",
+    "MALAYALAM",
+    "GUJARATI",
+    "GURMUKHI",
+    "THAI",
+    "HANGUL",
+    "HIRAGANA",
+    "KATAKANA",
+    "CJK",
+    "ETHIOPIC",
+)
+
+# Scripts whose letterforms are mutually confusable, so a letter from one can
+# stand in for a letter of another without looking wrong (Latin c / Cyrillic с,
+# Latin o / Greek ο). Mixing outside this set is not a look-alike risk and is
+# often normal: Japanese mixes Han with Hiragana and Katakana in every sentence.
+CONFUSABLE_SCRIPTS = frozenset({"LATIN", "CYRILLIC", "GREEK", "ARMENIAN"})
+
+# Intent/rule direction markers. A sentence under an intent meaning one
+# direction should not reach for the rule meaning the other.
+#
+# Deliberately limited to verbs that only ever express direction. "on"/"off"
+# looks like an obvious pair but cannot be used: several languages define <on>
+# as the *preposition* (it/HassTurnOff sentences use `(<in>|<of>|<at>|<on>)`),
+# so pairing it with "off" reports working sentences.
+DIRECTION_ANTONYMS = (
+    ("increase", "decrease"),
+    ("pause", "unpause"),
+    ("next", "previous"),
+)
 
 
 def match_anything(value):
@@ -792,6 +840,15 @@ def run() -> int:
         # (B) Un-localized example: in non-English slot-combination groups (WARN)
         validate_localized_examples(language, warnings[language])
 
+        # (C)/(D) Per-sentence checks sharing one read of sentences/<lang>/
+        sentence_entries = load_language_sentences(language)
+
+        # (C) Sentence requires a letter from the wrong script (WARN)
+        validate_sentence_scripts(sentence_entries, warnings[language])
+
+        # (D) Sentence references the opposite direction's rule (ERROR)
+        validate_rule_directions(sentence_entries, errors[language])
+
         validate_slot_combinations(
             intent_schemas,
             language,
@@ -1385,6 +1442,211 @@ def validate_rule_references(
                     f"undefined list {{{list_name}}} (not in lists/, "
                     f"lists/{language}/, or builtin slot lists)"
                 )
+
+
+def load_language_sentences(language: str) -> list[tuple[str, str, str]]:
+    """Return ``(rel_path, intent_name, sentence)`` for a language's sentences.
+
+    Read once and shared by the per-sentence checks below: YAML parsing dominates
+    the runtime of this script, so each extra walk over sentences/<lang>/ is worth
+    avoiding.
+    """
+    entries: list[tuple[str, str, str]] = []
+    sentence_dir: Path = SENTENCE_DIR / language
+    if not sentence_dir.is_dir():
+        return entries
+
+    for sentence_path in sorted(sentence_dir.glob("*/*.yaml")):
+        rel_path = str(sentence_path.relative_to(ROOT))
+        intent_name = sentence_path.parent.name
+
+        try:
+            sentence_doc = yaml.safe_load(sentence_path.read_text(encoding="utf8"))
+        except yaml.YAMLError:
+            # Malformed YAML is already reported elsewhere.
+            continue
+
+        if not sentence_doc:
+            continue
+
+        for group in sentence_doc.get("data", []) or []:
+            for sentence in group.get("sentences", []) or []:
+                if isinstance(sentence, str):
+                    entries.append((rel_path, intent_name, sentence))
+
+    return entries
+
+
+@lru_cache(maxsize=None)
+def char_script(char: str) -> Optional[str]:
+    """Return the script a letter belongs to, or None if it is not a letter.
+
+    Cached: unicodedata.name() is comparatively slow and this is called for every
+    character of every sentence, but an alphabet is small so the cache is tiny.
+    """
+    try:
+        char_name = unicodedata.name(char)
+    except ValueError:
+        return None
+
+    for prefix in SCRIPT_NAME_PREFIXES:
+        if char_name.startswith(prefix):
+            return prefix
+
+    return None
+
+
+def expression_literal_text(expression: Expression) -> str:
+    """Return the literal text of a parsed sentence, without reference names."""
+    chunks: list[str] = []
+
+    def visitor(e: Expression, arg: Any):
+        if isinstance(e, TextChunk):
+            chunks.append(e.text)
+        return arg
+
+    _visit_expression(expression, visitor, None)
+    return "".join(chunks)
+
+
+def find_foreign_letter_tokens(
+    expression: Expression, dominant_script: str
+) -> list[str]:
+    """Return single-letter tokens written in the wrong script for a language.
+
+    A homoglyph typo (Cyrillic с mistyped as Latin c) is invisible on screen and
+    silently stops a word from ever matching, so it needs to be found mechanically.
+
+    Only single-letter tokens sitting in *sequence* position are reported.
+    Languages legitimately offer a foreign-script spelling as one branch of an
+    alternative -- ``(k|к|кельвин[ов|а])`` lets a user say the Latin or the
+    Cyrillic form of "kelvin" -- and every such case in the repository is written
+    that way. A letter that is merely one option among several is intentional; a
+    letter the sentence *requires* in sequence with native words is not.
+
+    Alternative branches arrive wrapped in single-item Groups, so a one-item
+    Group keeps the "offered as an alternative" flag while a longer Group (a real
+    sequence) clears it.
+    """
+    foreign_tokens: list[str] = []
+
+    def walk(expression: Expression, offered_as_alternative: bool) -> None:
+        if isinstance(expression, Alternative):
+            for item in expression.items:
+                walk(item, True)
+            return
+
+        if isinstance(expression, Group):
+            group: Group = expression
+            nested = offered_as_alternative if len(group.items) == 1 else False
+            for item in group.items:
+                walk(item, nested)
+            return
+
+        if isinstance(expression, TextChunk) and not offered_as_alternative:
+            text_chunk: TextChunk = expression
+            for token in text_chunk.text.split():
+                if len(token) != 1:
+                    continue
+                token_script = char_script(token)
+                if (
+                    (token_script is not None)
+                    and (token_script != dominant_script)
+                    and (token_script in CONFUSABLE_SCRIPTS)
+                ):
+                    foreign_tokens.append(token)
+
+    walk(expression, False)
+    return foreign_tokens
+
+
+def validate_sentence_scripts(
+    sentence_entries: list[tuple[str, str, str]], warnings: list[str]
+) -> None:
+    """Warn when a sentence requires a single letter from the wrong script.
+
+    The language's own script is worked out from its sentences rather than
+    configured, so this needs no per-language table and keeps working as
+    languages are added.
+    """
+    script_counts: Counter[str] = Counter()
+    parsed: list[tuple[str, str, Expression]] = []
+
+    for rel_path, _intent_name, sentence in sentence_entries:
+        try:
+            expression = parse_sentence(sentence).expression
+        except Exception:  # pylint: disable=broad-except
+            # Unparseable sentences are reported by the sentence schema.
+            continue
+
+        parsed.append((rel_path, sentence, expression))
+
+        # Count only the literal words. {list:slot} and <rule> names are ASCII by
+        # convention, and there is enough of them that counting the raw template
+        # makes every language look like it is written in Latin.
+        for char in expression_literal_text(expression):
+            script = char_script(char)
+            if script is not None:
+                script_counts[script] += 1
+
+    if not script_counts:
+        return
+
+    dominant_script = script_counts.most_common(1)[0][0]
+    if dominant_script not in CONFUSABLE_SCRIPTS:
+        # No letter of another script can pass for one of this language's own.
+        return
+
+    for rel_path, sentence, expression in parsed:
+        for token in sorted(
+            set(find_foreign_letter_tokens(expression, dominant_script))
+        ):
+            script = char_script(token)
+            warnings.append(
+                f"{rel_path}: sentence requires '{token}' "
+                f"(U+{ord(token):04X}, {script}) in a {dominant_script} language - "
+                f"likely a look-alike of the {dominant_script} letter it replaces: "
+                f"'{sentence}'"
+            )
+
+
+def name_tokens(name: str) -> set[str]:
+    """Split an intent or rule name into lowercase words.
+
+    Handles both ``HassIncreaseTimer`` and ``timer_decrease``.
+    """
+    spaced = re.sub(r"(?<!^)(?=[A-Z])", "_", name)
+    return {token for token in re.split(r"[_\W]+", spaced.lower()) if token}
+
+
+def validate_rule_directions(
+    sentence_entries: list[tuple[str, str, str]], errors: list[str]
+) -> None:
+    """Check that sentences do not reach for the opposite direction's rule.
+
+    Copying a sentence file between mirrored intents and forgetting to flip the
+    rule is worse than a dead sentence: once the slot combination is declared,
+    the sentence matches, so the *opposite* phrasing runs the wrong intent (a
+    "уменьши"/decrease sentence adding time under HassIncreaseTimer).
+    """
+    for rel_path, intent_name, sentence in sentence_entries:
+        intent_tokens = name_tokens(intent_name)
+
+        for rule_name in sorted(set(RULE_REF_RE.findall(sentence))):
+            rule_name_tokens = name_tokens(rule_name)
+
+            for first, second in DIRECTION_ANTONYMS:
+                for own, opposite in ((first, second), (second, first)):
+                    if (
+                        (own in intent_tokens)
+                        and (opposite in rule_name_tokens)
+                        and (own not in rule_name_tokens)
+                    ):
+                        errors.append(
+                            f"{rel_path}: sentence under an intent that means "
+                            f"'{own}' references <{rule_name}>, which means "
+                            f"'{opposite}': '{sentence}'"
+                        )
 
 
 def validate_localized_examples(language: str, warnings: list[str]) -> None:

--- a/sentences/ru/HassIncreaseTimer/area_hours_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_hours_seconds.yaml
@@ -4,7 +4,7 @@
 language: "ru"
 data:
   - sentences:
-      - "<timer_decrease> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
-      - "<timer_decrease> таймер <in> {area} на {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы]"
-    example: "уменьши таймер на кухне на 1 час и 15 секунд"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
+      - "<timer_increase> таймер <in> {area} на {timer_hours:hours} час[а|ов][ и] {timer_seconds:seconds} секунд[у|ы]"
+    example: "увеличь таймер на кухне на 1 час и 15 секунд"
     response: "default"

--- a/sentences/ru/HassIncreaseTimer/area_minutes_seconds.yaml
+++ b/sentences/ru/HassIncreaseTimer/area_minutes_seconds.yaml
@@ -4,7 +4,7 @@
 language: "ru"
 data:
   - sentences:
-      - "<timer_decrease> {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
-      - "<timer_decrease> таймер <in> {area} на {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы]"
-    example: "уменьши таймер на кухне на 1 минуту и 15 секунд"
+      - "<timer_increase> {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы][ у] таймер(а|у) <in> {area}"
+      - "<timer_increase> таймер <in> {area} на {timer_minutes:minutes} минут[у|ы][ и] {timer_seconds:seconds} секунд[у|ы]"
+    example: "увеличь таймер на кухне на 1 минуту и 15 секунд"
     response: "default"

--- a/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
+++ b/sentences/ru/HassIncreaseTimer/name_hours_minutes.yaml
@@ -5,7 +5,7 @@ language: "ru"
 data:
   - sentences:
       - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] {timer_name:name}( |-)таймер(а|у)"
-      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] таймер(у|а) [c (именем|названием)] {timer_name:name}"
-      - "<timer_increase> таймер[у] [c (именем|названием)] {timer_name:name} на {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы]"
+      - "<timer_increase> {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы] [у] таймер(у|а) [с (именем|названием)] {timer_name:name}"
+      - "<timer_increase> таймер[у] [с (именем|названием)] {timer_name:name} на {timer_hours:hours} час[а|ов][ и] {timer_minutes:minutes} минут[у|ы]"
     example: "увеличь таймер Полив на 1 час и 15 минут"
     response: "default"

--- a/tests/test_validate_sentence_typos.py
+++ b/tests/test_validate_sentence_typos.py
@@ -1,0 +1,207 @@
+"""Tests for the per-sentence typo checks in validate.
+
+Covers validate_sentence_scripts (look-alike letters from the wrong script) and
+validate_rule_directions (a sentence reaching for the opposite direction's rule).
+"""
+
+import importlib
+from typing import Any
+
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+validate: Any = importlib.import_module("script.intentfest.validate")
+
+
+def _entries(*sentences, intent="HassTurnOn", path="sentences/xx/HassTurnOn/a.yaml"):
+    return [(path, intent, sentence) for sentence in sentences]
+
+
+def _scripts(*sentences, **kwargs):
+    warnings: list[str] = []
+    validate.validate_sentence_scripts(_entries(*sentences, **kwargs), warnings)
+    return warnings
+
+
+def _directions(*sentences, **kwargs):
+    errors: list[str] = []
+    validate.validate_rule_directions(_entries(*sentences, **kwargs), errors)
+    return errors
+
+
+# --------------------------------------------------------------------------
+# validate_sentence_scripts
+# --------------------------------------------------------------------------
+
+
+def test_latin_letter_in_cyrillic_sentence_warns():
+    """A bare Latin c standing in for Cyrillic с is reported."""
+    warnings = _scripts(
+        "включи таймер [c (именем|названием)] {name}",
+        "выключи таймер на кухне",
+    )
+
+    assert len(warnings) == 1
+    assert "U+0063" in warnings[0]
+    assert "LATIN" in warnings[0]
+    assert "CYRILLIC" in warnings[0]
+
+
+def test_correct_cyrillic_letter_does_not_warn():
+    """The same sentence with Cyrillic с is clean."""
+    assert not _scripts(
+        "включи таймер [с (именем|названием)] {name}",
+        "выключи таймер на кухне",
+    )
+
+
+def test_latin_offered_as_alternative_does_not_warn():
+    """A Latin spelling offered alongside the native one is intentional.
+
+    Languages deliberately accept both "k" and "к"/"кельвин" for kelvin, so the
+    letter being *one option among several* is the signal that it is wanted.
+    """
+    assert not _scripts(
+        "установи температуру {temperature}[[ ](k|к|кельвин[ов|а])]",
+        "установи температуру света в спальне",
+    )
+
+
+def test_latin_in_optional_alternative_does_not_warn():
+    """The `[ k| келвина]` form (bg) is also an alternative, not a sequence."""
+    assert not _scripts(
+        "зададени температура {temperature}[ k| келвина]",
+        "намали температурата в спалнята",
+    )
+
+
+def test_latin_language_does_not_warn_on_its_own_letters():
+    """A Latin-script language is not reported for using Latin letters."""
+    assert not _scripts(
+        "turn on the light in the kitchen",
+        "set a timer for 5 minutes",
+    )
+
+
+def test_cyrillic_letter_in_latin_sentence_warns():
+    """The check works in the other direction too."""
+    # "с" here is U+0441 CYRILLIC SMALL LETTER ES, not Latin c.
+    warnings = _scripts(
+        "turn on the light [с (named)] {name}",
+        "set a timer for 5 minutes",
+    )
+
+    assert len(warnings) == 1
+    assert "U+0441" in warnings[0]
+
+
+def test_non_confusable_script_is_ignored():
+    """Han mixed with Hiragana is normal Japanese, not a look-alike risk."""
+    assert not _scripts(
+        "キッチンの照明をつけて",
+        "タイマーを5分に設定して",
+    )
+
+
+def test_multi_letter_foreign_word_is_ignored():
+    """Loanwords are intentional; only single-letter tokens are look-alike risks."""
+    assert not _scripts(
+        "привет home assistant",
+        "включи свет на кухне",
+    )
+
+
+def test_no_sentences_is_noop():
+    """An empty language produces no warnings."""
+    assert not _scripts()
+
+
+# --------------------------------------------------------------------------
+# validate_rule_directions
+# --------------------------------------------------------------------------
+
+
+def test_opposite_direction_rule_errors():
+    """An increase intent referencing a decrease rule is an error."""
+    errors = _directions(
+        "<timer_decrease> {timer_hours:hours} часа таймеру",
+        intent="HassIncreaseTimer",
+        path="sentences/ru/HassIncreaseTimer/hours_only.yaml",
+    )
+
+    assert len(errors) == 1
+    assert "increase" in errors[0]
+    assert "timer_decrease" in errors[0]
+
+
+def test_matching_direction_rule_is_clean():
+    """The correct rule for the intent produces no error."""
+    assert not _directions(
+        "<timer_increase> {timer_hours:hours} часа таймеру",
+        intent="HassIncreaseTimer",
+        path="sentences/ru/HassIncreaseTimer/hours_only.yaml",
+    )
+
+
+def test_direction_check_is_symmetric():
+    """A decrease intent referencing an increase rule is also caught."""
+    errors = _directions(
+        "<timer_increase> {timer_hours:hours} часа таймеру",
+        intent="HassDecreaseTimer",
+        path="sentences/ru/HassDecreaseTimer/hours_only.yaml",
+    )
+
+    assert len(errors) == 1
+    assert "decrease" in errors[0]
+
+
+def test_pause_unpause_pair():
+    """pause/unpause is treated as a direction pair."""
+    errors = _directions(
+        "<timer_unpause> таймер",
+        intent="HassPauseTimer",
+        path="sentences/ru/HassPauseTimer/default.yaml",
+    )
+
+    assert len(errors) == 1
+    assert "unpause" in errors[0]
+
+
+def test_unpause_intent_does_not_match_its_own_pause_token():
+    """HassUnpauseTimer with <timer_unpause> must not be flagged.
+
+    "unpause" contains "pause", so a naive substring check would report the
+    correct rule as the opposite one.
+    """
+    assert not _directions(
+        "<timer_unpause> таймер",
+        intent="HassUnpauseTimer",
+        path="sentences/ru/HassUnpauseTimer/default.yaml",
+    )
+
+
+def test_rule_naming_both_directions_is_not_flagged():
+    """A rule whose name covers both directions is not an opposite reference."""
+    assert not _directions(
+        "<timer_increase_decrease> таймер",
+        intent="HassIncreaseTimer",
+        path="sentences/ru/HassIncreaseTimer/hours_only.yaml",
+    )
+
+
+def test_on_off_is_deliberately_not_a_pair():
+    """<on> is a preposition rule in several languages, so on/off is excluded."""
+    assert not _directions(
+        "<turn_off> [<the>] {name} (<in>|<of>|<at>|<on>) [<the>] {floor}",
+        intent="HassTurnOff",
+        path="sentences/it/HassTurnOff/name_floor.yaml",
+    )
+
+
+def test_unrelated_intent_is_clean():
+    """An intent with no direction marker is never flagged."""
+    assert not _directions(
+        "<turn_on> [<the>] {name}",
+        intent="HassTurnOn",
+        path="sentences/en/HassTurnOn/name_only.yaml",
+    )


### PR DESCRIPTION
Stacked on #4104 — based on that branch so the diff is just this commit and CI is green (both checks fire on the ru bugs that PR fixes). Retarget to `main` once #4104 merges.

Adds the two checks discussed on #4104. Both target bug classes that reference validation cannot see, because in both cases every reference is perfectly valid. Both were found by hand in `ru/HassIncreaseTimer`, and neither would have been found by reading the file.

## 1. `validate_sentence_scripts` — look-alike letters (WARN)

ru wrote `[c (именем|названием)]` with a **Latin `c` (U+0063)** where Cyrillic **`с` (U+0441)** belongs. The optional group could never match, so the `{timer_name}` wildcard swallowed the phrase and `name` resolved to `с названием Пицца` instead of `Пицца`. The two characters are visually identical — this cannot be caught by review.

The hard part is that a bare foreign letter is sometimes deliberate. Languages accept both spellings of "kelvin":

```yaml
{color_temperature:temperature}[[ ](k|к|кельвин[ов|а])]   # ru — intentional
{color_temperature:temperature}[ k| келвина]              # bg — intentional
таймер(у|а) [c (именем|названием)]                        # ru — the bug
```

The distinguishing feature is structural, not lexical: in the legitimate cases the Latin letter is **one branch of an alternative**, offered alongside the native form. In the bug it is a **sequence item** the sentence requires. Every legitimate instance in the repository is written as an alternative, so the check reports only single-letter tokens in sequence position.

Two further restrictions keep it quiet:

- Only scripts with mutually confusable letterforms (Latin/Cyrillic/Greek/Armenian). Japanese mixes Han with Hiragana and Katakana in every sentence, and Arabic/Hebrew/CJK letters have no Latin look-alikes.
- Only single-letter tokens. `привет home assistant` and `(лایٹ | light[s] | بتی)` are loanwords, not typos.

The language's own script is derived from its sentences, so there is no per-language table to maintain. One subtlety worth flagging: this must count **literal text only**. `{list:slot}` and `<rule>` names are ASCII by convention and there are enough of them that counting whole templates classifies bg, ru and ar as *Latin*-script languages. My first attempt did exactly that and produced 659 false warnings.

## 2. `validate_rule_directions` — opposite-direction rules (ERROR)

ru's `area_hours_seconds.yaml` and `area_minutes_seconds.yaml` used `<timer_decrease>` under `HassIncreaseTimer`. As #4104 notes, this is worse than a dead sentence: once the slot combination is declared the sentence matches, so `уменьши таймер на кухне на 1 час` **adds** time.

Limited to verbs that only ever express direction — `increase`/`decrease`, `pause`/`unpause`, `next`/`previous`. `on`/`off` is the obvious fourth pair and is deliberately excluded: several languages define `<on>` as the *preposition*, so it's `(<in>|<of>|<at>|<on>)` in `it/HassTurnOff` would be reported as a wrong-direction rule. A candidate table including on/off produced exactly those 6 false positives, which is why it isn't there.

Token-based rather than substring-based, so `HassUnpauseTimer` referencing `<timer_unpause>` is not flagged for containing "pause". There is a test for that.

## Verification

- `python -m script.intentfest validate` across all 65 languages: **0 errors, 1131 warnings — byte-identical to the count before this change.** Neither check reports anything on the current repository.
- Reintroducing each bug makes the corresponding check fire:
  - Latin `c` restored → 2 warnings naming `U+0063, LATIN` in a `CYRILLIC` language.
  - `<timer_decrease>` restored → 2 errors, exit 1.
- 17 new unit tests in `tests/test_validate_sentence_typos.py`, including the kelvin alternatives, the `unpause` token case, and the `on`/`off` exclusion.
- Full suite: 14,224 passed. `black` / `isort` / `flake8` / `pylint` (10.00/10) / `mypy` clean (the 3 `mypy` errors are pre-existing missing `hassil` stubs).

## Cost

These checks look at every sentence, which is not free — YAML parsing already dominates this script. Sentences are read once and shared between the two checks, and `char_script` is cached because `unicodedata.name()` is called per character. Net cost on a 4-language run is ~30% (2.16s → 2.85s); sharing the read and caching took it down from ~60%.

## Note on severity

The script check is a WARN and the direction check an ERROR, matching how confident each is. A WARN still blocks a PR that touches the offending file, via the existing changed-files promotion in `run()` — verified — so a newly introduced homoglyph fails CI on the PR that introduces it without breaking unrelated work if a legitimate case ever appears.

Related: #4102, #4103, #4104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
