### PR TITLE
[de] Add Speech-to-Phrase lean sentence blocks

### DIFF
--- a/sentences/de/HassCancelTimer/default.yaml
+++ b/sentences/de/HassCancelTimer/default.yaml
@@ -9,3 +9,9 @@ data:
       - "[(den|meinen|unseren) ]Timer <timer_cancel_end_of_sentence>"
     example: "beende den Timer"
     response: "default"
+  - sentences:
+      - "(stoppe|beende) [den] Timer"
+      - "[den ]Timer abbrechen"
+    example: "stoppe den Timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/de/HassClimateGetTemperature/area_only.yaml
@@ -24,3 +24,8 @@ data:
       - "<area> (Ziel|Soll)temperatur"
     example: "Zieltemperatur im Wohnzimmer"
     response: "target_temperature"
+  - sentences:
+      - "Wie ist die Temperatur (im|in der) {area}"
+    example: "Wie ist die Temperatur im Wohnzimmer"
+    response: "current_temperature"
+    speech_to_phrase: true

--- a/sentences/de/HassClimateGetTemperature/default.yaml
+++ b/sentences/de/HassClimateGetTemperature/default.yaml
@@ -20,3 +20,9 @@ data:
       - "(Ziel|Soll)temperatur[ <hier>]"
     example: "Zieltemperatur"
     response: "target_temperature"
+  - sentences:
+      - "Wie ist die Temperatur"
+      - "Wie (warm|kalt) ist es"
+    example: "Wie ist die Temperatur"
+    response: "current_temperature"
+    speech_to_phrase: true

--- a/sentences/de/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/de/HassClimateGetTemperature/name_only.yaml
@@ -24,3 +24,11 @@ data:
     name_domains:
       - "climate"
     response: "target_temperature"
+  - sentences:
+      - "Wie ist die Temperatur vom {name}"
+      - "Wie (warm|kalt) ist [<artikel_bestimmt> ]{name}"
+    example: "Wie ist die Temperatur vom EcoBee"
+    name_domains:
+      - "climate"
+    response: "current_temperature"
+    speech_to_phrase: true

--- a/sentences/de/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/de/HassDecreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "{timer_hours:hours} Stunde[n] (weniger|kürzer)"
     example: "Timer um 1 Stunde verkürzen"
     response: "default"
+  - sentences:
+      - "verkürze [den] Timer um {timer_hours:hours} Stunde[n]"
+    example: "verkürze den Timer um 2 Stunden"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/de/HassDecreaseTimer/minutes_only.yaml
@@ -12,3 +12,8 @@ data:
       - "{timer_hour_parts_to_minutes:minutes} (weniger|kürzer)"
     example: "Timer um 5 Minuten verkürzen"
     response: "default"
+  - sentences:
+      - "verkürze [den] Timer um {timer_minutes:minutes} Minute[n]"
+    example: "verkürze den Timer um 5 Minuten"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/de/HassDecreaseTimer/seconds_only.yaml
@@ -12,3 +12,8 @@ data:
       - "{timer_minute_parts_to_seconds:seconds} (weniger|kürzer)"
     example: "Timer um 5 Sekunden verkürzen"
     response: "default"
+  - sentences:
+      - "verkürze [den] Timer um {timer_seconds:seconds} Sekunde[n]"
+    example: "verkürze den Timer um 30 Sekunden"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassFanSetSpeed/default.yaml
+++ b/sentences/de/HassFanSetSpeed/default.yaml
@@ -11,3 +11,8 @@ data:
       - "[Geschwindigkeit ](<luefter>|<luefter_genitiv>)[ <hier>][ auf] {fan_speed:percentage}[%| Prozent][ <setzen_end_of_sentence>]"
     example: "Stelle die Geschwindigkeit der Ventilatoren auf 50%"
     response: "default"
+  - sentences:
+      - "setze die Geschwindigkeit des Ventilators auf {fan_speed:percentage} Prozent"
+    example: "setze die Geschwindigkeit des Ventilators auf 50 Prozent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassFanSetSpeed/name_only.yaml
+++ b/sentences/de/HassFanSetSpeed/name_only.yaml
@@ -12,3 +12,10 @@ data:
     name_domains:
       - "fan"
     response: "default"
