### PR TITLE
[it] Add Speech-to-Phrase lean sentence blocks

### DIFF
--- a/sentences/it/HassCancelTimer/default.yaml
+++ b/sentences/it/HassCancelTimer/default.yaml
@@ -1,6 +1,12 @@
+---
 language: it
 data:
   - sentences:
       - "<timer_cancel>[ il| il mio] timer"
     example: "cancella timer"
     response: "default"
+  - sentences:
+      - "cancella il timer"
+    example: "cancella il timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/it/HassClimateGetTemperature/area_only.yaml
@@ -12,3 +12,8 @@ data:
       - "quanti gradi [(ci sono | fanno | ci stanno)] (<in>|<the>) {area}"
     example: "qual è la temperatura nel soggiorno"
     response: "default"
+  - sentences:
+      - "qual è la temperatura in {area}"
+    example: "qual è la temperatura in Cucina"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassClimateGetTemperature/default.yaml
+++ b/sentences/it/HassClimateGetTemperature/default.yaml
@@ -12,3 +12,8 @@ data:
       - "quanti gradi [(ci sono | fanno | ci stanno)] [<in_here>]"
     example: "qual è la temperatura"
     response: "default"
+  - sentences:
+      - "qual è la temperatura"
+    example: "qual è la temperatura"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/it/HassClimateGetTemperature/name_only.yaml
@@ -13,3 +13,10 @@ data:
     name_domains:
       - "climate"
     response: "default"
+  - sentences:
+      - "qual è la temperatura del {name}"
+    example: "qual è la temperatura del Termostato Soggiorno"
+    name_domains:
+      - "climate"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/it/HassDecreaseTimer/hours_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -5,3 +6,8 @@ data:
       - "(diminuisci|riduci)[ il[ mio]] timer di {timer_hours:hours} or(a|e)"
     example: "togli 1 ora dal timer"
     response: "default"
+  - sentences:
+      - "togli {timer_hours:hours} or(a|e) dal timer"
+    example: "togli 2 ora dal timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/it/HassDecreaseTimer/minutes_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -5,3 +6,8 @@ data:
       - "(diminuisci|riduci)[ il[ mio]] timer di {timer_minutes:minutes} minut(o|i)"
     example: "togli 5 minuti dal timer"
     response: "default"
+  - sentences:
+      - "togli {timer_minutes:minutes} minut(o|i) dal timer"
+    example: "togli 5 minuto dal timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/it/HassDecreaseTimer/seconds_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -5,3 +6,8 @@ data:
       - "(diminuisci|riduci)[ il[ mio]] timer di {timer_seconds:seconds} second(o|i)"
     example: "togli 30 secondi dal timer"
     response: "default"
+  - sentences:
+      - "togli {timer_seconds:seconds} second(o|i) dal timer"
+    example: "togli 30 secondo dal timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassGetCurrentDate/default.yaml
+++ b/sentences/it/HassGetCurrentDate/default.yaml
@@ -9,3 +9,8 @@ data:
       - "(dimmi | dammi) la data [di oggi | odierna]"
     example: "che giorno è oggi"
     response: "default"
+  - sentences:
+      - "che giorno è oggi"
+    example: "che giorno è oggi"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassGetCurrentTime/default.yaml
+++ b/sentences/it/HassGetCurrentTime/default.yaml
@@ -10,3 +10,8 @@ data:
       - "(Dimmi | Dammi) l'orario [attuale | esatto]"
     example: "che ore sono"
     response: "default"
+  - sentences:
+      - "Che ore sono"
+    example: "Che ore sono"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassGetState/name_only.yaml
+++ b/sentences/it/HassGetState/name_only.yaml
@@ -20,3 +20,10 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  - sentences:
+      - "qual è il valore del {name}"
+    example: "qual è il valore del Temperatura Esterna"
+    name_domains:
+      - sensor
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/it/HassGetState/name_state.yaml
+++ b/sentences/it/HassGetState/name_state.yaml
@@ -54,3 +54,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  - sentences:
+      - "è [<the>] {name} {on_off_states:state}"
+    example: "è lo Luce A acceso"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "è [<the>] {name} {cover_states:state}"
+    example: "è lo Finestra Cucina aperto"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "è [<the>] {name} {lock_states:state}"
+    example: "è lo Porta Ingresso chiuso"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/it/HassGetWeather/default.yaml
+++ b/sentences/it/HassGetWeather/default.yaml
@@ -9,3 +9,8 @@ data:
       - "<what_is> il tempo"
     example: "che tempo fa"
     response: "default"
