### PR TITLE
[ES] Add missing HassClimateSetTemperature slot combinations

### DIFF
--- a/rules/es/common.yaml
+++ b/rules/es/common.yaml
@@ -25,6 +25,7 @@ expansion_rules:
   establece: (pon[ga|er|é]|estable[z]c(a|e|er|é)|ajust(a|e|ar|á)|configur(a|e|ar|á)|cambi(a[r]|á|e))
   establece_abre_cierra: (<establece>|<abre>|<cierra>)
   establece_sube_baja: (<establece>|<enciende>|<sube>|<baja>)
+  floor: "[([en|de] [el|la]|del)] ([planta|piso] {floor}|{floor} [planta|piso])"
   inicia: (inici(a|e|ar|á)|com[i]en(za|ce|zar|zá)|emp[i]e(za|ce|zar|zá))
   luces: "[el|la|los|las] (luz|luces|lámpara[s]|bombill(a|o)[s]|ampolleta[s]|luminaria[s]|lamparilla[s]|foco[s]|interruptor[es]|llave[s][ de la luz])"
   otra_vez: (otra vez|de nuevo|una vez más)

--- a/sentences/es/HassClimateSetTemperature/floor_temperature.yaml
+++ b/sentences/es/HassClimateSetTemperature/floor_temperature.yaml
@@ -1,0 +1,15 @@
+---
+# HassClimateSetTemperature - floor_temperature
+# example: pon la temperatura de la primera planta a 20 grados
+# slots:
+# - {floor}
+# - {temperature}
+
+language: "es"
+data:
+  - sentences:
+      - "<establece_sube_baja> <temp> [([en|de] [el|la]|del)] [planta|piso] {floor} [planta|piso] a {temperature}[([ ]°)|( grados)]"
+      - "<establece_sube_baja> [([en|de] [el|la]|del)] [planta|piso] {floor} [planta|piso] <temp> a {temperature}[([ ]°)|( grados)]"
+      - "<establece_sube_baja> <temp> a {temperature}[([ ]°)|( grados)] [([en|de] [el|la]|del)] [planta|piso] {floor} [planta|piso]"
+    example: "pon la temperatura de la primera planta a 20 grados"
+    response: "default"

--- a/sentences/es/HassClimateSetTemperature/floor_temperature.yaml
+++ b/sentences/es/HassClimateSetTemperature/floor_temperature.yaml
@@ -8,8 +8,8 @@
 language: "es"
 data:
   - sentences:
-      - "<establece_sube_baja> <temp> [([en|de] [el|la]|del)] [planta|piso] {floor} [planta|piso] a {temperature}[([ ]°)|( grados)]"
-      - "<establece_sube_baja> [([en|de] [el|la]|del)] [planta|piso] {floor} [planta|piso] <temp> a {temperature}[([ ]°)|( grados)]"
-      - "<establece_sube_baja> <temp> a {temperature}[([ ]°)|( grados)] [([en|de] [el|la]|del)] [planta|piso] {floor} [planta|piso]"
+      - "<establece_sube_baja> <temp> <floor> a {temperature}[([ ]°)|( grados)]"
+      - "<establece_sube_baja> <floor> <temp> a {temperature}[([ ]°)|( grados)]"
+      - "<establece_sube_baja> <temp> a {temperature}[([ ]°)|( grados)] <floor>"
     example: "pon la temperatura de la primera planta a 20 grados"
     response: "default"

--- a/sentences/es/HassClimateSetTemperature/name_temperature.yaml
+++ b/sentences/es/HassClimateSetTemperature/name_temperature.yaml
@@ -1,0 +1,16 @@
+---
+# HassClimateSetTemperature - name_temperature
+# example: pon el termostato oficina a 20 grados
+# slots:
+# - {name}
+# - {temperature}
+
+language: "es"
+data:
+  - sentences:
+      - "<establece_sube_baja> <temp> de[l] [el|la|los|las] {name} a {temperature}[([ ]°)|( grados)]"
+      - "<establece_sube_baja> [el|la|los|las] {name} [<temp>] a {temperature}[([ ]°)|( grados)]"
+    example: "pon el termostato oficina a 20 grados"
+    name_domains:
+      - "climate"
+    response: "default"

--- a/tests/es/HassClimateSetTemperature/floor_temperature.yaml
+++ b/tests/es/HassClimateSetTemperature/floor_temperature.yaml
@@ -1,0 +1,16 @@
+---
+# HassClimateSetTemperature - floor_temperature
+
+language: "es"
+floors:
+  - name: "Primera planta"
+
+tests:
+  - sentences:
+      - "pon la temperatura de la primera planta a 20 grados"
+      - "establece en la primera planta la temperatura a 20"
+      - "configura la temperatura a 20° en la primera planta"
+    slots:
+      floor: "Primera planta"
+      temperature: 20
+    response: "Temperatura ajustada"

--- a/tests/es/HassClimateSetTemperature/name_temperature.yaml
+++ b/tests/es/HassClimateSetTemperature/name_temperature.yaml
@@ -1,0 +1,16 @@
+---
+# HassClimateSetTemperature - name_temperature
+
+language: "es"
+entities:
+  - name: "Termostato oficina"
+    domain: "climate"
+
+tests:
+  - sentences:
+      - "pon la temperatura del termostato oficina a 20 grados"
+      - "ajusta el termostato oficina a 20°"
+    slots:
+      name: "Termostato oficina"
+      temperature: 20
+    response: "Temperatura ajustada"


### PR DESCRIPTION
## Summary

Add Spanish sentence support and tests for the two remaining
`HassClimateSetTemperature` slot combinations:

- `name_temperature`, to set the temperature of a climate entity by name,
  for example: "pon la temperatura del termostato oficina a 20 grados"
- `floor_temperature`, to set the temperature on a floor,
  for example: "pon la temperatura de la primera planta a 20 grados"

Spanish already supports `temperature_only` and `area_temperature`, but
utterances targeting a climate entity by name or targeting a floor were not
handled by `HassClimateSetTemperature`.

Both combinations are already declared in `intents.yaml` and are implemented
for English and other languages, so no core schema change is needed.

## Testing

Before adding the sentence definitions, the targeted regression tests failed
because the representative utterances were matched as
`HassMediaSearchAndPlay`.

After the changes:

- `script/test --language es`: 281 passed
- Overmatch check: 1,084 sentences checked, 0 cross-intent overmatches and
  0 no-matches
- Spanish intent validation passed
- Repository lint passed
