### PR TITLE
[nl] Add Speech-to-Phrase lean sentence blocks

### DIFF
--- a/sentences/nl/HassCancelTimer/default.yaml
+++ b/sentences/nl/HassCancelTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "[<my>] <timer> (stoppen|annuleren|[op] stop zetten)"
     example: "annuleer timer"
     response: "default"
+  - sentences:
+      - "stop de timer"
+    example: "stop de timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/nl/HassClimateGetTemperature/area_only.yaml
@@ -10,3 +10,8 @@ data:
       - "Wat is de {area}[ ]temperatuur"
     example: "wat is de temperatuur in de woonkamer"
     response: "default"
+  - sentences:
+      - "Wat is de temperatuur in [de|het] {area}"
+    example: "Wat is de temperatuur in de Keuken"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassClimateGetTemperature/default.yaml
+++ b/sentences/nl/HassClimateGetTemperature/default.yaml
@@ -10,3 +10,8 @@ data:
       - "hoe (warm|koud|heet|koel) is het [<here>]"
     example: "wat is de temperatuur"
     response: "default"
+  - sentences:
+      - "wat is de temperatuur"
+    example: "wat is de temperatuur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/nl/HassClimateGetTemperature/name_only.yaml
@@ -12,3 +12,10 @@ data:
     name_domains:
       - "climate"
     response: "default"
+  - sentences:
+      - "Wat is de temperatuur van [de|het] {name}"
+    example: "Wat is de temperatuur van de Thermostaat"
+    name_domains:
+      - "climate"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/nl/HassDecreaseTimer/hours_only.yaml
@@ -11,3 +11,8 @@ data:
       - "[de|mijn|m'n] <timer> met {timer_hours:hours} (uur[tje]|uren|uurtjes) (verkorten|inkorten)"
     example: "haal 1 uur van timer af"
     response: "default"
+  - sentences:
+      - "verkort de timer met {timer_hours:hours} (uur|uren)"
+    example: "verkort de timer met 2 uur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/nl/HassDecreaseTimer/minutes_only.yaml
@@ -13,3 +13,8 @@ data:
       - "verkort [de|mijn|m'n] <timer> met {timer_half:minutes} uur[tje]"
     example: "haal 5 minuten van timer af"
     response: "default"
+  - sentences:
+      - "verkort de timer met {timer_minutes:minutes} (minuut|minuten)"
+    example: "verkort de timer met 5 minuut"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/nl/HassDecreaseTimer/seconds_only.yaml
@@ -13,3 +13,8 @@ data:
       - "verkort [de|mijn|m'n] <timer> met {timer_half:seconds} minuut[je]"
     example: "haal 30 seconden van timer af"
     response: "default"
+  - sentences:
+      - "verkort de timer met {timer_seconds:seconds} seconde[s|n]"
+    example: "verkort de timer met 30 secondes"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassFanSetSpeed/default.yaml
+++ b/sentences/nl/HassFanSetSpeed/default.yaml
@@ -9,3 +9,8 @@ data:
       - "[<numeric_value_set>] [de] snelheid [van] <fan> [<here>] [<to>] {fan_speed:percentage}[%| procent]"
     example: "zet de fansnelheid op 50%"
     response: "default"
+  - sentences:
+      - "zet de snelheid van de ventilator op {fan_speed:percentage} procent"
+    example: "zet de snelheid van de ventilator op 50 procent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassFanSetSpeed/name_only.yaml
+++ b/sentences/nl/HassFanSetSpeed/name_only.yaml
@@ -11,3 +11,10 @@ data:
     name_domains:
       - "fan"
     response: "default"
+  - sentences:
+      - "zet de snelheid van [de|het] {name} op {fan_speed:percentage} procent"
+    example: "zet de snelheid van de Plafondventilator op 50 procent"
+    name_domains:
+      - "fan"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassGetCurrentDate/default.yaml
+++ b/sentences/nl/HassGetCurrentDate/default.yaml
@@ -10,3 +10,8 @@ data:
       - "(vertel me|geef me) de [huidige] (datum|dag)"
     example: "wat is de datum"
     response: "default"
+  - sentences:
+      - "welke datum is het vandaag"
+    example: "welke datum is het vandaag"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassGetCurrentTime/default.yaml
+++ b/sentences/nl/HassGetCurrentTime/default.yaml
@@ -12,3 +12,8 @@ data:
       - "(vertel me|geef me) de [huidige] tijd"
     example: "hoe laat is het"
     response: "default"
