### PR TITLE
[ES] Add climate support to HassTurnOff

### DIFF
--- a/sentences/es/HassTurnOff/name_area.yaml
+++ b/sentences/es/HassTurnOff/name_area.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<apaga> [el|la|los|las] {name} [[en|de] [el|la]|del] {area}"
     example: "apaga la luz de techo de la cocina"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luces/lámparas" word

--- a/sentences/es/HassTurnOff/name_floor.yaml
+++ b/sentences/es/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<apaga> [el|la|los|las] {name} ([[en|de] [el|la]|del] [planta|piso] {floor}|[[en|de] [el|la]|del] {floor} [planta|piso])"
     example: "apaga la luz de techo de la planta baja"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luces/lámparas" word

--- a/sentences/es/HassTurnOff/name_only.yaml
+++ b/sentences/es/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<apaga> [el|la|los|las] {name}"
     example: "apaga la lámpara de la mesilla"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luces/lámparas" word

--- a/tests/es/HassTurnOff/name_area.yaml
+++ b/tests/es/HassTurnOff/name_area.yaml
@@ -7,6 +7,8 @@ entities:
     domain: light
   - name: Rincón de juego
     domain: light
+  - name: Aire acondicionado
+    domain: climate
   - name: Cortina izquierda
     domain: cover
   - name: Llave de paso
@@ -33,6 +35,14 @@ tests:
       name: Rincón de juego
       area: Cocina
     response: Se ha apagado la luz
+
+  # climate
+  - sentences:
+      - apaga el aire acondicionado del salón
+    slots:
+      name: Aire acondicionado
+      area: Salón
+    response: Se ha apagado el termostato
 
   # covers
   - sentences:

--- a/tests/es/HassTurnOff/name_floor.yaml
+++ b/tests/es/HassTurnOff/name_floor.yaml
@@ -7,6 +7,8 @@ entities:
     domain: light
   - name: Rincón de juego
     domain: light
+  - name: Aire acondicionado
+    domain: climate
   - name: Puerta corredera
     domain: cover
   - name: Llave de paso
@@ -30,6 +32,14 @@ tests:
       name: Rincón de juego
       floor: Planta baja
     response: Se ha apagado la luz
+
+  # climate
+  - sentences:
+      - apaga el aire acondicionado de la planta baja
+    slots:
+      name: Aire acondicionado
+      floor: Planta baja
+    response: Se ha apagado el termostato
 
   # covers
   - sentences:

--- a/tests/es/HassTurnOff/name_only.yaml
+++ b/tests/es/HassTurnOff/name_only.yaml
@@ -9,6 +9,8 @@ entities:
     domain: light
   - name: Ventilador de techo
     domain: fan
+  - name: Aire acondicionado
+    domain: climate
   - name: Cortina izquierda
     domain: cover
   - name: Llave de paso
@@ -40,6 +42,13 @@ tests:
     slots:
       name: Ventilador de techo
     response: Se ha apagado el ventilador
+
+  # climate
+  - sentences:
+      - apaga el aire acondicionado
+    slots:
+      name: Aire acondicionado
+    response: Se ha apagado el termostato
 
   # covers
   - sentences:


### PR DESCRIPTION
## Summary

Fix Spanish `HassTurnOff` sentences so climate entities can be targeted by
name.

For example, given:

- A climate entity named `Aire acondicionado`
- An area named `Salón`

The following sentence fails to resolve the climate entity as a target:

> Apaga el aire acondicionado del salón

The sentence structure is already supported by the Spanish `name_area`
template. However, its explicit `name_domains` list excludes the `climate`
domain, preventing `{name}` from matching the climate entity.

The equivalent English `HassTurnOff` sentence works because its generic
name-based sentence group uses `name_domains: "default"`. The shared `default`
group includes `climate`.

This change makes the Spanish generic `name_only`, `name_area`, and
`name_floor` groups use the same shared `default` group. This fixes the
area-based failure and keeps all three name-based targeting combinations
consistent.

## Tests

Added regression coverage for turning off a climate entity:

- By name: `Apaga el aire acondicionado`
- By name and area: `Apaga el aire acondicionado del salón`
- By name and floor: `Apaga el aire acondicionado de la planta baja`

## Validation

- `script/lint`
- `script/test --language es` — 281 passed