+  - sentences:
+      - "setze die Geschwindigkeit vom {name} auf {fan_speed:percentage} Prozent"
+    example: "setze die Geschwindigkeit vom Deckenventilator auf 50 Prozent"
+    name_domains:
+      - "fan"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassGetCurrentDate/default.yaml
+++ b/sentences/de/HassGetCurrentDate/default.yaml
@@ -11,3 +11,9 @@ data:
       - "(nenn[e]|gib|gebe|sag[e]|verrat[e]) mir das([ heutige] Datum|[ aktuelle] Datum[ von heute])"
     example: "welches Datum haben wir heute"
     response: "default"
+  - sentences:
+      - "welcher tag ist heute"
+      - "welches datum haben wir heute"
+    example: "welcher tag ist heute"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassGetCurrentTime/default.yaml
+++ b/sentences/de/HassGetCurrentTime/default.yaml
@@ -11,3 +11,9 @@ data:
       - "(nenn[e]|gib|gebe|sag[e]|verrat[e]) mir die[ aktuelle] uhrzeit"
     example: "wie spät ist es"
     response: "default"
+  - sentences:
+      - "wie spät ist es"
+      - "wie viel uhr ist es"
+    example: "wie spät ist es"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassGetState/name_only.yaml
+++ b/sentences/de/HassGetState/name_only.yaml
@@ -20,3 +20,10 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  - sentences:
+      - "was ist der Wert vom {name}"
+    example: "was ist der Wert vom Außentemperatur"
+    name_domains:
+      - sensor
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/de/HassGetState/name_state.yaml
+++ b/sentences/de/HassGetState/name_state.yaml
@@ -49,3 +49,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  - sentences:
+      - "ist [<artikel_bestimmt> ]{name} {on_off_states:state}"
+    example: "ist der Deckenventilator angeschaltet"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "ist [<artikel_bestimmt> ]{name} {cover_states:state}"
+    example: "ist das Wohnzimmerfenster offen"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "ist [<artikel_bestimmt> ]{name} {lock_states:state}"
+    example: "ist die Haustür abgeschlossen"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/de/HassGetWeather/default.yaml
+++ b/sentences/de/HassGetWeather/default.yaml
@@ -13,3 +13,8 @@ data:
       - "wie[ ]viel (Grad|°) (sind es|haben wir) ([dr]au(ss|ß)en|heute)"
     example: "wie warm ist es draußen"
     response: "outside_temp"
+  - sentences:
+      - "wie ist das Wetter"
+    example: "wie ist das Wetter"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/de/HassIncreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "{timer_hours:hours} Stunde[n] (mehr|länger)"
     example: "Timer um 1 Stunde verlängern"
     response: "default"
+  - sentences:
+      - "verlängere [den] Timer um {timer_hours:hours} Stunde[n]"
+    example: "verlängere den Timer um 2 Stunden"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/de/HassIncreaseTimer/minutes_only.yaml
@@ -12,3 +12,8 @@ data:
       - "{timer_hour_parts_to_minutes:minutes} (mehr|länger)"
     example: "Timer um 5 Minuten verlängern"
     response: "default"
+  - sentences:
+      - "verlängere [den] Timer um {timer_minutes:minutes} Minute[n]"
+    example: "verlängere den Timer um 5 Minuten"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/de/HassIncreaseTimer/seconds_only.yaml
@@ -12,3 +12,8 @@ data:
       - "{timer_minute_parts_to_seconds:seconds} (mehr|länger)"
     example: "Timer um 5 Sekunden verlängern"
     response: "default"
+  - sentences:
+      - "verlängere [den] Timer um {timer_seconds:seconds} Sekunde[n]"
+    example: "verlängere den Timer um 30 Sekunden"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassLightSet/area_brightness.yaml
+++ b/sentences/de/HassLightSet/area_brightness.yaml
@@ -38,3 +38,9 @@ data:
     example: "Stelle die Helligkeit im Schlafzimmer auf maximale Stufe"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "setze die Helligkeit im {area} auf {brightness} Prozent"
+    example: "setze die Helligkeit im Wohnzimmer auf 50 Prozent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/de/HassLightSet/brightness_only.yaml
+++ b/sentences/de/HassLightSet/brightness_only.yaml
@@ -18,3 +18,9 @@ data:
     example: "Stelle die Helligkeit auf 50%"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "setze die Helligkeit auf {brightness} Prozent"