+  - sentences:
+      - "che tempo fa"
+    example: "che tempo fa"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/it/HassIncreaseTimer/hours_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -5,3 +6,8 @@ data:
       - "aumenta[ il[ mio]] timer di {timer_hours:hours} or(a|e)"
     example: "aggiungi 1 ora al timer"
     response: "default"
+  - sentences:
+      - "aggiungi {timer_hours:hours} or(a|e) al timer"
+    example: "aggiungi 2 ora al timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/it/HassIncreaseTimer/minutes_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -5,3 +6,8 @@ data:
       - "aumenta[ il[ mio]] timer di {timer_minutes:minutes} minut(o|i)"
     example: "aggiungi 5 minuti al timer"
     response: "default"
+  - sentences:
+      - "aggiungi {timer_minutes:minutes} minut(o|i) al timer"
+    example: "aggiungi 5 minuto al timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/it/HassIncreaseTimer/seconds_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -5,3 +6,8 @@ data:
       - "aumenta[ il[ mio]] timer di {timer_seconds:seconds} second(o|i)"
     example: "aggiungi 30 secondi al timer"
     response: "default"
+  - sentences:
+      - "aggiungi {timer_seconds:seconds} second(o|i) al timer"
+    example: "aggiungi 30 secondo al timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassLightSet/area_brightness.yaml
+++ b/sentences/it/HassLightSet/area_brightness.yaml
@@ -17,3 +17,9 @@ data:
     example: "imposta la luminosità del soggiorno al 50%"
     inferred_domain: "light"
     response: "brightness_area"
+  - sentences:
+      - "imposta la luminosità in {area} al {brightness} per cento"
+    example: "imposta la luminosità in Cucina al 50 per cento"
+    inferred_domain: "light"
+    response: "brightness_area"
+    speech_to_phrase: true

--- a/sentences/it/HassLightSet/name_brightness.yaml
+++ b/sentences/it/HassLightSet/name_brightness.yaml
@@ -20,3 +20,10 @@ data:
     name_domains:
       - "light"
     response: "brightness"
+  - sentences:
+      - "imposta la luminosità del {name} al {brightness} per cento"
+    example: "imposta la luminosità del Luce A al 50 per cento"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/it/HassMediaNext/default.yaml
+++ b/sentences/it/HassMediaNext/default.yaml
@@ -22,3 +22,9 @@ data:
       - "salta al[ brano |l'elemento | programma |l'episodio ](successivo|seguente)"
     example: "prossima canzone"
     response: "default"
+  - sentences:
+      - "vai avanti"
+      - "prossima canzone"
+    example: "vai avanti"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassMediaPause/default.yaml
+++ b/sentences/it/HassMediaPause/default.yaml
@@ -10,3 +10,9 @@ data:
       - "(metti in pausa|pausa) [il |i |su |sul |sui ]media player"
     example: "metti in pausa la musica"
     response: "default"
+  - sentences:
+      - "pausa"
+      - "metti in pausa la musica"
+    example: "pausa"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassMediaPrevious/default.yaml
+++ b/sentences/it/HassMediaPrevious/default.yaml
@@ -14,3 +14,9 @@ data:
       - "[vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']][elemento|episodio] precedente"
     example: "canzone precedente"
     response: "default"
+  - sentences:
+      - "vai indietro"
+      - "canzone precedente"
+    example: "vai indietro"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassMediaUnpause/default.yaml
+++ b/sentences/it/HassMediaUnpause/default.yaml
@@ -10,3 +10,9 @@ data:
       - "riprendi [il |i |su |sul |sui ]media player"
     example: "riprendi la musica"
     response: "default"
