### PR TITLE
Flag sentence/test files no slot combination declares

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -837,6 +837,9 @@ def run() -> int:
         # (A) Dangling rule/list references in rules/<lang>/ (ERROR)
         validate_rule_references(language, available_list_names, errors[language])
 
+        # (A2) Sentence/test files no declared slot combination points at (ERROR)
+        validate_undeclared_files(intent_schemas, language, errors[language])
+
         # (B) Un-localized example: in non-English slot-combination groups (WARN)
         validate_localized_examples(language, warnings[language])
 
@@ -1441,6 +1444,60 @@ def validate_rule_references(
                     f"rules/{language}/: expansion rule <{name}> references "
                     f"undefined list {{{list_name}}} (not in lists/, "
                     f"lists/{language}/, or builtin slot lists)"
+                )
+
+
+def validate_undeclared_files(
+    intent_schemas: dict,
+    language: str,
+    errors: list[str],
+) -> None:
+    """Check that every sentence/test file is named after a declared combination.
+
+    Almost everything in this repo reaches a file by enumerating the slot
+    combinations declared in intents.yaml: validate_slot_combinations,
+    tests/test_slot_combinations.py, check_overmatch and load_intents_dict all
+    work that way. A file whose name is not a declared combination of its intent
+    is therefore opened by nothing -- it is not validated, not tested, and not
+    shipped, but it looks exactly like a file that is.
+
+    That silence is the problem. A contributor edits such a file and reasonably
+    believes the change took effect, and the content stays unchecked until the
+    combination is declared later, at which point it goes live all at once. That
+    is the #4102/#4104 sequence: six undeclared ru files accumulated three
+    dangling references, and declaring the combinations is what would have
+    activated them.
+
+    Naming the files instead of validating around them keeps the two views --
+    what is on disk and what intents.yaml declares -- from drifting apart again.
+    """
+    for top_dir in (SENTENCE_DIR, TESTS_DIR):
+        language_dir: Path = top_dir / language
+        if not language_dir.is_dir():
+            continue
+
+        for intent_dir in sorted(p for p in language_dir.iterdir() if p.is_dir()):
+            rel_dir = str(intent_dir.relative_to(ROOT))
+            intent_name = intent_dir.name
+
+            if intent_name not in intent_schemas:
+                # One error for the directory, rather than one per file inside it.
+                errors.append(
+                    f"{rel_dir}/: directory is not an intent defined in intents.yaml"
+                )
+                continue
+
+            combo_names = set(intent_schemas[intent_name]["slot_combinations"])
+
+            for path in sorted(intent_dir.glob("*.yaml")):
+                if path.stem in combo_names:
+                    continue
+
+                errors.append(
+                    f"{path.relative_to(ROOT)}: no slot combination named "
+                    f"'{path.stem}' is declared for {intent_name} in intents.yaml, "
+                    f"so this file is never loaded (rename it to a declared "
+                    f"combination, declare the combination, or delete it)"
                 )
 
 

--- a/tests/ca/HassStartTimer/command_hours.yaml
+++ b/tests/ca/HassStartTimer/command_hours.yaml
@@ -1,5 +1,5 @@
 ---
-# HassStartTimer - command_hours_only
+# HassStartTimer - command_hours
 
 language: ca
 tests:

--- a/tests/ca/HassStartTimer/command_minutes.yaml
+++ b/tests/ca/HassStartTimer/command_minutes.yaml
@@ -1,5 +1,5 @@
 ---
-# HassStartTimer - command_minutes_only
+# HassStartTimer - command_minutes
 
 language: ca
 tests:

--- a/tests/ca/HassStartTimer/command_seconds.yaml
+++ b/tests/ca/HassStartTimer/command_seconds.yaml
@@ -1,5 +1,5 @@
 ---
-# HassStartTimer - command_seconds_only
+# HassStartTimer - command_seconds
 
 language: ca
 tests:

--- a/tests/ca/HassStartTimer/name_hours.yaml
+++ b/tests/ca/HassStartTimer/name_hours.yaml
@@ -1,5 +1,5 @@
 ---
-# HassStartTimer - name_hours_only
+# HassStartTimer - name_hours
 
 language: ca
 tests:

--- a/tests/ca/HassStartTimer/name_minutes.yaml
+++ b/tests/ca/HassStartTimer/name_minutes.yaml
@@ -1,5 +1,5 @@
 ---
-# HassStartTimer - name_minutes_only
+# HassStartTimer - name_minutes
 
 language: ca
 tests:

--- a/tests/ca/HassStartTimer/name_seconds.yaml
+++ b/tests/ca/HassStartTimer/name_seconds.yaml
@@ -1,5 +1,5 @@
 ---
-# HassStartTimer - name_seconds_only
+# HassStartTimer - name_seconds
 
 language: ca
 tests:

--- a/tests/test_validate_undeclared_files.py
+++ b/tests/test_validate_undeclared_files.py
@@ -10,7 +10,7 @@ import yaml
 # (the package has no ``script/__init__.py``), tripping "source file found twice".
 validate: Any = importlib.import_module("script.intentfest.validate")
 
-INTENT_SCHEMAS = {
+INTENT_SCHEMAS: dict[str, Any] = {
     "HassTurnOn": {"slot_combinations": {"name_only": {}, "area_domain": {}}},
     "HassStartTimer": {"slot_combinations": {"name_hours": {}}},
 }

--- a/tests/test_validate_undeclared_files.py
+++ b/tests/test_validate_undeclared_files.py
@@ -1,0 +1,109 @@
+"""Tests for validate.validate_undeclared_files (files no combination points at)."""
+
+import importlib
+from typing import Any
+
+import yaml
+
+# Loaded dynamically: a static ``from script.intentfest...`` import would make
+# mypy resolve the module under both ``intentfest.*`` and ``script.intentfest.*``
+# (the package has no ``script/__init__.py``), tripping "source file found twice".
+validate: Any = importlib.import_module("script.intentfest.validate")
+
+INTENT_SCHEMAS = {
+    "HassTurnOn": {"slot_combinations": {"name_only": {}, "area_domain": {}}},
+    "HassStartTimer": {"slot_combinations": {"name_hours": {}}},
+}
+
+
+def _write(top_dir, language, intent, stem, doc=None):
+    intent_dir = top_dir / language / intent
+    intent_dir.mkdir(parents=True, exist_ok=True)
+    (intent_dir / f"{stem}.yaml").write_text(
+        yaml.safe_dump(doc or {"language": language}, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _validate(tmp_path, monkeypatch, language="xx"):
+    monkeypatch.setattr(validate, "SENTENCE_DIR", tmp_path / "sentences")
+    monkeypatch.setattr(validate, "TESTS_DIR", tmp_path / "tests")
+    monkeypatch.setattr(validate, "ROOT", tmp_path)
+    errors: list[str] = []
+    validate.validate_undeclared_files(INTENT_SCHEMAS, language, errors)
+    return errors
+
+
+def test_declared_files_no_errors(tmp_path, monkeypatch):
+    """Files named after a declared combination produce no errors."""
+    _write(tmp_path / "sentences", "xx", "HassTurnOn", "name_only")
+    _write(tmp_path / "sentences", "xx", "HassTurnOn", "area_domain")
+    _write(tmp_path / "tests", "xx", "HassTurnOn", "name_only")
+
+    assert not _validate(tmp_path, monkeypatch)
+
+
+def test_undeclared_sentence_file_errors(tmp_path, monkeypatch):
+    """A sentence file no combination points at is reported."""
+    _write(tmp_path / "sentences", "xx", "HassTurnOn", "name_only")
+    _write(tmp_path / "sentences", "xx", "HassTurnOn", "hours_seconds")
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 1
+    assert "sentences/xx/HassTurnOn/hours_seconds.yaml" in errors[0]
+    assert "HassTurnOn" in errors[0]
+
+
+def test_undeclared_test_file_errors(tmp_path, monkeypatch):
+    """A test file no combination points at is reported.
+
+    This is the case that was live in the repo: tests/ca/HassStartTimer held six
+    ``*_only``-suffixed files whose combinations are named without the suffix, so
+    the test harness never generated a case for them and the matching sentence
+    files went untested.
+    """
+    _write(tmp_path / "tests", "xx", "HassStartTimer", "name_hours_only")
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 1
+    assert "tests/xx/HassStartTimer/name_hours_only.yaml" in errors[0]
+
+
+def test_unknown_intent_dir_reported_once(tmp_path, monkeypatch):
+    """An intent directory not in intents.yaml is one error, not one per file."""
+    _write(tmp_path / "sentences", "xx", "HassNotAnIntent", "name_only")
+    _write(tmp_path / "sentences", "xx", "HassNotAnIntent", "area_domain")
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 1
+    assert "sentences/xx/HassNotAnIntent/" in errors[0]
+    assert "not an intent defined in intents.yaml" in errors[0]
+
+
+def test_both_trees_are_walked(tmp_path, monkeypatch):
+    """An undeclared file in each of sentences/ and tests/ is reported."""
+    _write(tmp_path / "sentences", "xx", "HassTurnOn", "bogus")
+    _write(tmp_path / "tests", "xx", "HassTurnOn", "bogus")
+
+    errors = _validate(tmp_path, monkeypatch)
+
+    assert len(errors) == 2
+    assert any(error.startswith("sentences/") for error in errors)
+    assert any(error.startswith("tests/") for error in errors)
+
+
+def test_top_level_files_are_ignored(tmp_path, monkeypatch):
+    """Language-level files such as _common.yaml are not combination files."""
+    language_dir = tmp_path / "sentences" / "xx"
+    language_dir.mkdir(parents=True, exist_ok=True)
+    (language_dir / "_common.yaml").write_text("language: xx\n", encoding="utf-8")
+
+    assert not _validate(tmp_path, monkeypatch)
+
+
+def test_missing_language_dir_is_noop(tmp_path, monkeypatch):
+    """A language with no sentence or test directory produces no errors."""
+    assert not _validate(tmp_path, monkeypatch, language="zz")


### PR DESCRIPTION
Flags any file under `sentences/<lang>/<Intent>/` or `tests/<lang>/<Intent>/` whose name is not a declared slot combination of that intent. Runs for all 65 languages.

### Why

Almost everything in this repo reaches a file by enumerating the slot combinations declared in `intents.yaml` — `validate_slot_combinations`, `tests/test_slot_combinations.py` (`gen_tests`), `check_overmatch`, and `load_intents_dict` (which feeds `merged_output`) all work that way. A file whose name is not a declared combination of its intent is therefore opened by nothing: not validated, not tested, and not shipped.

The silence is the problem. The file looks exactly like one that works, so a contributor edits it and reasonably believes the change took effect. Meanwhile the content accumulates errors nobody sees, until someone declares the combination and it all goes live at once. That is the #4102 / #4104 sequence: six undeclared `ru` files had collected three dangling references, and declaring the combinations is what would have activated them.

Naming the files is what keeps the two views — what is on disk, and what `intents.yaml` declares — from drifting apart again. #4103 makes undeclared files' *contents* validate; this stops them existing.

### It found six live violations

`tests/ca/HassStartTimer/` held six files named `command_hours_only.yaml`, `name_hours_only.yaml`, … but the declared combinations have no `_only` suffix (`command_hours`, `name_hours`, …). So the harness generated no case for them, and — because `test_slot_combinations.py` returns early when a test file is absent unless the combination is `importance: required` — the six matching *sentence* files were never verified either, silently.

Renamed to the declared names. **All 21 `ca` `HassStartTimer` tests pass**, so those sentences were correct the whole time; they just had nothing checking them. Six of the repo's untested-but-shipped sentence files are now tested.

### The check

- Walks both `sentences/` and `tests/`, since the live violations were in `tests/`.
- An intent *directory* not in `intents.yaml` is one error for the directory rather than one per file inside it.
- Top-level language files (`_common.yaml`) are untouched — only files inside intent directories are combination files.
- Ungated by `SLOT_COMBO_VALIDATION_LANGUAGES`: the languages that allow-list excludes are exactly the ones most likely to drift, and the check passes for all 65 today.

Errors look like:

```
tests/ca/HassStartTimer/name_hours_only.yaml: no slot combination named 'name_hours_only' is declared for HassStartTimer in intents.yaml, so this file is never loaded (rename it to a declared combination, declare the combination, or delete it)
sentences/en/HassNotReal/: directory is not an intent defined in intents.yaml
```

### Verification

- `python -m script.intentfest validate` (all 65 languages): 0 errors after the rename; the six violations above before it.
- Both violation shapes confirmed to fail validation when injected (a misnamed combo file, and an unknown intent directory), and to clear when removed.
- 7 new unit tests in `tests/test_validate_undeclared_files.py`, including the `tests/`-tree case and the report-once-per-unknown-directory behavior.
- Full suite: 14,231 passed (the count is unchanged by the rename — those six generated cases already existed and were passing vacuously via the early return; they now actually assert).
- `black` / `isort` / `flake8` / `pylint` (10.00/10) clean.

### Still open

Of the 17 declared-and-shipped sentence files with no test file at all, 6 are fixed here. The remaining 11 (`ca` 7, `cs` 2, `ro` 2) have no test file under any name, so this check cannot see them — `validate`'s existing "Missing test file" check would, but it does not run for those languages. Ungating that one needs a decision on error vs. warning, since it would block until those tests are written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