+    example: "setze die Helligkeit auf 50 Prozent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/de/HassLightSet/floor_brightness.yaml
+++ b/sentences/de/HassLightSet/floor_brightness.yaml
@@ -38,3 +38,9 @@ data:
     example: "Stelle die Helligkeit im Erdgeschoss auf maximale Stufe"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "setze die Helligkeit im {floor} auf {brightness} Prozent"
+    example: "setze die Helligkeit im Erdgeschoss auf 50 Prozent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/de/HassLightSet/name_brightness.yaml
+++ b/sentences/de/HassLightSet/name_brightness.yaml
@@ -36,3 +36,10 @@ data:
     name_domains:
       - "light"
     response: "brightness"
+  - sentences:
+      - "setze die Helligkeit vom {name} auf {brightness} Prozent"
+    example: "setze die Helligkeit vom Licht A auf 50 Prozent"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/de/HassMediaNext/default.yaml
+++ b/sentences/de/HassMediaNext/default.yaml
@@ -17,3 +17,9 @@ data:
       - "<starte> (ein anderes|einen anderen) <song>[ ab]"
     example: "nächster Titel"
     response: "default"
+  - sentences:
+      - "nächstes Lied"
+      - "spiele nächstes Lied"
+    example: "nächstes Lied"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassMediaPause/default.yaml
+++ b/sentences/de/HassMediaPause/default.yaml
@@ -11,3 +11,8 @@ data:
       - "[(die|das|mein|meine) ]<media_type> [<hier> ](pausieren|pause|anhalten|stop[p]|stoppen|aus[schalten])"
     example: "pausiere die Musik"
     response: "default"
+  - sentences:
+      - "(pause|pausiere|stopp)"
+    example: "pause"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassMediaPlayerMute/default.yaml
+++ b/sentences/de/HassMediaPlayerMute/default.yaml
@@ -9,3 +9,9 @@ data:
       - "[<source_of_noise> ][<hier> ]<media_mute>"
     example: Musik muten
     response: default
+  - sentences:
+      - "Stumm schalten"
+      - "ton aus"
+    example: "Stumm schalten"
+    response: default
+    speech_to_phrase: true

--- a/sentences/de/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/de/HassMediaPlayerUnmute/default.yaml
@@ -9,3 +9,9 @@ data:
       - "[<source_of_noise> ][<hier> ]<media_unmute>"
     example: Musik entmuten
     response: default
+  - sentences:
+      - "ton an"
+      - "laut schalten"
+    example: "ton an"
+    response: default
+    speech_to_phrase: true

--- a/sentences/de/HassMediaPrevious/default.yaml
+++ b/sentences/de/HassMediaPrevious/default.yaml
@@ -16,3 +16,9 @@ data:
       - "<wiederhole> <song>[ nochmal]"
     example: "vorheriger Titel"
     response: "default"
+  - sentences:
+      - "letztes Lied"
+      - "vorheriges Lied"
+    example: "letztes Lied"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassMediaUnpause/default.yaml
+++ b/sentences/de/HassMediaUnpause/default.yaml
@@ -12,3 +12,10 @@ data:
       - "lass [(die|das|mein|meine) ]<media_type> [<hier> ]weiter(spielen|laufen)"
     example: "Musik fortsetzen"
     response: "default"
+  - sentences:
+      - "fortsetzen"
+      - "weiter machen"
+      - "musik fortsetzen"
+    example: "fortsetzen"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassNevermind/default.yaml
+++ b/sentences/de/HassNevermind/default.yaml
@@ -15,3 +15,9 @@ data:
       - "[doch ](nicht[s]|nix)"
     example: "vergiss es"
     response: "default"
+  - sentences:
+      - "vergiss es"
+      - "egal"
+    example: "vergiss es"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassPauseTimer/default.yaml
+++ b/sentences/de/HassPauseTimer/default.yaml
@@ -9,3 +9,8 @@ data:
       - "halt[e] (den|meinen|unseren) Timer an"
     example: "pausiere den Timer"
     response: "default"
