### PR TITLE
[pt-br] Fix other timer intents regression

### DIFF
--- a/sentences/pt-BR/HassCancelAllTimers/area_only.yaml
+++ b/sentences/pt-BR/HassCancelAllTimers/area_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [todos ][os |meus |os meus ]temporizadores (em|na|no|da|do) {area}"
+      - "(cancela[r]|elimina[r]|aborta[r]) [todos ][os |meus |os meus ](alarmes|cronômetros|timers|temporizadores) (em|na|no|da|do) {area}"
     example: "cancelar todos os temporizadores da cozinha"
     response: "area"

--- a/sentences/pt-BR/HassCancelAllTimers/default.yaml
+++ b/sentences/pt-BR/HassCancelAllTimers/default.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [todos ][os |meus |os meus ]temporizadores"
+      - "(cancela[r]|elimina[r]|aborta[r]) [todos ][os |meus |os meus ](alarmes|cronômetros|timers|temporizadores)"
     example: "cancelar todos os temporizadores"
     response: "default"

--- a/sentences/pt-BR/HassCancelTimer/area_only.yaml
+++ b/sentences/pt-BR/HassCancelTimer/area_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]temporizador (em|na|no|da|do) {area}"
+      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]<timer> (em|na|no|da|do) {area}"
     example: "cancelar o temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassCancelTimer/default.yaml
+++ b/sentences/pt-BR/HassCancelTimer/default.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]temporizador"
+      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]<timer>"
     example: "cancelar o temporizador"
     response: "default"

--- a/sentences/pt-BR/HassCancelTimer/hours_only.yaml
+++ b/sentences/pt-BR/HassCancelTimer/hours_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]temporizador (de|para) <nb_start_hours> hora[s]"
+      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]<timer> (de|para) <nb_start_hours> hora[s]"
     example: "cancelar o temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassCancelTimer/minutes_only.yaml
+++ b/sentences/pt-BR/HassCancelTimer/minutes_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]temporizador (de|para) <nb_start_minutes> minuto[s]"
+      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]<timer> (de|para) <nb_start_minutes> minuto[s]"
     example: "cancelar o temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassCancelTimer/name_only.yaml
+++ b/sentences/pt-BR/HassCancelTimer/name_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]temporizador {timer_name:name}"
+      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]<timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]<timer> {timer_name:name}"
     example: "cancelar o temporizador pizza"
     response: "default"

