### PR TITLE
[ES] Add missing HassLightSet color temperature combinations

### DIFF
--- a/sentences/es/HassLightSet/area_temperature.yaml
+++ b/sentences/es/HassLightSet/area_temperature.yaml
@@ -1,0 +1,15 @@
+---
+# HassLightSet - area_temperature
+# example: pon la temperatura de color del salón a 2700 kelvin
+# slots:
+# - {area}
+# - {temperature}
+
+language: "es"
+data:
+  - sentences:
+      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] {area} [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] {area} [a|al|en] {color_temperature_names:temperature}"
+    example: "pon la temperatura de color del salón a 2700 kelvin"
+    inferred_domain: "light"
+    response: "temperature"

--- a/sentences/es/HassLightSet/area_temperature.yaml
+++ b/sentences/es/HassLightSet/area_temperature.yaml
@@ -8,8 +8,8 @@
 language: "es"
 data:
   - sentences:
-      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] {area} [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
-      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] {area} [a|al|en] {color_temperature_names:temperature}"
+      - "<establece> [la] temperatura de color [de [todas] <luces>] <area> [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<establece> [la] temperatura de color [de [todas] <luces>] <area> [a|al|en] {color_temperature_names:temperature}"
     example: "pon la temperatura de color del salón a 2700 kelvin"
     inferred_domain: "light"
     response: "temperature"

--- a/sentences/es/HassLightSet/floor_temperature.yaml
+++ b/sentences/es/HassLightSet/floor_temperature.yaml
@@ -8,8 +8,8 @@
 language: "es"
 data:
   - sentences:
-      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] [planta|piso] {floor} [planta|piso] [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
-      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] [planta|piso] {floor} [planta|piso] [a|al|en] {color_temperature_names:temperature}"
+      - "<establece> [la] temperatura de color [de [todas] <luces>] <floor> [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<establece> [la] temperatura de color [de [todas] <luces>] <floor> [a|al|en] {color_temperature_names:temperature}"
     example: "pon la temperatura de color de la primera planta a 2700 kelvin"
     inferred_domain: "light"
     response: "temperature"

--- a/sentences/es/HassLightSet/floor_temperature.yaml
+++ b/sentences/es/HassLightSet/floor_temperature.yaml
@@ -1,0 +1,15 @@
+---
+# HassLightSet - floor_temperature
+# example: pon la temperatura de color de la primera planta a 2700 kelvin
+# slots:
+# - {floor}
+# - {temperature}
+
+language: "es"
+data:
+  - sentences:
+      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] [planta|piso] {floor} [planta|piso] [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<establece> [la] temperatura de color [de [todas] <luces>] [[en|de] [el|la]|del] [planta|piso] {floor} [planta|piso] [a|al|en] {color_temperature_names:temperature}"
+    example: "pon la temperatura de color de la primera planta a 2700 kelvin"
+    inferred_domain: "light"
+    response: "temperature"

--- a/sentences/es/HassLightSet/temperature_only.yaml
+++ b/sentences/es/HassLightSet/temperature_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassLightSet - temperature_only
+# example: pon la temperatura de color a 2700 kelvin
+# slots: {temperature}
+# context_area: true
+
+language: "es"
+data:
+  - sentences:
+      - "<establece> [la] temperatura de color [de [todas] <luces>] [<de_aqui>] [a|al|en] {color_temperature:temperature}[[ ](k|kelvin)]"
+      - "<establece> [la] temperatura de color [de [todas] <luces>] [<de_aqui>] [a|al|en] {color_temperature_names:temperature}"
+    example: "pon la temperatura de color a 2700 kelvin"
+    inferred_domain: "light"
+    response: "temperature"

--- a/tests/es/HassLightSet/area_temperature.yaml
+++ b/tests/es/HassLightSet/area_temperature.yaml
@@ -1,0 +1,21 @@
+---
+# HassLightSet - area_temperature
+
+language: "es"
+areas:
+  - name: "Salón"
+
+tests:
+  - sentences:
+      - "pon la temperatura de color del salón a 2700 kelvin"
+    slots:
+      area: "Salón"
+      temperature: 2700
+    response: "Temperatura de color establecida"
+
+  - sentences:
+      - "ajusta la temperatura de color de las luces del salón a blanco cálido"
+    slots:
+      area: "Salón"
+      temperature: 2700
+    response: "Temperatura de color establecida"

--- a/tests/es/HassLightSet/floor_temperature.yaml
+++ b/tests/es/HassLightSet/floor_temperature.yaml
@@ -1,0 +1,21 @@
+---
+# HassLightSet - floor_temperature
+
+language: "es"
+floors:
+  - name: "Primera planta"
+
+tests:
+  - sentences:
+      - "pon la temperatura de color de la primera planta a 2700 kelvin"
+    slots:
+      floor: "Primera planta"
+      temperature: 2700
+    response: "Temperatura de color establecida"
+
+  - sentences:
+      - "ajusta la temperatura de color de las luces de la primera planta a blanco cálido"
+    slots:
+      floor: "Primera planta"
+      temperature: 2700
+    response: "Temperatura de color establecida"

--- a/tests/es/HassLightSet/temperature_only.yaml
+++ b/tests/es/HassLightSet/temperature_only.yaml
@@ -1,0 +1,16 @@
+---
+# HassLightSet - temperature_only
+
+language: "es"
+tests:
+  - sentences:
+      - "pon la temperatura de color a 2700 kelvin"
+    slots:
+      temperature: 2700
+    response: "Temperatura de color establecida"
+
+  - sentences:
+      - "ajusta la temperatura de color de las luces de aquí a blanco cálido"
+    slots:
+      temperature: 2700
+    response: "Temperatura de color establecida"


### PR DESCRIPTION
## Summary

Add Spanish sentence support and tests for the three remaining
`HassLightSet` color-temperature slot combinations:

- `temperature_only`, for lights in the voice satellite's area
- `area_temperature`, for all lights in a named area
- `floor_temperature`, for all lights on a named floor

The new sentences support both numeric Kelvin values and named color
temperatures such as "blanco cálido".

Unlike the existing `name_temperature` sentences, where "de color" is
optional because the named entity is constrained to the `light` domain, these
aggregate combinations deliberately require "de color". This keeps phrases
about light color temperature distinct from room/climate temperature commands
and avoids collisions with `HassClimateSetTemperature`.

## Testing

Before adding the sentence definitions, the targeted regression tests failed
because the representative utterances were matched as
`HassMediaSearchAndPlay`.

After the changes:

- Targeted regression tests: 3 passed
- `script/test --language es`: 281 passed
- Overmatch check: 1,085 sentences checked, 0 cross-intent overmatches and
  0 no-matches
- Spanish intent validation passed
- Repository lint passed