+  - sentences:
+      - "hoe laat is het"
+    example: "hoe laat is het"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassGetState/name_only.yaml
+++ b/sentences/nl/HassGetState/name_only.yaml
@@ -20,3 +20,10 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  - sentences:
+      - "wat is de waarde van [de|het] {name}"
+    example: "wat is de waarde van de Buitentemperatuur"
+    name_domains:
+      - sensor
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/nl/HassGetState/name_state.yaml
+++ b/sentences/nl/HassGetState/name_state.yaml
@@ -49,3 +49,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  - sentences:
+      - "is [de|het] {name} {on_off_states:state}"
+    example: "is de Lamp A aan"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "is [de|het] {name} {cover_states:state}"
+    example: "is de Gordijn Links open"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "is [de|het] {name} {lock_states:state}"
+    example: "is de Voordeur dicht"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/nl/HassGetWeather/default.yaml
+++ b/sentences/nl/HassGetWeather/default.yaml
@@ -8,3 +8,8 @@ data:
       - "(wat|hoe) is (het [huidige] weer|de [huidige] weersvoorspelling) [buiten]"
     example: "wat voor weer is het"
     response: "default"
+  - sentences:
+      - "wat voor weer is het"
+    example: "wat voor weer is het"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/nl/HassIncreaseTimer/hours_only.yaml
@@ -10,3 +10,8 @@ data:
       - "aan [de|mijn|m'n] <timer> {timer_hours:hours} (uur[tje]|uren|uurtjes) toevoegen"
     example: "voeg 1 uur toe aan timer"
     response: "default"
+  - sentences:
+      - "verleng de timer met {timer_hours:hours} (uur|uren)"
+    example: "verleng de timer met 2 uur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/nl/HassIncreaseTimer/minutes_only.yaml
@@ -12,3 +12,8 @@ data:
       - "verleng [de|mijn|m'n] <timer> met {timer_half:minutes} uur[tje]"
     example: "voeg 5 minuten toe aan timer"
     response: "default"
+  - sentences:
+      - "verleng de timer met {timer_minutes:minutes} (minuut|minuten)"
+    example: "verleng de timer met 5 minuut"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/nl/HassIncreaseTimer/seconds_only.yaml
@@ -12,3 +12,8 @@ data:
       - "verleng [de|mijn|m'n] <timer> met {timer_half:seconds} minuut[je]"
     example: "voeg 30 seconden toe aan timer"
     response: "default"
+  - sentences:
+      - "verleng de timer met {timer_seconds:seconds} seconde[s|n]"
+    example: "verleng de timer met 30 secondes"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassLightSet/area_brightness.yaml
+++ b/sentences/nl/HassLightSet/area_brightness.yaml
@@ -27,3 +27,9 @@ data:
     example: "zet de slaapkamer op de minimale helderheid"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "zet de helderheid in [de|het] {area} op {brightness} procent"
+    example: "zet de helderheid in de Keuken op 50 procent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/nl/HassLightSet/brightness_only.yaml
+++ b/sentences/nl/HassLightSet/brightness_only.yaml
@@ -25,3 +25,9 @@ data:
     example: "zet de helderheid naar maximaal"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "zet de helderheid op {brightness} procent"
+    example: "zet de helderheid op 50 procent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/nl/HassLightSet/floor_brightness.yaml
+++ b/sentences/nl/HassLightSet/floor_brightness.yaml
@@ -16,3 +16,9 @@ data:
     example: "zet de helderheid op de eerste verdieping naar 50%"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "zet de helderheid in [de|het] {floor} op {brightness} procent"
+    example: "zet de helderheid in de Eerste Verdieping op 50 procent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/nl/HassLightSet/name_brightness.yaml
+++ b/sentences/nl/HassLightSet/name_brightness.yaml
@@ -28,3 +28,10 @@ data:
     name_domains:
       - "light"
     response: "brightness"
+  - sentences:
+      - "zet de helderheid van [de|het] {name} op {brightness} procent"
+    example: "zet de helderheid van de Lamp A op 50 procent"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/nl/HassMediaNext/default.yaml
+++ b/sentences/nl/HassMediaNext/default.yaml
@@ -13,3 +13,8 @@ data:
       - "[de|het] volgende <media_item> (opzetten|afspelen)"
     example: "volgende"
     response: "default"