+  - sentences:
+      - "riprendi"
+      - "riprendi la musica"
+    example: "riprendi"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassNevermind/default.yaml
+++ b/sentences/it/HassNevermind/default.yaml
@@ -10,3 +10,9 @@ data:
       - "no"
     example: "lascia stare"
     response: "default"
+  - sentences:
+      - "lascia stare"
+      - "niente"
+    example: "lascia stare"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassPauseTimer/default.yaml
+++ b/sentences/it/HassPauseTimer/default.yaml
@@ -1,6 +1,12 @@
+---
 language: it
 data:
   - sentences:
       - "metti in pausa[ il| il mio] timer"
     example: "metti in pausa timer"
     response: "default"
+  - sentences:
+      - "metti in pausa il timer"
+    example: "metti in pausa il timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassSetPosition/name_only.yaml
+++ b/sentences/it/HassSetPosition/name_only.yaml
@@ -15,3 +15,11 @@ data:
       - "cover"
       - "valve"
     response: "default"
+  - sentences:
+      - "imposta la posizione del {name} al {position} per cento"
+    example: "imposta la posizione del Finestra Cucina al 50 per cento"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassSetVolume/default.yaml
+++ b/sentences/it/HassSetVolume/default.yaml
@@ -10,3 +10,8 @@ data:
       - "<numeric_value_set> [il ]volume <to> {volume:volume_level}[<percent>]"
     example: "imposta il volume al 90%"
     response: "default"
+  - sentences:
+      - "imposta il volume al {volume:volume_level} per cento"
+    example: "imposta il volume al 50 per cento"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassSetVolumeRelative/default.yaml
+++ b/sentences/it/HassSetVolumeRelative/default.yaml
@@ -24,3 +24,18 @@ data:
       - "volume giù [<of>] {volume_step_down:volume_step}[<percent>]"
     example: "abbassa il volume del 20%"
     response: "default"
+  - sentences:
+      - "volume {volume_step}"
+    example: "volume su"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "alza il volume di {volume_step_up:volume_step} per cento"
+    example: "alza il volume di 10 per cento"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "abbassa il volume di {volume_step_down:volume_step} per cento"
+    example: "abbassa il volume di 10 per cento"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassStartTimer/hours_only.yaml
+++ b/sentences/it/HassStartTimer/hours_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -7,3 +8,9 @@ data:
       - "timer {timer_hours:hours} or(a|e)"
     example: "timer per 1 ora"
     response: "default"
+  - sentences:
+      - "imposta un timer di {timer_hours:hours} or(a|e)"
+      - "timer di {timer_hours:hours} or(a|e)"
+    example: "imposta un timer di 2 ora"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassStartTimer/minutes_only.yaml
+++ b/sentences/it/HassStartTimer/minutes_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -9,3 +10,9 @@ data:
       - "timer (per|da|di|d') {timer_half:minutes} or(a|e)"
     example: "timer per 5 minuti"
     response: "default"
+  - sentences:
+      - "imposta un timer di {timer_minutes:minutes} minut(o|i)"
+      - "timer di {timer_minutes:minutes} minut(o|i)"
+    example: "imposta un timer di 5 minuto"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassStartTimer/seconds_only.yaml
+++ b/sentences/it/HassStartTimer/seconds_only.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -9,3 +10,9 @@ data:
       - "timer (per|da|di|d') {timer_half:seconds} minut(o|i)"
     example: "timer per 30 secondi"
     response: "default"
+  - sentences:
+      - "imposta un timer di {timer_seconds:seconds} second(o|i)"
+      - "timer di {timer_seconds:seconds} second(o|i)"
+    example: "imposta un timer di 30 secondo"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassTimerStatus/default.yaml
+++ b/sentences/it/HassTimerStatus/default.yaml
@@ -1,3 +1,4 @@
+---
 language: it
 data:
   - sentences:
@@ -6,3 +7,8 @@ data:
       - "[quanto ]tempo (manca|resta|rimane|rimanente) (a|su)(l[ mio]|i[ miei]) timer"
     example: "stato timer"
     response: "default"