+  - sentences:
+      - "pausiere [den] Timer"
+    example: "pausiere den Timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassSetPosition/name_only.yaml
+++ b/sentences/de/HassSetPosition/name_only.yaml
@@ -31,3 +31,12 @@ data:
       - "cover"
       - "valve"
     response: "default"
+  - sentences:
+      - "setze [<artikel_bestimmt> ]{name} auf {position} Prozent"
+      - "öffne [<artikel_bestimmt> ]{name} auf {position} Prozent"
+    example: "setze das Wohnzimmerfenster auf 50 Prozent"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassSetVolume/default.yaml
+++ b/sentences/de/HassSetVolume/default.yaml
@@ -17,3 +17,8 @@ data:
       - "[die ]Lautstärke[ <hier>][ auf] [(die|das) ]{volume_mapping:volume_level}[ Stufe][ <setzen_end_of_sentence>]"
     example: "Stelle die Lautstärke auf maximum"
     response: "default"
+  - sentences:
+      - "setze die Lautstärke auf {volume_level} Prozent"
+    example: "setze die Lautstärke auf 50 Prozent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassSetVolumeRelative/default.yaml
+++ b/sentences/de/HassSetVolumeRelative/default.yaml
@@ -30,3 +30,18 @@ data:
       - "dreh[e] die lautstärke[ der Musik][ um] {volume_step_down:volume_step}[%| Prozent] [he]runter"
     example: "Lautstärke um 20 Prozent leiser"
     response: "default"
+  - sentences:
+      - "[die ]lautstärke {volume_step}"
+    example: "die lautstärke lauter"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "erhöhe die lautstärke um {volume_step_up:volume_step} Prozent"
+    example: "erhöhe die lautstärke um 10 Prozent"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "verringere die lautstärke um {volume_step_down:volume_step} Prozent"
+    example: "verringere die lautstärke um 10 Prozent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassStartTimer/hours_only.yaml
+++ b/sentences/de/HassStartTimer/hours_only.yaml
@@ -12,3 +12,9 @@ data:
       - "<timer_set>[ einen] Timer (auf|für) {timer_hours:hours} Stunde[n]"
     example: "Timer für 1 Stunde"
     response: "default"
+  - sentences:
+      - "stelle einen Timer für {timer_hours:hours} Stunde[n]"
+      - "Timer für {timer_hours:hours} Stunde[n]"
+    example: "stelle einen Timer für 2 Stunden"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassStartTimer/minutes_only.yaml
+++ b/sentences/de/HassStartTimer/minutes_only.yaml
@@ -14,3 +14,9 @@ data:
       - "<timer_set>[ einen] Timer (auf|für) {timer_hour_parts_to_minutes:minutes}"
     example: "Timer für 5 Minuten"
     response: "default"
+  - sentences:
+      - "stelle einen Timer für {timer_minutes:minutes} Minute[n]"
+      - "Timer für {timer_minutes:minutes} Minute[n]"
+    example: "stelle einen Timer für 5 Minuten"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassStartTimer/seconds_only.yaml
+++ b/sentences/de/HassStartTimer/seconds_only.yaml
@@ -14,3 +14,9 @@ data:
       - "<timer_set>[ einen] Timer (auf|für) {timer_minute_parts_to_seconds:seconds}"
     example: "Timer für 30 Sekunden"
     response: "default"
+  - sentences:
+      - "stelle einen Timer für {timer_seconds:seconds} Sekunde[n]"
+      - "Timer für {timer_seconds:seconds} Sekunde[n]"
+    example: "stelle einen Timer für 30 Sekunden"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassTimerStatus/default.yaml
+++ b/sentences/de/HassTimerStatus/default.yaml
@@ -15,3 +15,9 @@ data:
       - "wann läuft (der|mein|unser) Timer ab"
     example: "Timer Status"
     response: "default"
+  - sentences:
+      - "wie lange läuft der Timer noch"
+      - "Timer Status"
+    example: "wie lange läuft der Timer noch"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOff/area_domain.yaml
+++ b/sentences/de/HassTurnOff/area_domain.yaml
@@ -41,3 +41,16 @@ data:
     example: "schalte den Ventilator im Wohnzimmer aus"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "schalte das Licht im {area} aus"