--- a/sentences/pt-BR/HassCancelTimer/seconds_only.yaml
+++ b/sentences/pt-BR/HassCancelTimer/seconds_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]temporizador (de|para) <nb_start_seconds> segundo[s]"
+      - "(cancela[r]|elimina[r]|aborta[r]) [o |a ][meu |minha ]<timer> (de|para) <nb_start_seconds> segundo[s]"
     example: "cancelar o temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/area_hours.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/area_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area} [em ]<nb_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area} [em ]<nb_hours> hora[s]"
     example: "remover 1 hora ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/area_hours_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/area_hours_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area} [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area} [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
     example: "remover 1 hora e 5 minutos ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/area_hours_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/area_hours_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area} [em ]<nb_hours> hora[s] [e ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area} [em ]<nb_hours> hora[s] [e ]<nb_seconds> segundo[s]"
     example: "remover 1 hora e 30 segundos ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/area_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/area_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area} [em ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area} [em ]<nb_minutes> minuto[s]"
     example: "remover 5 minutos ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/area_minutes_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/area_minutes_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area} [em ]<nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area} [em ]<nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s]"
     example: "remover 5 minutos e 30 segundos ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/area_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/area_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (em|na|no|da|do) {area} [em ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (em|na|no|da|do) {area} [em ]<nb_seconds> segundo[s]"
     example: "remover 30 segundos ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/hours_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/hours_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer>"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
     example: "remover 1 hora e 5 minutos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/hours_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) temporizador"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador [em ]<nb_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) <timer>"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> [em ]<nb_hours> hora[s]"
     example: "remover 1 hora ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/hours_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/hours_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador [em ]<nb_hours> hora[s] [e ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer>"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> [em ]<nb_hours> hora[s] [e ]<nb_seconds> segundo[s]"
     example: "remover 1 hora e 30 segundos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/hours_start_hours.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/hours_start_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_hours> hora[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_hours> hora[s] [em ]<nb_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_hours> hora[s] [em ]<nb_hours> hora[s]"
     example: "remover 1 hora ao temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/hours_start_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/hours_start_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_minutes> minuto[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_minutes> minuto[s] [em ]<nb_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_minutes> minuto[s] [em ]<nb_hours> hora[s]"
     example: "remover 1 hora ao temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/hours_start_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/hours_start_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_seconds> segundo[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_seconds> segundo[s] [em ]<nb_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_seconds> segundo[s] [em ]<nb_hours> hora[s]"
     example: "remover 1 hora ao temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/minutes_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador [em ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer>"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> [em ]<nb_minutes> minuto[s]"
     example: "remover 5 minutos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/minutes_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/minutes_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador [em ]<nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer>"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> [em ]<nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s]"
     example: "remover 5 minutos e 30 segundos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/minutes_start_hours.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/minutes_start_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_hours> hora[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_hours> hora[s] [em ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_hours> hora[s] [em ]<nb_minutes> minuto[s]"
     example: "remover 5 minutos ao temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/minutes_start_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/minutes_start_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_minutes> minuto[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_minutes> minuto[s] [em ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_minutes> minuto[s] [em ]<nb_minutes> minuto[s]"
     example: "remover 5 minutos ao temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/minutes_start_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/minutes_start_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_seconds> segundo[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_seconds> segundo[s] [em ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_seconds> segundo[s] [em ]<nb_minutes> minuto[s]"
     example: "remover 5 minutos ao temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/name_hours.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/name_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador {timer_name:name} [em ]<nb_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] (do|ao|do meu|ao meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> {timer_name:name} [em ]<nb_hours> hora[s]"
     example: "remover 1 hora ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/name_hours_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/name_hours_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador {timer_name:name} [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> {timer_name:name} [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
     example: "remover 1 hora e 5 minutos ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/name_hours_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/name_hours_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador {timer_name:name} [em ]<nb_hours> hora[s] [e ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_hours> hora[s] [e ]<nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> {timer_name:name} [em ]<nb_hours> hora[s] [e ]<nb_seconds> segundo[s]"
     example: "remover 1 hora e 30 segundos ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/name_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/name_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador {timer_name:name} [em ]<nb_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_minutes> minuto[s] (do|ao|do meu|ao meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> {timer_name:name} [em ]<nb_minutes> minuto[s]"
     example: "remover 5 minutos ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/name_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/name_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador {timer_name:name} [em ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> {timer_name:name} [em ]<nb_seconds> segundo[s]"
     example: "remover 30 segundos ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/seconds_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador [em ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer>"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> [em ]<nb_seconds> segundo[s]"
     example: "remover 30 segundos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/seconds_start_hours.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/seconds_start_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_hours> hora[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_hours> hora[s] [em ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_hours> hora[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_hours> hora[s] [em ]<nb_seconds> segundo[s]"
     example: "remover 30 segundos ao temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/seconds_start_minutes.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/seconds_start_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_minutes> minuto[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_minutes> minuto[s] [em ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_minutes> minuto[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_minutes> minuto[s] [em ]<nb_seconds> segundo[s]"
     example: "remover 30 segundos ao temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassDecreaseTimer/seconds_start_seconds.yaml