+  - sentences:
+      - "het volgende nummer"
+    example: "het volgende nummer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassMediaPause/default.yaml
+++ b/sentences/nl/HassMediaPause/default.yaml
@@ -12,3 +12,8 @@ data:
       - "[zet [[de|het] (lied[je[s]]|nummer[s]|track[s]|item[s]|aflevering[en]|video[s]|film[pje][s]|muziek[je[s]]|playlist[s]|afspeellijst[en])] op] (pauze|stop)"
     example: "pauzeren"
     response: "default"
+  - sentences:
+      - "pauzeer"
+    example: "pauzeer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassMediaPlayerMute/default.yaml
+++ b/sentences/nl/HassMediaPlayerMute/default.yaml
@@ -17,3 +17,8 @@ data:
       - "zet [<here>] het geluid (van [de] (muziek|media[ ][player[s]|speler[s]]);uit)"
     example: "dempen"
     response: "default"
+  - sentences:
+      - "zet het geluid uit"
+    example: "zet het geluid uit"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/nl/HassMediaPlayerUnmute/default.yaml
@@ -13,3 +13,8 @@ data:
       - "zet [<here>] het geluid (van [de] (muziek|media[ ][player[s]|speler[s]]);[weer] aan)"
     example: "zet het geluid aan"
     response: "default"
+  - sentences:
+      - "zet het geluid aan"
+    example: "zet het geluid aan"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassMediaPrevious/default.yaml
+++ b/sentences/nl/HassMediaPrevious/default.yaml
@@ -12,3 +12,8 @@ data:
       - "[de|het] vorige <media_item> (opzetten|afspelen)"
     example: "vorige"
     response: "default"
+  - sentences:
+      - "het vorige nummer"
+    example: "het vorige nummer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassMediaUnpause/default.yaml
+++ b/sentences/nl/HassMediaUnpause/default.yaml
@@ -12,3 +12,8 @@ data:
       - "ga verder met [de|het] <media_item>"
     example: "hervatten"
     response: "default"
+  - sentences:
+      - "hervat"
+    example: "hervat"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassNevermind/default.yaml
+++ b/sentences/nl/HassNevermind/default.yaml
@@ -7,5 +7,11 @@ data:
   - sentences:
       - "laat maar [zitten]"
       - "annuleer"
-    example: "nevermind"
+    example: "laat maar zitten"
     response: "default"
+  - sentences:
+      - "laat maar zitten"
+      - "annuleer"
+    example: "laat maar zitten"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassPauseTimer/default.yaml
+++ b/sentences/nl/HassPauseTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "[<my>] <timer> (pauzeren|op pauze zetten)"
     example: "pauzeer timer"
     response: "default"
+  - sentences:
+      - "pauzeer de timer"
+    example: "pauzeer de timer"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassSetPosition/name_only.yaml
+++ b/sentences/nl/HassSetPosition/name_only.yaml
@@ -24,3 +24,17 @@ data:
     name_domains:
       - "valve"
     response: "default"
+  - sentences:
+      - "zet de positie van [de|het] {name} op {position} procent"
+    example: "zet de positie van de Gordijn Links op 50 procent"
+    name_domains:
+      - "cover"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "zet [de|het] {name} op {position} procent"
+    example: "zet de Waterklep op 50 procent"
+    name_domains:
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassSetVolume/default.yaml
+++ b/sentences/nl/HassSetVolume/default.yaml
@@ -10,3 +10,8 @@ data:
       - "({volume:volume_level}[[ ]%|procent];volume)"
     example: "zet het volume naar 90 procent"
     response: "default"
+  - sentences:
+      - "zet het volume op {volume:volume_level} procent"
+    example: "zet het volume op 50 procent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassSetVolumeRelative/default.yaml
+++ b/sentences/nl/HassSetVolumeRelative/default.yaml
@@ -19,3 +19,10 @@ data:
       - "[het] volume [met] {volume_step_down:volume_step}[%| procent] (omlaag|lager|naar beneden) (zetten|draaien)"
     example: "verhoog het volume"
     response: "default"
+  - sentences:
+      - "volume {volume_step}"
+      - "verhoog het volume met {volume_step_up:volume_step} procent"
+      - "verlaag het volume met {volume_step_down:volume_step} procent"
+    example: "volume hoger"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassStartTimer/hours_only.yaml
+++ b/sentences/nl/HassStartTimer/hours_only.yaml
@@ -10,3 +10,8 @@ data:
       - "<timer> (van|voor|op) {timer_hours:hours} (uur[tje]|uren|uurtjes)"
     example: "timer voor 1 uur"
     response: "default"