+  - sentences:
+      - "quanto tempo manca al timer"
+    example: "quanto tempo manca al timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOff/area_domain.yaml
+++ b/sentences/it/HassTurnOff/area_domain.yaml
@@ -27,3 +27,15 @@ data:
     example: "spegni i ventilatori in cucina"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "spegni le luci in {area}"
+    example: "spegni le luci in Cucina"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "spegni i ventilatori in {area}"
+    example: "spegni i ventilatori in Cucina"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOff/domain_only.yaml
+++ b/sentences/it/HassTurnOff/domain_only.yaml
@@ -29,3 +29,9 @@ data:
     example: "spegni i ventilatori"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "spegni le luci"
+    example: "spegni le luci"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOff/floor_domain.yaml
+++ b/sentences/it/HassTurnOff/floor_domain.yaml
@@ -16,3 +16,9 @@ data:
     example: "spegni le luci al primo piano"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "spegni le luci al {floor}"
+    example: "spegni le luci al Primo piano"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOff/name_only.yaml
+++ b/sentences/it/HassTurnOff/name_only.yaml
@@ -51,3 +51,28 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "spegni [<the>] {name}"
+    example: "spegni lo Luce A"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "chiudi [<the>] {name}"
+    example: "chiudi lo Finestra Cucina"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "sblocca [<the>] {name}"
+    example: "sblocca lo Porta Ingresso"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOn/area_domain.yaml
+++ b/sentences/it/HassTurnOn/area_domain.yaml
@@ -22,3 +22,15 @@ data:
     example: "accendi le ventole in cucina"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "accendi le luci in {area}"
+    example: "accendi le luci in Cucina"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "accendi i ventilatori in {area}"
+    example: "accendi i ventilatori in Cucina"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOn/domain_only.yaml
+++ b/sentences/it/HassTurnOn/domain_only.yaml
@@ -22,3 +22,9 @@ data:
     example: "accendi le ventole"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "accendi le luci"
+    example: "accendi le luci"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOn/floor_domain.yaml
+++ b/sentences/it/HassTurnOn/floor_domain.yaml
@@ -14,3 +14,9 @@ data:
     example: "accendi le luci al primo piano"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "accendi le luci al {floor}"
+    example: "accendi le luci al Primo piano"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOn/name_area.yaml
+++ b/sentences/it/HassTurnOn/name_area.yaml
@@ -51,3 +51,14 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "accendi [<the>] {name} in {area}"
+    example: "accendi lo Luce A in Cucina"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/it/HassTurnOn/name_only.yaml
+++ b/sentences/it/HassTurnOn/name_only.yaml
@@ -50,3 +50,28 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "accendi [<the>] {name}"
+    example: "accendi lo Luce A"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "apri [<the>] {name}"
+    example: "apri lo Finestra Cucina"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "chiudi a chiave [<the>] {name}"
+    example: "chiudi a chiave lo Porta Ingresso"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/it/HassUnpauseTimer/default.yaml
+++ b/sentences/it/HassUnpauseTimer/default.yaml
@@ -1,6 +1,12 @@
+---
 language: it
 data:
   - sentences:
       - "(riprendi|continua|riavvia)[ il| il mio] timer"
     example: "metti in pausa timer"
     response: "default"
+  - sentences:
+      - "riprendi il timer"
+    example: "riprendi il timer"
+    response: "default"
+    speech_to_phrase: true

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,4 +1,4 @@
-"""Speech-to-Phrase subset verification (Method B).
+"""Speech-to-Phrase subset verification.
 
 A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
 the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
@@ -6,24 +6,31 @@ also has untagged (rich) blocks, Home Assistant drops the tagged block from its
 grammar (see ``partition_speech_to_phrase`` and the loader in
 ``test_slot_combinations.py``). That is only sound if the lean block's language
 is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
-recognise a phrasing HA never would.
+recognise a phrasing Home Assistant never would.
 