+++ b/sentences/pt-BR/HassDecreaseTimer/seconds_start_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_seconds> segundo[s]"
-      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) temporizador (de|para) <nb_start_seconds> segundo[s] [em ]<nb_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) <nb_seconds> segundo[s] (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_seconds> segundo[s]"
+      - "(reduz[ir]|remove[r]|retira[r]|tira[r]) (do|ao|do meu|ao meu) <timer> (de|para) <nb_start_seconds> segundo[s] [em ]<nb_seconds> segundo[s]"
     example: "remover 30 segundos ao temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/area_hours.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/area_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) temporizador (em|na|no|da|do) {area}"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (em|na|no|da|do) {area} [em ]<nb_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) <timer> (em|na|no|da|do) {area}"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (em|na|no|da|do) {area} [em ]<nb_hours> hora[s]"
     example: "adicionar 1 hora ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/area_minutes.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/area_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) temporizador (em|na|no|da|do) {area}"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (em|na|no|da|do) {area} [em ]<nb_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) <timer> (em|na|no|da|do) {area}"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (em|na|no|da|do) {area} [em ]<nb_minutes> minuto[s]"
     example: "adicionar 5 minutos ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/area_seconds.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/area_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) temporizador (em|na|no|da|do) {area}"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (em|na|no|da|do) {area} [em ]<nb_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) <timer> (em|na|no|da|do) {area}"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (em|na|no|da|do) {area} [em ]<nb_seconds> segundo[s]"
     example: "adicionar 30 segundos ao temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/hours_minutes.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/hours_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (ao|no|ao meu|no meu) temporizador"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] [e ]<nb_minutes> minuto[s] (ao|no|ao meu|no meu) <timer>"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> [em ]<nb_hours> hora[s] [e ]<nb_minutes> minuto[s]"
     example: "adicionar 1 hora e 5 minutos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/hours_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) temporizador"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador [em ]<nb_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) <timer>"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> [em ]<nb_hours> hora[s]"
     example: "adicionar 1 hora ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/hours_start_hours.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/hours_start_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_hours> hora[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_hours> hora[s] [em ]<nb_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_hours> hora[s] [em ]<nb_hours> hora[s]"
     example: "adicionar 1 hora ao temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/hours_start_minutes.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/hours_start_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_minutes> minuto[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_minutes> minuto[s] [em ]<nb_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_minutes> minuto[s] [em ]<nb_hours> hora[s]"
     example: "adicionar 1 hora ao temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/hours_start_seconds.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/hours_start_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_seconds> segundo[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_seconds> segundo[s] [em ]<nb_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_seconds> segundo[s] [em ]<nb_hours> hora[s]"
     example: "adicionar 1 hora ao temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/minutes_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) temporizador"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador [em ]<nb_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) <timer>"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> [em ]<nb_minutes> minuto[s]"
     example: "adicionar 5 minutos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/minutes_seconds.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/minutes_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s] (ao|no|ao meu|no meu) temporizador"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador [em ]<nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s] (ao|no|ao meu|no meu) <timer>"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> [em ]<nb_minutes> minuto[s] [e ]<nb_seconds> segundo[s]"
     example: "adicionar 5 minutos e 30 segundos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/minutes_start_hours.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/minutes_start_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_hours> hora[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_hours> hora[s] [em ]<nb_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_hours> hora[s] [em ]<nb_minutes> minuto[s]"
     example: "adicionar 5 minutos ao temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/minutes_start_minutes.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/minutes_start_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_minutes> minuto[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_minutes> minuto[s] [em ]<nb_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_minutes> minuto[s] [em ]<nb_minutes> minuto[s]"
     example: "adicionar 5 minutos ao temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/minutes_start_seconds.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/minutes_start_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_seconds> segundo[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_seconds> segundo[s] [em ]<nb_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_seconds> segundo[s] [em ]<nb_minutes> minuto[s]"
     example: "adicionar 5 minutos ao temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/name_hours.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/name_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador {timer_name:name} [em ]<nb_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_hours> hora[s] (ao|no|ao meu|no meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> {timer_name:name} [em ]<nb_hours> hora[s]"
     example: "adicionar 1 hora ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/name_minutes.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/name_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador {timer_name:name} [em ]<nb_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_minutes> minuto[s] (ao|no|ao meu|no meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> {timer_name:name} [em ]<nb_minutes> minuto[s]"
     example: "adicionar 5 minutos ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/name_seconds.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/name_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador {timer_name:name} [em ]<nb_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) <timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> {timer_name:name} [em ]<nb_seconds> segundo[s]"
     example: "adicionar 30 segundos ao temporizador chamado pizza"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/seconds_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) temporizador"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador [em ]<nb_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) <timer>"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> [em ]<nb_seconds> segundo[s]"
     example: "adicionar 30 segundos ao temporizador"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/seconds_start_hours.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/seconds_start_hours.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_hours> hora[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_hours> hora[s] [em ]<nb_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_hours> hora[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_hours> hora[s] [em ]<nb_seconds> segundo[s]"
     example: "adicionar 30 segundos ao temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/seconds_start_minutes.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/seconds_start_minutes.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_minutes> minuto[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_minutes> minuto[s] [em ]<nb_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_minutes> minuto[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_minutes> minuto[s] [em ]<nb_seconds> segundo[s]"
     example: "adicionar 30 segundos ao temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassIncreaseTimer/seconds_start_seconds.yaml
+++ b/sentences/pt-BR/HassIncreaseTimer/seconds_start_seconds.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_seconds> segundo[s]"
-      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) temporizador (de|para) <nb_start_seconds> segundo[s] [em ]<nb_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) <nb_seconds> segundo[s] (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_seconds> segundo[s]"
+      - "(aumenta[r]|adiciona[r]|acrescenta[r]|junta[r]) (ao|no|ao meu|no meu) <timer> (de|para) <nb_start_seconds> segundo[s] [em ]<nb_seconds> segundo[s]"
     example: "adicionar 30 segundos ao temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassPauseTimer/area_only.yaml
+++ b/sentences/pt-BR/HassPauseTimer/area_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]temporizador (em|na|no|da|do) {area}"
+      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]<timer> (em|na|no|da|do) {area}"
     example: "pausar o temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassPauseTimer/default.yaml