+  - sentences:
+      - "zet een timer van {timer_hours:hours} (uur|uren)"
+    example: "zet een timer van 2 uur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassStartTimer/minutes_only.yaml
+++ b/sentences/nl/HassStartTimer/minutes_only.yaml
@@ -14,3 +14,8 @@ data:
       - "<timer> (van|voor|op) {timer_one_and_a_half:minutes} uur[tje]"
     example: "timer voor 5 minuten"
     response: "default"
+  - sentences:
+      - "zet een timer van {timer_minutes:minutes} (minuut|minuten)"
+    example: "zet een timer van 5 minuut"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassStartTimer/seconds_only.yaml
+++ b/sentences/nl/HassStartTimer/seconds_only.yaml
@@ -14,3 +14,8 @@ data:
       - "<timer> (van|voor|op) {timer_one_and_a_half:seconds} minuut[je]"
     example: "timer voor 45 seconden"
     response: "default"
+  - sentences:
+      - "zet een timer van {timer_seconds:seconds} seconde[s|n]"
+    example: "zet een timer van 30 secondes"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassTimerStatus/default.yaml
+++ b/sentences/nl/HassTimerStatus/default.yaml
@@ -9,5 +9,10 @@ data:
       - "[hoe veel] tijd [is] [er] [nog] over (op|van|voor) [<my>] <timer>[s]"
       - "hoe lang (is|moet) [<my>] <timer> nog"
       - "hoe lang (zijn|moeten) [<my>] <timer>s nog"
-    example: "timer status"
+    example: "wat is de timer status"
     response: "default"
+  - sentences:
+      - "hoe lang is de timer nog"
+    example: "hoe lang is de timer nog"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassTurnOff/area_domain.yaml
+++ b/sentences/nl/HassTurnOff/area_domain.yaml
@@ -27,3 +27,15 @@ data:
     example: "doe de ventilatoren in de keuken uit"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "doe de lichten uit in [de|het] {area}"
+    example: "doe de lichten uit in de Keuken"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "doe de ventilator uit in [de|het] {area}"
+    example: "doe de ventilator uit in de Keuken"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/nl/HassTurnOff/domain_only.yaml
+++ b/sentences/nl/HassTurnOff/domain_only.yaml
@@ -24,3 +24,9 @@ data:
     example: "doe de ventilatoren uit"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "doe de lichten uit"
+    example: "doe de lichten uit"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/nl/HassTurnOff/name_only.yaml
+++ b/sentences/nl/HassTurnOff/name_only.yaml
@@ -48,3 +48,28 @@ data:
     name_domains:
       - "valve"
     response: "valve"
+  - sentences:
+      - "doe [de|het] {name} uit"
+    example: "doe de Lamp A uit"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "sluit [de|het] {name}"
+    example: "sluit de Gordijn Links"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "ontgrendel [de|het] {name}"
+    example: "ontgrendel de Voordeur"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/nl/HassTurnOn/area_domain.yaml
+++ b/sentences/nl/HassTurnOn/area_domain.yaml
@@ -30,3 +30,15 @@ data:
     example: "doe de ventilatoren in de keuken aan"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "doe de lichten aan in [de|het] {area}"
+    example: "doe de lichten aan in de Keuken"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "doe de ventilator aan in [de|het] {area}"
+    example: "doe de ventilator aan in de Keuken"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/nl/HassTurnOn/domain_only.yaml
+++ b/sentences/nl/HassTurnOn/domain_only.yaml
@@ -26,3 +26,9 @@ data:
     example: "doe de ventilatoren aan"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "doe de lichten aan"
+    example: "doe de lichten aan"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/nl/HassTurnOn/name_area.yaml
+++ b/sentences/nl/HassTurnOn/name_area.yaml
@@ -52,3 +52,14 @@ data:
     name_domains:
       - "valve"
     response: "valve"
+  - sentences:
+      - "doe [de|het] {name} in [de|het] {area} aan"
+    example: "doe de Lamp A in de Keuken aan"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/nl/HassTurnOn/name_only.yaml
+++ b/sentences/nl/HassTurnOn/name_only.yaml
@@ -49,3 +49,28 @@ data:
     name_domains:
       - "valve"
     response: "valve"
+  - sentences:
+      - "doe [de|het] {name} aan"
+    example: "doe de Lamp A aan"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "open [de|het] {name}"
+    example: "open de Gordijn Links"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "vergrendel [de|het] {name}"
+    example: "vergrendel de Voordeur"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/nl/HassUnpauseTimer/default.yaml
+++ b/sentences/nl/HassUnpauseTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "[<my>] <timer> (hervatten|weer aan zetten)"
     example: "hervat timer"
     response: "default"