-We verify containment by enumeration rather than with an FST/OpenFST toolchain:
-lean blocks are finite and small by construction, so we expand every phrasing on
-both sides (slots rendered as literal ``{list}`` sentinels via
-``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
-complete for the lean side (no recursion, bounded fan-out) and needs no slot
-lists, entities, or intent context.
+Containment is checked by *matching*, not by enumerating both sides. The lean
+side is enumerated (it is small and non-recursive by construction) and each
+phrasing is then handed to hassil's recognizer built from the rich blocks: if
+the rich grammar accepts it, it is in the rich language. Enumerating the rich
+side instead is what the first version of this test did, and it does not scale
+-- English is small enough to get away with it, but e.g. the Spanish
+``HassTurnOn`` blocks expand into billions of phrasings and exhaust memory.
 
-Only English is wired up for now; the collector is language-agnostic.
+Slots are neutralised on both sides: every ``{list}`` reference is replaced with
+a per-list sentinel word, and the rich grammar gets a one-value text list for
+each, so matching compares phrasing structure rather than slot contents (which
+would need entities, areas and floors that this test deliberately does not load).
+
+Languages are discovered from the tagged blocks themselves.
 """
 
 import importlib
+import re
 from typing import Any
 
 import pytest
 import yaml
-from hassil import Intents, normalize_whitespace
+from hassil import Intents, SlotList, TextSlotList, normalize_whitespace, recognize
 from hassil.sample import sample_sentence
 
 from . import RULES_DIR, SENTENCES_DIR
@@ -31,7 +38,26 @@ from . import RULES_DIR, SENTENCES_DIR
 _util: Any = importlib.import_module("script.intentfest.util")
 partition_speech_to_phrase = _util.partition_speech_to_phrase
 
-LANGUAGES = ["en"]
+
+def _languages_with_s2p_blocks() -> list[str]:
+    """Every language that has at least one ``speech_to_phrase``-tagged block.
+
+    Discovered rather than hard-coded so adding a language's lean blocks does
+    not also require editing this list (and so a branch per language does not
+    collide here)."""
+    langs = []
+    for lang_dir in sorted(p for p in SENTENCES_DIR.iterdir() if p.is_dir()):
+        for combo_path in lang_dir.glob("*/*.yaml"):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            if any(b.get("speech_to_phrase") for b in data):
+                langs.append(lang_dir.name)
+                break
+    return langs
+
+
+LANGUAGES = _languages_with_s2p_blocks()
+
+_SLOT_REF = re.compile(r"\{([^{}]+)\}")
 
 
 def _load_expansion_rules(language: str) -> dict[str, str]:
@@ -44,10 +70,22 @@ def _load_expansion_rules(language: str) -> dict[str, str]:
     return rules
 
 
-def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
-    """Every phrasing a set of templates can produce, with slots left as literal
-    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
-    sides are compared on phrasing structure, not enumerated slot values."""
+def _list_name(ref: str) -> str:
+    """``timer_hours:hours`` -> ``timer_hours``; ``0..100`` -> ``_range``."""
+    name = ref.split(":", 1)[0].strip()
+    return "_range" if re.match(r"^-?\d+\s*\.\.", name) else name
+
+
+def _sentinel(list_name: str) -> str:
+    """A single word that cannot collide with real vocabulary."""
+    return "zz" + re.sub(r"[^a-z0-9]+", "", list_name.lower()) + "zz"
+
+
+def _lean_phrasings(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> set[str]:
+    """Every phrasing the lean templates produce, with each slot reference
+    replaced by its sentinel word."""
     intents = Intents.from_dict(
         {
             "language": language,
@@ -66,8 +104,47 @@ def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> se
                 expand_lists=False,
                 expand_ranges=False,
             ):
+                text = _SLOT_REF.sub(lambda m: _sentinel(_list_name(m.group(1))), text)
                 out.add(normalize_whitespace(text).strip())
     return out
+
+
+def _referenced_lists(sentences: list[str], rules: dict[str, str]) -> set[str]:
+    """List names reachable from these templates, following expansion rules."""
+    seen_rules: set[str] = set()
+    names: set[str] = set()
+    pending = list(sentences)
+    while pending:
+        text = pending.pop()
+        names.update(_list_name(m) for m in _SLOT_REF.findall(text))
+        for rule_name in re.findall(r"<([a-zA-Z0-9_]+)>", text):
+            if rule_name in rules and rule_name not in seen_rules:
+                seen_rules.add(rule_name)
+                pending.append(rules[rule_name])
+    return names
+
+
+def _rich_intents(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> tuple[Intents, dict[str, SlotList]]:
+    """Rich blocks as a recognizer, with every referenced list bound to its
+    sentinel so slot *contents* never affect the match."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {
+                "_S2P": {"data": [{"sentences": sentences, "slots": {"x": "y"}}]}
+            },
+            "expansion_rules": rules,
+        }
+    )
+    slot_lists: dict[str, SlotList] = {
+        name: TextSlotList.from_strings([_sentinel(name)])
+        for name in _referenced_lists(sentences, rules)
+    }
+    # An inline range (`{0..100}`) keeps its own ref text, so bind that too.
+    slot_lists.setdefault("_range", TextSlotList.from_strings([_sentinel("_range")]))
+    return intents, slot_lists
 
 
 def _collect() -> list[tuple[str, str, str]]:
@@ -98,17 +175,19 @@ def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
     ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
 
     rules = _load_expansion_rules(lang)
-    rich = _phrasings(
-        [s for block in ha_blocks for s in block["sentences"]], lang, rules
-    )
+    rich_sentences = [s for block in ha_blocks for s in block["sentences"]]
+    rich, slot_lists = _rich_intents(rich_sentences, lang, rules)
 
     for block in s2p_only:
-        lean = _phrasings(block["sentences"], lang, rules)
-        extra = lean - rich
+        extra = [
+            phrasing
+            for phrasing in sorted(_lean_phrasings(block["sentences"], lang, rules))
+            if recognize(phrasing, rich, slot_lists=slot_lists) is None
+        ]
         assert not extra, (
             f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
             f"not recognised by the Home Assistant (rich) block(s): "
-            f"{sorted(extra)[:10]}"
+            f"{extra[:10]}"
         )
 
 


### PR DESCRIPTION
Speech-to-Phrase builds a constrained FST grammar instead of matching with
hassil, so it consumes the `speech_to_phrase`-tagged subset of each slot
combination rather than the full block. Only English had those blocks, so the
add-on could not serve Italian even though a Italian acoustic model exists.

This adds **50 tagged blocks** covering the same 26 intents as English.

### How the sentences were chosen

Every sentence is a **restriction of Italian's own untagged templates** — taken
from what the rich blocks already accept, not newly invented phrasing. Home
Assistant's grammar is therefore unchanged: `partition_speech_to_phrase` drops
the tagged block whenever an untagged sibling exists, and the subset check
proves the lean language is contained in the rich one.

Italian ships no combo file for `HassFanSetSpeed/{default,name_only}`,
`HassLightSet/{brightness_only,floor_brightness}` or
`HassMediaPlayer{Mute,Unmute}/default`, so those six are not covered here.

### Verification

Each block's `example` was synthesized with the Italian Home Assistant Cloud TTS
voice and decoded through the real Speech-to-Phrase grammar (`stt_it_conformer_ctc_large`), then
scored on whether hassil resolves the transcript back to the command that was
spoken — not on string equality, since the decoder legitimately picks a
different in-grammar realization (articles drop, numbers are spelled out).

**50/50 examples resolve to the correct command.**

`script/test` and `python3 -m script.intentfest validate --language it` both pass.

### Note on the shared test change

`tests/test_speech_to_phrase.py` now discovers languages from the tagged blocks
instead of a hard-coded `["en"]`, and checks containment by *matching* each lean
phrasing against the rich blocks rather than enumerating both sides. Enumeration
does not scale past English — the Spanish `HassTurnOn` blocks expand far enough
to exhaust memory — while matching is linear in the (small) lean side and gives
the same answer. Verified against a planted violation to confirm it still fails
when it should.

That change is **byte-identical in all seven of these language PRs**, so
whichever merges first makes it a no-op for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)