+++ b/sentences/pt-BR/HassPauseTimer/default.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]temporizador"
+      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]<timer>"
     example: "pausar o temporizador"
     response: "default"

--- a/sentences/pt-BR/HassPauseTimer/hours_only.yaml
+++ b/sentences/pt-BR/HassPauseTimer/hours_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]temporizador (de|para) <nb_start_hours> hora[s]"
+      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]<timer> (de|para) <nb_start_hours> hora[s]"
     example: "pausar o temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassPauseTimer/minutes_only.yaml
+++ b/sentences/pt-BR/HassPauseTimer/minutes_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]temporizador (de|para) <nb_start_minutes> minuto[s]"
+      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]<timer> (de|para) <nb_start_minutes> minuto[s]"
     example: "pausar o temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassPauseTimer/name_only.yaml
+++ b/sentences/pt-BR/HassPauseTimer/name_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]temporizador {timer_name:name}"
+      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]<timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]<timer> {timer_name:name}"
     example: "pausar o temporizador pizza"
     response: "default"

--- a/sentences/pt-BR/HassPauseTimer/seconds_only.yaml
+++ b/sentences/pt-BR/HassPauseTimer/seconds_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]temporizador (de|para) <nb_start_seconds> segundo[s]"
+      - "(pausa[r]|para[r]|suspende[r]) [o |a ][meu |minha ]<timer> (de|para) <nb_start_seconds> segundo[s]"
     example: "pausar o temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassTimerStatus/area_only.yaml
+++ b/sentences/pt-BR/HassTimerStatus/area_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]temporizador (em|na|no|da|do) {area}"
-      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]temporizador (em|na|no|da|do) {area}"
+      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]<timer> (em|na|no|da|do) {area}"
+      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]<timer> (em|na|no|da|do) {area}"
     example: "qual o estado do temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassTimerStatus/default.yaml
+++ b/sentences/pt-BR/HassTimerStatus/default.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [meus |os |os meus ]temporizadores"
-      - "quanto tempo (falta|resta) (nos|para os) [meus |os |os meus ]temporizadores"
+      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [meus |os |os meus ]<timer>"
+      - "quanto tempo (falta|resta) (nos|para os) [meus |os |os meus ]<timer>"
     example: "qual o estado dos temporizadores"
     response: "default"

