### PR TITLE
[ES] Add climate support to HassTurnOn

### DIFF
--- a/sentences/es/HassTurnOn/name_area.yaml
+++ b/sentences/es/HassTurnOn/name_area.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<enciende> [el|la|los|las] {name} [[en|de] [el|la]|del] {area}"
     example: "enciende la luz de techo de la cocina"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luces/lámparas" word

--- a/sentences/es/HassTurnOn/name_floor.yaml
+++ b/sentences/es/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<enciende> [el|la|los|las] {name} ([[en|de] [el|la]|del] [planta|piso] {floor}|[[en|de] [el|la]|del] {floor} [planta|piso])"
     example: "enciende la luz de techo de la planta baja"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luces/lámparas" word

--- a/sentences/es/HassTurnOn/name_only.yaml
+++ b/sentences/es/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<enciende> [el|la|los|las] {name}"
       - "[el|la|los|las] {name}"
     example: "enciende la lámpara de la mesilla"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luces/lámparas" word

--- a/tests/es/HassTurnOn/name_area.yaml
+++ b/tests/es/HassTurnOn/name_area.yaml
@@ -7,6 +7,8 @@ entities:
     domain: light
   - name: Rincón de juego
     domain: light
+  - name: Aire acondicionado
+    domain: climate
   - name: Cortina izquierda
     domain: cover
   - name: Llave de paso
@@ -33,6 +35,14 @@ tests:
       name: Rincón de juego
       area: Cocina
     response: Se ha activado la luz
+
+  # climate
+  - sentences:
+      - enciende el aire acondicionado del salón
+    slots:
+      name: Aire acondicionado
+      area: Salón
+    response: Se ha activado el termostato
 
   # covers
   - sentences:

--- a/tests/es/HassTurnOn/name_floor.yaml
+++ b/tests/es/HassTurnOn/name_floor.yaml
@@ -7,6 +7,8 @@ entities:
     domain: light
   - name: Rincón de juego
     domain: light
+  - name: Aire acondicionado
+    domain: climate
   - name: Puerta corredera
     domain: cover
   - name: Llave de paso
@@ -30,6 +32,14 @@ tests:
       name: Rincón de juego
       floor: Planta baja
     response: Se ha activado la luz
+
+  # climate
+  - sentences:
+      - enciende el aire acondicionado de la planta baja
+    slots:
+      name: Aire acondicionado
+      floor: Planta baja
+    response: Se ha activado el termostato
 
   # covers
   - sentences:

--- a/tests/es/HassTurnOn/name_only.yaml
+++ b/tests/es/HassTurnOn/name_only.yaml
@@ -9,6 +9,8 @@ entities:
     domain: light
   - name: Ventilador de techo
     domain: fan
+  - name: Aire acondicionado
+    domain: climate
   - name: Cortina izquierda
     domain: cover
   - name: Llave de paso
@@ -44,6 +46,13 @@ tests:
     slots:
       name: Ventilador de techo
     response: Se ha activado el ventilador
+
+  # climate
+  - sentences:
+      - enciende el aire acondicionado
+    slots:
+      name: Aire acondicionado
+    response: Se ha activado el termostato
 
   # covers
   - sentences:


### PR DESCRIPTION
## Summary

Fix Spanish `HassTurnOn` sentences so climate entities can be targeted by
name.

For example, given:

- A climate entity named `Aire acondicionado`
- An area named `Salón`

The following sentence fails to resolve the climate entity as a target:

> Enciende el aire acondicionado del salón

The sentence structure is already supported by the Spanish `name_area`
template. However, its explicit `name_domains` list excludes the `climate`
domain, preventing `{name}` from matching the climate entity.

The equivalent English `HassTurnOn` sentence works because its generic
name-based sentence group uses `name_domains: "default"`. The shared `default`
group includes `climate`.

This change makes the Spanish generic `name_only`, `name_area`, and
`name_floor` groups use the same shared `default` group. This mirrors the
Spanish `HassTurnOff` fix in #4117 and keeps the name-based targeting
combinations consistent.

## Tests

Added regression coverage for turning on a climate entity:

- By name: `Enciende el aire acondicionado`
- By name and area: `Enciende el aire acondicionado del salón`
- By name and floor: `Enciende el aire acondicionado de la planta baja`

Before the sentence-domain change, the three targeted regression tests failed
with `Sentence was not recognized`. After the change, all three pass.

## Validation

- `script/lint`
- `script/test --language es` — 281 passed
- Overmatch audit — 1,082 sentences checked, 0 overmatches, 0 no-matches