+      - "das Licht im {area} ausschalten"
+    example: "schalte das Licht im Wohnzimmer aus"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "schalte den Ventilator im {area} aus"
+    example: "schalte den Ventilator im Wohnzimmer aus"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOff/domain_only.yaml
+++ b/sentences/de/HassTurnOff/domain_only.yaml
@@ -34,3 +34,10 @@ data:
     example: "schalte den Ventilator aus"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "schalte das Licht aus"
+      - "[das ]Licht aus"
+    example: "schalte das Licht aus"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOff/floor_domain.yaml
+++ b/sentences/de/HassTurnOff/floor_domain.yaml
@@ -19,3 +19,9 @@ data:
     example: "schalte alle Lichter im Obergeschoss aus"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "schalte das Licht im {floor} aus"
+    example: "schalte das Licht im Erdgeschoss aus"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOff/name_only.yaml
+++ b/sentences/de/HassTurnOff/name_only.yaml
@@ -62,3 +62,34 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "schalte [<artikel_bestimmt> ]{name} aus"
+    example: "schalte den Deckenventilator aus"
+    name_domains:
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "schalte [<artikel_bestimmt> ]{name} aus"
+    example: "schalte das Licht A aus"
+    name_domains:
+      - "light"
+    response: "light"
+    speech_to_phrase: true
+  - sentences:
+      - "schließe [<artikel_bestimmt> ]{name}"
+    example: "schließe das Wohnzimmerfenster"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "entsperre [<artikel_bestimmt> ]{name}"
+    example: "entsperre die Haustür"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOn/area_domain.yaml
+++ b/sentences/de/HassTurnOn/area_domain.yaml
@@ -46,3 +46,15 @@ data:
     example: "schalte den Ventilator im Wohnzimmer ein"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "schalte das Licht im {area} an"
+    example: "schalte das Licht im Wohnzimmer an"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "schalte den Ventilator im {area} an"
+    example: "schalte den Ventilator im Wohnzimmer an"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOn/domain_only.yaml
+++ b/sentences/de/HassTurnOn/domain_only.yaml
@@ -43,3 +43,10 @@ data:
     example: "schalte den Ventilator an"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "schalte das Licht an"
+      - "[das ]Licht an"
+    example: "schalte das Licht an"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOn/floor_domain.yaml
+++ b/sentences/de/HassTurnOn/floor_domain.yaml
@@ -21,3 +21,9 @@ data:
     example: "schalte alle Lichter im Obergeschoss an"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "schalte das Licht im {floor} an"
+    example: "schalte das Licht im Erdgeschoss an"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOn/name_area.yaml
+++ b/sentences/de/HassTurnOn/name_area.yaml
@@ -66,3 +66,20 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "schalte [<artikel_bestimmt> ]{name} im {area} an"
+    example: "schalte den Deckenventilator im Wohnzimmer an"
+    name_domains:
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "schalte [<artikel_bestimmt> ]{name} im {area} an"
+    example: "schalte das Licht A im Wohnzimmer an"
+    name_domains:
+      - "light"
+    response: "light"
+    speech_to_phrase: true

--- a/sentences/de/HassTurnOn/name_only.yaml
+++ b/sentences/de/HassTurnOn/name_only.yaml
@@ -63,3 +63,34 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "schalte [<artikel_bestimmt> ]{name} an"
+    example: "schalte den Deckenventilator an"
+    name_domains:
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "schalte [<artikel_bestimmt> ]{name} an"
+    example: "schalte das Licht A an"
+    name_domains:
+      - "light"
+    response: "light"
+    speech_to_phrase: true
+  - sentences:
+      - "öffne [<artikel_bestimmt> ]{name}"
+    example: "öffne das Wohnzimmerfenster"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "schließe [<artikel_bestimmt> ]{name} ab"
+    example: "schließe die Haustür ab"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/de/HassUnpauseTimer/default.yaml
+++ b/sentences/de/HassUnpauseTimer/default.yaml
@@ -9,3 +9,8 @@ data:
       - "lass[e] (den|meinen) Timer weiter[ ]laufen"
     example: "setze den Timer fort"
     response: "default"
+  - sentences:
+      - "setze [den] Timer fort"
+    example: "setze den Timer fort"
+    response: "default"
+    speech_to_phrase: true

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,4 +1,4 @@
-"""Speech-to-Phrase subset verification (Method B).
+"""Speech-to-Phrase subset verification.
 
 A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
 the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