--- a/sentences/pt-BR/HassTimerStatus/hours_only.yaml
+++ b/sentences/pt-BR/HassTimerStatus/hours_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]temporizador (de|para) <nb_start_hours> hora[s]"
-      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]temporizador (de|para) <nb_start_hours> hora[s]"
+      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]<timer> (de|para) <nb_start_hours> hora[s]"
+      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]<timer> (de|para) <nb_start_hours> hora[s]"
     example: "qual o estado do temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassTimerStatus/minutes_only.yaml
+++ b/sentences/pt-BR/HassTimerStatus/minutes_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]temporizador (de|para) <nb_start_minutes> minuto[s]"
-      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]temporizador (de|para) <nb_start_minutes> minuto[s]"
+      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]<timer> (de|para) <nb_start_minutes> minuto[s]"
+      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]<timer> (de|para) <nb_start_minutes> minuto[s]"
     example: "qual o estado do temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassTimerStatus/name_only.yaml
+++ b/sentences/pt-BR/HassTimerStatus/name_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]<timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]<timer> (chamado|com o nome|de nome|de) {timer_name:name}"
     example: "qual o estado do temporizador pizza"
     response: "default"

--- a/sentences/pt-BR/HassTimerStatus/seconds_only.yaml
+++ b/sentences/pt-BR/HassTimerStatus/seconds_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]temporizador (de|para) <nb_start_seconds> segundo[s]"
-      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]temporizador (de|para) <nb_start_seconds> segundo[s]"
+      - "[(qual|que) [é] ][o |a ](estado d|tempo restante n)(o|os) [o |a ][meu |minha ]<timer> (de|para) <nb_start_seconds> segundo[s]"
+      - "quanto tempo (falta|resta) (no|para o) [o |a ][meu |minha ]<timer> (de|para) <nb_start_seconds> segundo[s]"
     example: "qual o estado do temporizador de 30 segundos"
     response: "default"

--- a/sentences/pt-BR/HassUnpauseTimer/area_only.yaml
+++ b/sentences/pt-BR/HassUnpauseTimer/area_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]temporizador (em|na|no|da|do) {area}"
+      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]<timer> (em|na|no|da|do) {area}"
     example: "continuar o temporizador da cozinha"
     response: "default"

--- a/sentences/pt-BR/HassUnpauseTimer/default.yaml
+++ b/sentences/pt-BR/HassUnpauseTimer/default.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]temporizador"
+      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]<timer>"
     example: "continuar o temporizador"
     response: "default"

--- a/sentences/pt-BR/HassUnpauseTimer/hours_only.yaml
+++ b/sentences/pt-BR/HassUnpauseTimer/hours_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]temporizador (de|para) <nb_start_hours> hora[s]"
+      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]<timer> (de|para) <nb_start_hours> hora[s]"
     example: "continuar o temporizador de 1 hora"
     response: "default"

--- a/sentences/pt-BR/HassUnpauseTimer/minutes_only.yaml
+++ b/sentences/pt-BR/HassUnpauseTimer/minutes_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]temporizador (de|para) <nb_start_minutes> minuto[s]"
+      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]<timer> (de|para) <nb_start_minutes> minuto[s]"
     example: "continuar o temporizador de 5 minutos"
     response: "default"

--- a/sentences/pt-BR/HassUnpauseTimer/name_only.yaml
+++ b/sentences/pt-BR/HassUnpauseTimer/name_only.yaml
@@ -2,7 +2,7 @@
 language: pt-BR
 data:
   - sentences:
-      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]temporizador (chamado|com o nome|de nome|de) {timer_name:name}"
-      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]temporizador {timer_name:name}"
+      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]<timer> (chamado|com o nome|de nome|de) {timer_name:name}"
+      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]<timer> {timer_name:name}"
     example: "continuar o temporizador pizza"
     response: "default"

--- a/sentences/pt-BR/HassUnpauseTimer/seconds_only.yaml
+++ b/sentences/pt-BR/HassUnpauseTimer/seconds_only.yaml
@@ -2,6 +2,6 @@
 language: pt-BR
 data:
   - sentences:
-      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]temporizador (de|para) <nb_start_seconds> segundo[s]"
+      - "(continua[r]|retoma[r]|prossegue|prosseguir) [o |a ][meu |minha ]<timer> (de|para) <nb_start_seconds> segundo[s]"
     example: "continuar o temporizador de 30 segundos"
     response: "default"

--- a/tests/pt-BR/HassCancelAllTimers/default.yaml
+++ b/tests/pt-BR/HassCancelAllTimers/default.yaml
@@ -24,3 +24,8 @@ tests:
       - "cancela todos os temporizadores"
       - "elimina os meus temporizadores"
     response: "3 temporizadores foram cancelados."
+  - sentences:
+      - "cancela todos os alarmes"
+      - "cancela todos os cronômetros"
+      - "cancela todos os timers"
+    response: "3 temporizadores foram cancelados."

--- a/tests/pt-BR/HassCancelTimer/default.yaml
+++ b/tests/pt-BR/HassCancelTimer/default.yaml
@@ -14,3 +14,8 @@ tests:
       - "cancela o temporizador"
       - "elimina o meu temporizador"
     response: "Cancelado"
+  - sentences:
+      - "cancela o alarme"
+      - "cancela o cronômetro"
+      - "cancela o timer"
+    response: "Cancelado"

--- a/tests/pt-BR/HassDecreaseTimer/minutes_only.yaml
+++ b/tests/pt-BR/HassDecreaseTimer/minutes_only.yaml
@@ -16,3 +16,10 @@ tests:
     slots:
       minutes: 5
     response: "Tempo reduzido"
+  - sentences:
+      - "remove 5 minutos do alarme"
+      - "remove 5 minutos do cronômetro"
+      - "remove 5 minutos do timer"
+    slots:
+      minutes: 5
+    response: "Tempo reduzido"

--- a/tests/pt-BR/HassIncreaseTimer/minutes_only.yaml
+++ b/tests/pt-BR/HassIncreaseTimer/minutes_only.yaml
@@ -16,3 +16,10 @@ tests:
     slots:
       minutes: 5
     response: "Tempo adicionado"
+  - sentences:
+      - "adiciona 5 minutos ao alarme"
+      - "adiciona 5 minutos ao cronômetro"
+      - "adiciona 5 minutos ao timer"
+    slots:
+      minutes: 5
+    response: "Tempo adicionado"

--- a/tests/pt-BR/HassPauseTimer/default.yaml
+++ b/tests/pt-BR/HassPauseTimer/default.yaml
@@ -14,3 +14,8 @@ tests:
       - "pausa o temporizador"
       - "para o meu temporizador"
     response: "Temporizador pausado"
+  - sentences:
+      - "pausa o alarme"
+      - "pausa o cronômetro"
+      - "pausa o timer"
+    response: "Temporizador pausado"

--- a/tests/pt-BR/HassTimerStatus/default.yaml
+++ b/tests/pt-BR/HassTimerStatus/default.yaml
@@ -14,3 +14,8 @@ tests:
       - "qual o estado dos temporizadores"
       - "quanto tempo falta nos temporizadores"
     response: "Restam 3 minutos."
+  - sentences:
+      - "qual o estado dos alarmes"
+      - "qual o estado dos cronômetros"
+      - "qual o estado dos timers"
+    response: "Restam 3 minutos."

--- a/tests/pt-BR/HassUnpauseTimer/default.yaml
+++ b/tests/pt-BR/HassUnpauseTimer/default.yaml
@@ -14,3 +14,8 @@ tests:
       - "continua o temporizador"
       - "retoma o meu temporizador"
     response: "Temporizador retomado"
+  - sentences:
+      - "continua o alarme"
+      - "continua o cronômetro"
+      - "continua o timer"
+    response: "Temporizador retomado"


### PR DESCRIPTION
Continuation of https://github.com/OHF-Voice/intents/pull/4111 fixing regressions introduced by https://github.com/OHF-Voice/intents/pull/3951

Fixes:

- HassCancelAllTimers
- HassCancelTimer
- HassDecreaseTimer
- HassIncreaseTimer
- HassPauseTimer
- HassUnpauseTimer
- HassTimerStatus

Closes #4112 