### PR TITLE
[sv] Add floor_domain support for HassTurnOn and HassTurnOff intents

### DIFF
--- a/responses/sv/HassTurnOff.yaml
+++ b/responses/sv/HassTurnOff.yaml
@@ -24,6 +24,7 @@ responses:
         } %}
         Slog av {{ translations.get(state.domain) }}
       lights_area: "Släckte lamporna"
+      lights_floor: "Släckte lamporna"
       light_all: "Släckte alla lampor"
       fans_area: "Stoppade fläktarna"
       cover: "Stänger"

--- a/responses/sv/HassTurnOn.yaml
+++ b/responses/sv/HassTurnOn.yaml
@@ -24,6 +24,7 @@ responses:
         } %}
         Slog på {{ translations.get(state.domain) }}
       lights_area: "Tände lamporna"
+      lights_floor: "Tände lamporna"
       fans_area: "Startade fläktarna"
       cover: "Öppnar"
       cover_device_class: "Öppnar {{ slots.device_class }}"

--- a/rules/sv/common.yaml
+++ b/rules/sv/common.yaml
@@ -2,6 +2,7 @@ language: sv
 expansion_rules:
   name: "{name}[e|me][t|n][s]"
   area: "{area}[e|me][t|n][s]"
+  floor: "{floor}[e|me][t|n][s]"
   here: (här | här inne | i det här rummet | i detta rum)
   vad: (vad är | vad är det | vad är det för | vilken)
   är: (är det | är)

--- a/sentences/sv/HassTurnOff/floor_domain.yaml
+++ b/sentences/sv/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,16 @@
+---
+# HassTurnOff - floor_domain
+# example: slå av lamporna på första våningen
+# slots:
+# - {floor}
+# - {domain}
+
+language: "sv"
+data:
+  # lights
+  - sentences:
+      - "<slå_av> [<alla>] <ljuskällor> <i_på> <floor>"
+      - "<slå_av> [<alla>] <floor> <ljuskällor>"
+    example: "slå av lamporna på första våningen"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/sentences/sv/HassTurnOn/floor_domain.yaml
+++ b/sentences/sv/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,16 @@
+---
+# HassTurnOn - floor_domain
+# example: tänd lamporna på första våningen
+# slots:
+# - {floor}
+# - {domain}
+
+language: "sv"
+data:
+  # lights
+  - sentences:
+      - "<slå_på> [<alla>] <ljuskällor> <i_på> <floor>"
+      - "<slå_på> [<alla>] <floor> <ljuskällor>"
+    example: "tänd lamporna på första våningen"
+    inferred_domain: "light"
+    response: "lights_floor"

--- a/tests/sv/HassTurnOff/floor_domain.yaml
+++ b/tests/sv/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,17 @@
+language: "sv"
+
+floors:
+  - name: "Entreplan"
+
+tests:
+  # lights
+  - sentences:
+      - "släck ljuset på entreplanet"
+      - "släck alla lampor på entreplanet"
+      - "slå av entreplanets lampor"
+    intent:
+      name: "HassTurnOff"
+    slots:
+      floor: "Entreplan"
+      domain: "light"
+    response: "Släckte lamporna"

--- a/tests/sv/HassTurnOn/floor_domain.yaml
+++ b/tests/sv/HassTurnOn/floor_domain.yaml
@@ -1,0 +1,17 @@
+language: "sv"
+
+floors:
+  - name: "Entreplan"
+
+tests:
+  # lights
+  - sentences:
+      - "tänd ljuset på entreplanet"
+      - "tänd alla lampor på entreplanet"
+      - "slå på entreplanets lampor"
+    intent:
+      name: "HassTurnOn"
+    slots:
+      floor: "Entreplan"
+      domain: "light"
+    response: "Tände lamporna"


### PR DESCRIPTION
Added floor_domain to HassTurnOn and HassTurnOff.
- sentences
- tests
- responses

Also added expansion rule for floor, same change as in PR #4120, thus making that PR obsolete.