+  - sentences:
+      - "hervat de timer"
+    example: "hervat de timer"
+    response: "default"
+    speech_to_phrase: true

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,4 +1,4 @@
-"""Speech-to-Phrase subset verification (Method B).
+"""Speech-to-Phrase subset verification.
 
 A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
 the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
@@ -6,24 +6,31 @@ also has untagged (rich) blocks, Home Assistant drops the tagged block from its
 grammar (see ``partition_speech_to_phrase`` and the loader in
 ``test_slot_combinations.py``). That is only sound if the lean block's language
 is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
-recognise a phrasing HA never would.
+recognise a phrasing Home Assistant never would.
 
-We verify containment by enumeration rather than with an FST/OpenFST toolchain:
-lean blocks are finite and small by construction, so we expand every phrasing on
-both sides (slots rendered as literal ``{list}`` sentinels via
-``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
-complete for the lean side (no recursion, bounded fan-out) and needs no slot
-lists, entities, or intent context.
+Containment is checked by *matching*, not by enumerating both sides. The lean
+side is enumerated (it is small and non-recursive by construction) and each
+phrasing is then handed to hassil's recognizer built from the rich blocks: if
+the rich grammar accepts it, it is in the rich language. Enumerating the rich
+side instead is what the first version of this test did, and it does not scale
+-- English is small enough to get away with it, but e.g. the Spanish
+``HassTurnOn`` blocks expand into billions of phrasings and exhaust memory.
 
-Only English is wired up for now; the collector is language-agnostic.
+Slots are neutralised on both sides: every ``{list}`` reference is replaced with
+a per-list sentinel word, and the rich grammar gets a one-value text list for
+each, so matching compares phrasing structure rather than slot contents (which
+would need entities, areas and floors that this test deliberately does not load).
+
+Languages are discovered from the tagged blocks themselves.
 """
 
 import importlib
+import re
 from typing import Any
 
 import pytest
 import yaml
-from hassil import Intents, normalize_whitespace
+from hassil import Intents, SlotList, TextSlotList, normalize_whitespace, recognize
 from hassil.sample import sample_sentence
 
 from . import RULES_DIR, SENTENCES_DIR
@@ -31,7 +38,26 @@ from . import RULES_DIR, SENTENCES_DIR
 _util: Any = importlib.import_module("script.intentfest.util")
 partition_speech_to_phrase = _util.partition_speech_to_phrase
 
-LANGUAGES = ["en"]
+
+def _languages_with_s2p_blocks() -> list[str]:
+    """Every language that has at least one ``speech_to_phrase``-tagged block.
+
+    Discovered rather than hard-coded so adding a language's lean blocks does
+    not also require editing this list (and so a branch per language does not
+    collide here)."""
+    langs = []
+    for lang_dir in sorted(p for p in SENTENCES_DIR.iterdir() if p.is_dir()):
+        for combo_path in lang_dir.glob("*/*.yaml"):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            if any(b.get("speech_to_phrase") for b in data):
+                langs.append(lang_dir.name)
+                break
+    return langs
+
+
+LANGUAGES = _languages_with_s2p_blocks()
+
+_SLOT_REF = re.compile(r"\{([^{}]+)\}")
 
 
 def _load_expansion_rules(language: str) -> dict[str, str]:
@@ -44,10 +70,22 @@ def _load_expansion_rules(language: str) -> dict[str, str]:
     return rules
 
 
-def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
-    """Every phrasing a set of templates can produce, with slots left as literal
-    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
-    sides are compared on phrasing structure, not enumerated slot values."""
+def _list_name(ref: str) -> str:
+    """``timer_hours:hours`` -> ``timer_hours``; ``0..100`` -> ``_range``."""
+    name = ref.split(":", 1)[0].strip()
+    return "_range" if re.match(r"^-?\d+\s*\.\.", name) else name
+
+
+def _sentinel(list_name: str) -> str:
+    """A single word that cannot collide with real vocabulary."""
+    return "zz" + re.sub(r"[^a-z0-9]+", "", list_name.lower()) + "zz"
+
+
+def _lean_phrasings(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> set[str]:
+    """Every phrasing the lean templates produce, with each slot reference
+    replaced by its sentinel word."""
     intents = Intents.from_dict(
         {
             "language": language,
@@ -66,8 +104,47 @@ def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> se
                 expand_lists=False,
                 expand_ranges=False,
             ):
+                text = _SLOT_REF.sub(lambda m: _sentinel(_list_name(m.group(1))), text)
                 out.add(normalize_whitespace(text).strip())
     return out
+
+
+def _referenced_lists(sentences: list[str], rules: dict[str, str]) -> set[str]:
+    """List names reachable from these templates, following expansion rules."""
+    seen_rules: set[str] = set()
+    names: set[str] = set()
+    pending = list(sentences)
+    while pending:
+        text = pending.pop()
+        names.update(_list_name(m) for m in _SLOT_REF.findall(text))
+        for rule_name in re.findall(r"<([a-zA-Z0-9_]+)>", text):
+            if rule_name in rules and rule_name not in seen_rules:
+                seen_rules.add(rule_name)
+                pending.append(rules[rule_name])
+    return names
+
+
+def _rich_intents(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> tuple[Intents, dict[str, SlotList]]:
+    """Rich blocks as a recognizer, with every referenced list bound to its
+    sentinel so slot *contents* never affect the match."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {
+                "_S2P": {"data": [{"sentences": sentences, "slots": {"x": "y"}}]}
+            },
+            "expansion_rules": rules,
+        }
+    )
+    slot_lists: dict[str, SlotList] = {
+        name: TextSlotList.from_strings([_sentinel(name)])
+        for name in _referenced_lists(sentences, rules)
+    }
+    # An inline range (`{0..100}`) keeps its own ref text, so bind that too.
+    slot_lists.setdefault("_range", TextSlotList.from_strings([_sentinel("_range")]))
+    return intents, slot_lists
 
 
 def _collect() -> list[tuple[str, str, str]]:
@@ -98,17 +175,19 @@ def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
     ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
 
     rules = _load_expansion_rules(lang)
-    rich = _phrasings(
-        [s for block in ha_blocks for s in block["sentences"]], lang, rules
-    )
+    rich_sentences = [s for block in ha_blocks for s in block["sentences"]]
+    rich, slot_lists = _rich_intents(rich_sentences, lang, rules)
 
     for block in s2p_only:
-        lean = _phrasings(block["sentences"], lang, rules)
-        extra = lean - rich
+        extra = [
+            phrasing
+            for phrasing in sorted(_lean_phrasings(block["sentences"], lang, rules))
+            if recognize(phrasing, rich, slot_lists=slot_lists) is None
+        ]
         assert not extra, (
             f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
             f"not recognised by the Home Assistant (rich) block(s): "
-            f"{sorted(extra)[:10]}"
+            f"{extra[:10]}"
         )
 
 


### PR DESCRIPTION
Speech-to-Phrase builds a constrained FST grammar instead of matching with
hassil, so it consumes the `speech_to_phrase`-tagged subset of each slot
combination rather than the full block. Only English had those blocks, so the
add-on could not serve Dutch even though a Dutch acoustic model exists.

This adds **53 tagged blocks** covering the same 26 intents as English.

### How the sentences were chosen

Every sentence is a **restriction of Dutch's own untagged templates** — taken
from what the rich blocks already accept, not newly invented phrasing. Home
Assistant's grammar is therefore unchanged: `partition_speech_to_phrase` drops
the tagged block whenever an untagged sibling exists, and the subset check
proves the lean language is contained in the rich one.

Dutch ships no `HassTurnOn/floor_domain` or `HassTurnOff/floor_domain` combo
file, so those two are not covered here.

### Verification

Each block's `example` was synthesized with the Dutch Home Assistant Cloud TTS
voice and decoded through the real Speech-to-Phrase grammar (`stt_nl_citrinet_256`), then
scored on whether hassil resolves the transcript back to the command that was
spoken — not on string equality, since the decoder legitimately picks a
different in-grammar realization (articles drop, numbers are spelled out).

**53/53 examples resolve to the correct command.**

`script/test` and `python3 -m script.intentfest validate --language nl` both pass.

### Note on the shared test change

`tests/test_speech_to_phrase.py` now discovers languages from the tagged blocks
instead of a hard-coded `["en"]`, and checks containment by *matching* each lean
phrasing against the rich blocks rather than enumerating both sides. Enumeration
does not scale past English — the Spanish `HassTurnOn` blocks expand far enough
to exhaust memory — while matching is linear in the (small) lean side and gives
the same answer. Verified against a planted violation to confirm it still fails
when it should.

That change is **byte-identical in all seven of these language PRs**, so
whichever merges first makes it a no-op for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)