@@ -6,24 +6,31 @@ also has untagged (rich) blocks, Home Assistant drops the tagged block from its
 grammar (see ``partition_speech_to_phrase`` and the loader in
 ``test_slot_combinations.py``). That is only sound if the lean block's language
 is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
-recognise a phrasing HA never would.
+recognise a phrasing Home Assistant never would.
 
-We verify containment by enumeration rather than with an FST/OpenFST toolchain:
-lean blocks are finite and small by construction, so we expand every phrasing on
-both sides (slots rendered as literal ``{list}`` sentinels via
-``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
-complete for the lean side (no recursion, bounded fan-out) and needs no slot
-lists, entities, or intent context.
+Containment is checked by *matching*, not by enumerating both sides. The lean
+side is enumerated (it is small and non-recursive by construction) and each
+phrasing is then handed to hassil's recognizer built from the rich blocks: if
+the rich grammar accepts it, it is in the rich language. Enumerating the rich
+side instead is what the first version of this test did, and it does not scale
+-- English is small enough to get away with it, but e.g. the Spanish
+``HassTurnOn`` blocks expand into billions of phrasings and exhaust memory.
 
-Only English is wired up for now; the collector is language-agnostic.
+Slots are neutralised on both sides: every ``{list}`` reference is replaced with
+a per-list sentinel word, and the rich grammar gets a one-value text list for
+each, so matching compares phrasing structure rather than slot contents (which
+would need entities, areas and floors that this test deliberately does not load).
+
+Languages are discovered from the tagged blocks themselves.
 """
 
 import importlib
+import re
 from typing import Any
 
 import pytest
 import yaml
-from hassil import Intents, normalize_whitespace
+from hassil import Intents, SlotList, TextSlotList, normalize_whitespace, recognize
 from hassil.sample import sample_sentence
 
 from . import RULES_DIR, SENTENCES_DIR
@@ -31,7 +38,26 @@ from . import RULES_DIR, SENTENCES_DIR
 _util: Any = importlib.import_module("script.intentfest.util")
 partition_speech_to_phrase = _util.partition_speech_to_phrase
 
-LANGUAGES = ["en"]
+
+def _languages_with_s2p_blocks() -> list[str]:
+    """Every language that has at least one ``speech_to_phrase``-tagged block.
+
+    Discovered rather than hard-coded so adding a language's lean blocks does
+    not also require editing this list (and so a branch per language does not
+    collide here)."""
+    langs = []
+    for lang_dir in sorted(p for p in SENTENCES_DIR.iterdir() if p.is_dir()):
+        for combo_path in lang_dir.glob("*/*.yaml"):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            if any(b.get("speech_to_phrase") for b in data):
+                langs.append(lang_dir.name)
+                break
+    return langs
+
+
+LANGUAGES = _languages_with_s2p_blocks()
+
+_SLOT_REF = re.compile(r"\{([^{}]+)\}")
 
 
 def _load_expansion_rules(language: str) -> dict[str, str]:
@@ -44,10 +70,22 @@ def _load_expansion_rules(language: str) -> dict[str, str]:
     return rules
 
 
-def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
-    """Every phrasing a set of templates can produce, with slots left as literal
-    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
-    sides are compared on phrasing structure, not enumerated slot values."""
+def _list_name(ref: str) -> str:
+    """``timer_hours:hours`` -> ``timer_hours``; ``0..100`` -> ``_range``."""
+    name = ref.split(":", 1)[0].strip()
+    return "_range" if re.match(r"^-?\d+\s*\.\.", name) else name
+
+
+def _sentinel(list_name: str) -> str:
+    """A single word that cannot collide with real vocabulary."""
+    return "zz" + re.sub(r"[^a-z0-9]+", "", list_name.lower()) + "zz"
+
+
+def _lean_phrasings(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> set[str]:
+    """Every phrasing the lean templates produce, with each slot reference
+    replaced by its sentinel word."""
     intents = Intents.from_dict(
         {
             "language": language,
@@ -66,8 +104,47 @@ def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> se
                 expand_lists=False,
                 expand_ranges=False,
             ):
+                text = _SLOT_REF.sub(lambda m: _sentinel(_list_name(m.group(1))), text)
                 out.add(normalize_whitespace(text).strip())
     return out
+
+
+def _referenced_lists(sentences: list[str], rules: dict[str, str]) -> set[str]:
+    """List names reachable from these templates, following expansion rules."""
+    seen_rules: set[str] = set()
+    names: set[str] = set()
+    pending = list(sentences)
+    while pending:
+        text = pending.pop()
+        names.update(_list_name(m) for m in _SLOT_REF.findall(text))
+        for rule_name in re.findall(r"<([a-zA-Z0-9_]+)>", text):
+            if rule_name in rules and rule_name not in seen_rules:
+                seen_rules.add(rule_name)
+                pending.append(rules[rule_name])
+    return names
+
+
+def _rich_intents(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> tuple[Intents, dict[str, SlotList]]:
+    """Rich blocks as a recognizer, with every referenced list bound to its
+    sentinel so slot *contents* never affect the match."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {
+                "_S2P": {"data": [{"sentences": sentences, "slots": {"x": "y"}}]}
+            },
+            "expansion_rules": rules,
+        }
+    )
+    slot_lists: dict[str, SlotList] = {
+        name: TextSlotList.from_strings([_sentinel(name)])
+        for name in _referenced_lists(sentences, rules)
+    }
+    # An inline range (`{0..100}`) keeps its own ref text, so bind that too.
+    slot_lists.setdefault("_range", TextSlotList.from_strings([_sentinel("_range")]))
+    return intents, slot_lists
 
 
 def _collect() -> list[tuple[str, str, str]]:
@@ -98,17 +175,19 @@ def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
     ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
 
     rules = _load_expansion_rules(lang)
-    rich = _phrasings(
-        [s for block in ha_blocks for s in block["sentences"]], lang, rules
-    )
+    rich_sentences = [s for block in ha_blocks for s in block["sentences"]]
+    rich, slot_lists = _rich_intents(rich_sentences, lang, rules)
 
     for block in s2p_only:
-        lean = _phrasings(block["sentences"], lang, rules)
-        extra = lean - rich
+        extra = [
+            phrasing
+            for phrasing in sorted(_lean_phrasings(block["sentences"], lang, rules))
+            if recognize(phrasing, rich, slot_lists=slot_lists) is None
+        ]
         assert not extra, (
             f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
             f"not recognised by the Home Assistant (rich) block(s): "
-            f"{sorted(extra)[:10]}"
+            f"{extra[:10]}"
         )
 
 


### PR DESCRIPTION
Speech-to-Phrase builds a constrained FST grammar instead of matching with
hassil, so it consumes the `speech_to_phrase`-tagged subset of each slot
combination rather than the full block. Only English had those blocks, so the
add-on could not serve German even though a German acoustic model exists.

This adds **59 tagged blocks** covering the same 26 intents as English.

### How the sentences were chosen

Every sentence is a **restriction of German's own untagged templates** — taken
from what the rich blocks already accept, not newly invented phrasing. Home
Assistant's grammar is therefore unchanged: `partition_speech_to_phrase` drops
the tagged block whenever an untagged sibling exists, and the subset check
proves the lean language is contained in the rich one.


### Verification

Each block's `example` was synthesized with the German Home Assistant Cloud TTS
voice and decoded through the real Speech-to-Phrase grammar (`stt_de_citrinet_1024`), then
scored on whether hassil resolves the transcript back to the command that was
spoken — not on string equality, since the decoder legitimately picks a
different in-grammar realization (articles drop, numbers are spelled out).

**59/59 examples resolve to the correct command.**

`script/test` and `python3 -m script.intentfest validate --language de` both pass.

### Note on the shared test change

`tests/test_speech_to_phrase.py` now discovers languages from the tagged blocks
instead of a hard-coded `["en"]`, and checks containment by *matching* each lean
phrasing against the rich blocks rather than enumerating both sides. Enumeration
does not scale past English — the Spanish `HassTurnOn` blocks expand far enough
to exhaust memory — while matching is linear in the (small) lean side and gives
the same answer. Verified against a planted violation to confirm it still fails
when it should.

That change is **byte-identical in all seven of these language PRs**, so
whichever merges first makes it a no-op for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)