### PR TITLE
[ca] Add Speech-to-Phrase lean sentence blocks

### DIFF
--- a/sentences/ca/HassCancelTimer/default.yaml
+++ b/sentences/ca/HassCancelTimer/default.yaml
@@ -7,3 +7,8 @@ data:
       - "(cancel[·l]a|atura|para|deixa|elimina)[r|t] [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre)"
     example: "cancel·la el temporitzador"
     response: "default"
+  - sentences:
+      - "atura el temporitzador"
+    example: "atura el temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/ca/HassClimateGetTemperature/area_only.yaml
@@ -11,3 +11,8 @@ data:
       - "(quanta|quina) calor [que] fa [<actual>] [<preposicio_singular>]{area}"
     example: "quina temperatura fa al dormitori"
     response: "default"
+  - sentences:
+      - "quina és la temperatura a [<pronom_singular>]{area}"
+    example: "quina és la temperatura a el Cuina"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassClimateGetTemperature/default.yaml
+++ b/sentences/ca/HassClimateGetTemperature/default.yaml
@@ -11,3 +11,8 @@ data:
       - "(quanta|quina) calor [que] fa [<actual>]"
     example: "quina temperatura fa"
     response: "default"
+  - sentences:
+      - "quina és la temperatura"
+    example: "quina és la temperatura"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/ca/HassClimateGetTemperature/name_only.yaml
@@ -13,3 +13,10 @@ data:
     name_domains:
       - "climate"
     response: "default"
+  - sentences:
+      - "quina és la temperatura del {name}"
+    example: "quina és la temperatura del Termòstat dormitori"
+    name_domains:
+      - "climate"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/ca/HassDecreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "([a]baixa|treu|resta|redueix)[r|-li] (a|al|de|del) [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre) [uns] {timer_hours:hours} (hora|hores)"
     example: "treu 1 hora al temporitzador"
     response: "default"
+  - sentences:
+      - "treu {timer_hours:hours} (hora|hores) del temporitzador"
+    example: "treu 2 hora del temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/ca/HassDecreaseTimer/minutes_only.yaml
@@ -9,3 +9,8 @@ data:
       - "([a]baixa|treu|resta|redueix)[r|-li] (a|al|de|del) [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre) [uns] {timer_minutes:minutes} minut[s]"
     example: "treu 5 minuts al temporitzador"
     response: "default"
+  - sentences:
+      - "treu {timer_minutes:minutes} minut[s] del temporitzador"
+    example: "treu 5 minuts del temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/ca/HassDecreaseTimer/seconds_only.yaml
@@ -9,3 +9,8 @@ data:
       - "([a]baixa|treu|resta|redueix)[r|-li] (a|al|de|del) [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre) [uns] {timer_seconds:seconds} segon[s]"
     example: "treu 30 segons al temporitzador"
     response: "default"
+  - sentences:
+      - "treu {timer_seconds:seconds} segon[s] del temporitzador"
+    example: "treu 30 segons del temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassFanSetSpeed/default.yaml
+++ b/sentences/ca/HassFanSetSpeed/default.yaml
@@ -10,3 +10,8 @@ data:
       - "<configura> [el|els] ventilador[s] [d'aqu(i|í)] (a|al) <fan_speed>"
     example: "posa els ventiladors al 50%"
     response: "default"
+  - sentences:
+      - "configura la velocitat del ventilador al {fan_speed:percentage} per cent"
+    example: "configura la velocitat del ventilador al 50 per cent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassFanSetSpeed/name_only.yaml
+++ b/sentences/ca/HassFanSetSpeed/name_only.yaml
@@ -13,3 +13,10 @@ data:
     name_domains:
       - "fan"
     response: "default"
+  - sentences:
+      - "configura la velocitat del {name} al {fan_speed:percentage} per cent"
+    example: "configura la velocitat del Ventilador sostre al 50 per cent"
+    name_domains:
+      - "fan"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassGetCurrentDate/default.yaml
+++ b/sentences/ca/HassGetCurrentDate/default.yaml
@@ -11,3 +11,8 @@ data:
       - "[avui|hui] quin[a] (dia|jorn|data) (és|som|estem)"
     example: "quin dia és avui"
     response: "default"
+  - sentences:
+      - "quin dia és avui"
+    example: "quin dia és avui"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassGetCurrentTime/default.yaml
+++ b/sentences/ca/HassGetCurrentTime/default.yaml
@@ -12,3 +12,8 @@ data:
       - "(saps|digues|diga|digue|dis)[-me|'m] (l'|s'|la )hora [d'ara [mateix]]"
     example: "quina hora és"
     response: "default"
+  - sentences:
+      - "quina hora és"
+    example: "quina hora és"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassGetState/name_only.yaml
+++ b/sentences/ca/HassGetState/name_only.yaml
@@ -20,3 +20,10 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  - sentences:
+      - "quin és el valor del {name}"
+    example: "quin és el valor del Temperatura exterior"
+    name_domains:
+      - sensor
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/ca/HassGetState/name_state.yaml
+++ b/sentences/ca/HassGetState/name_state.yaml
@@ -47,3 +47,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  - sentences:
+      - "està [<pronom_singular>]{name} {on_off_states:state}"
+    example: "està el Ventilador sostre engegat"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "està [<pronom_singular>]{name} {cover_states:state}"
+    example: "està el Finestra cuina oberta"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "està [<pronom_singular>]{name} {lock_states:state}"
+    example: "està el Porta A bloquejat"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/ca/HassGetWeather/default.yaml
+++ b/sentences/ca/HassGetWeather/default.yaml
@@ -9,3 +9,8 @@ data:
       - "com és el temps"
     example: "what is the weather"
     response: "default"
+  - sentences:
+      - "quin temps fa"
+    example: "quin temps fa"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/ca/HassIncreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "(puja|apuja|aixeca|afeg[e]ix|posa)[r|-li] (a|al|de|del) [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre) [uns] {timer_hours:hours} (hora|hores)"
     example: "afegeix 1 hora al temporitzador"
     response: "default"
+  - sentences:
+      - "afegeix {timer_hours:hours} (hora|hores) al temporitzador"
+    example: "afegeix 2 hora al temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/ca/HassIncreaseTimer/minutes_only.yaml
@@ -9,3 +9,8 @@ data:
       - "(puja|apuja|aixeca|afeg[e]ix|posa)[r|-li] (a|al|de|del) [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre) [uns] {timer_minutes:minutes} minut[s]"
     example: "afegeix 5 minuts al temporitzador"
     response: "default"
+  - sentences:
+      - "afegeix {timer_minutes:minutes} minut[s] al temporitzador"
+    example: "afegeix 5 minuts al temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/ca/HassIncreaseTimer/seconds_only.yaml
@@ -9,3 +9,8 @@ data:
       - "(puja|apuja|aixeca|afeg[e]ix|posa)[r|-li] (a|al|de|del) [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre) [uns] {timer_seconds:seconds} segon[s]"
     example: "afegeix 30 segons al temporitzador"
     response: "default"
+  - sentences:
+      - "afegeix {timer_seconds:seconds} segon[s] al temporitzador"
+    example: "afegeix 30 segons al temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassLightSet/area_brightness.yaml
+++ b/sentences/ca/HassLightSet/area_brightness.yaml
@@ -12,3 +12,9 @@ data:
     example: "posa la brillantor del dormitori al 50%"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "configura la brillantor a [<pronom_singular>]{area} al {brightness} per cent"
+    example: "configura la brillantor a el Cuina al 50 per cent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/ca/HassLightSet/brightness_only.yaml
+++ b/sentences/ca/HassLightSet/brightness_only.yaml
@@ -11,3 +11,9 @@ data:
     example: "posa la brillantor al 50%"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "configura la brillantor al {brightness} per cent"
+    example: "configura la brillantor al 50 per cent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/ca/HassLightSet/floor_brightness.yaml
+++ b/sentences/ca/HassLightSet/floor_brightness.yaml
@@ -10,3 +10,9 @@ data:
     example: "posa la brillantor de la planta baixa al 50%"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "configura la brillantor de la planta {floor} al {brightness} per cent"
+    example: "configura la brillantor de la planta Planta baixa al 50 per cent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/ca/HassLightSet/name_brightness.yaml
+++ b/sentences/ca/HassLightSet/name_brightness.yaml
@@ -13,3 +13,10 @@ data:
     name_domains:
       - "light"
     response: "brightness"
+  - sentences:
+      - "configura la brillantor del {name} al {brightness} per cent"
+    example: "configura la brillantor del Llum A al 50 per cent"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/ca/HassMediaNext/default.yaml
+++ b/sentences/ca/HassMediaNext/default.yaml
@@ -11,3 +11,8 @@ data:
       - "[vull|pots] <reproduir> [a|amb] [<pronom_singular>] <seguent> <element>"
     example: "següent cançó"
     response: "default"
+  - sentences:
+      - "següent cançó"
+    example: "següent cançó"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassMediaPause/default.yaml
+++ b/sentences/ca/HassMediaPause/default.yaml
@@ -10,3 +10,8 @@ data:
       - "(atura|para|deté)[r] [la reproducció|la música]"
     example: "pausa"
     response: "default"
+  - sentences:
+      - "pausa"
+    example: "pausa"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassMediaPlayerMute/default.yaml
+++ b/sentences/ca/HassMediaPlayerMute/default.yaml
@@ -14,3 +14,8 @@ data:
       - "silencia la (m(u|ú)sica) [aqui]"
     example: "silencia"
     response: "default"
+  - sentences:
+      - "silencia"
+    example: "silencia"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/ca/HassMediaPlayerUnmute/default.yaml
@@ -16,3 +16,8 @@ data:
       - "desmote(ix|ja[r])"
     example: "dessilencia"
     response: "default"
+  - sentences:
+      - "activa el so"
+    example: "activa el so"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassMediaPrevious/default.yaml
+++ b/sentences/ca/HassMediaPrevious/default.yaml
@@ -14,3 +14,8 @@ data:
       - "<reproduir> <again>"
     example: "cançó anterior"
     response: "default"
+  - sentences:
+      - "posa la cançó anterior"
+    example: "posa la cançó anterior"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassMediaUnpause/default.yaml
+++ b/sentences/ca/HassMediaUnpause/default.yaml
@@ -9,3 +9,8 @@ data:
       - "<reactiva>"
     example: "reprèn"
     response: "default"
+  - sentences:
+      - "continua"
+    example: "continua"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassNevermind/default.yaml
+++ b/sentences/ca/HassNevermind/default.yaml
@@ -11,3 +11,9 @@ data:
       - "(deixa|oblida)-ho [tot]"
     example: "deixa-ho"
     response: "default"
+  - sentences:
+      - "res"
+      - "deixa-ho"
+    example: "res"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassPauseTimer/default.yaml
+++ b/sentences/ca/HassPauseTimer/default.yaml
@@ -7,3 +7,8 @@ data:
       - "(pausa[r]|posa[r] en espera) [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre)"
     example: "pausa el temporitzador"
     response: "default"
+  - sentences:
+      - "pausa el temporitzador"
+    example: "pausa el temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassSetPosition/name_only.yaml
+++ b/sentences/ca/HassSetPosition/name_only.yaml
@@ -12,3 +12,11 @@ data:
       - "cover"
       - "valve"
     response: "default"
+  - sentences:
+      - "configura la posició del {name} al {position} per cent"
+    example: "configura la posició del Finestra cuina al 50 per cent"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassSetVolume/default.yaml
+++ b/sentences/ca/HassSetVolume/default.yaml
@@ -9,3 +9,8 @@ data:
       - "(<pujar>|<baixar>|<configura>) ([el] (volum|so)|[la] veu) (a|al) {volume:volume_level}[<percent>]"
     example: "posa el volum al 50%"
     response: "default"
+  - sentences:
+      - "configura el volum al {volume:volume_level} per cent"
+    example: "configura el volum al 50 per cent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassSetVolumeRelative/default.yaml
+++ b/sentences/ca/HassSetVolumeRelative/default.yaml
@@ -21,3 +21,18 @@ data:
       - "(baixa|abaixa|disminueix|redueix)[r|-li] [el|la|més] (volum|so|veu) [per|un|al] {volume_step_down:volume_step}[%| per[ ]cent]"
     example: "baixa el volum un 10 per cent"
     response: "default"
+  - sentences:
+      - "volum {volume_step}"
+    example: "volum puja"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "puja el volum un {volume_step_up:volume_step} per cent"
+    example: "puja el volum un 10 per cent"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "baixa el volum un {volume_step_down:volume_step} per cent"
+    example: "baixa el volum un 10 per cent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassStartTimer/hours_only.yaml
+++ b/sentences/ca/HassStartTimer/hours_only.yaml
@@ -11,3 +11,9 @@ data:
       - "temporitzador (de|d'|per|per a) {timer_hours:hours} (hora|hores)"
     example: "temporitzador de 1 hora"
     response: "default"
+  - sentences:
+      - "posa un temporitzador de {timer_hours:hours} (hora|hores)"
+      - "temporitzador de {timer_hours:hours} (hora|hores)"
+    example: "posa un temporitzador de 2 hora"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassStartTimer/minutes_only.yaml
+++ b/sentences/ca/HassStartTimer/minutes_only.yaml
@@ -11,3 +11,9 @@ data:
       - "temporitzador (de|d'|per|per a) {timer_minutes:minutes} minut[s]"
     example: "temporitzador de 5 minuts"
     response: "default"
+  - sentences:
+      - "posa un temporitzador de {timer_minutes:minutes} minut[s]"
+      - "temporitzador de {timer_minutes:minutes} minut[s]"
+    example: "posa un temporitzador de 5 minuts"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassStartTimer/seconds_only.yaml
+++ b/sentences/ca/HassStartTimer/seconds_only.yaml
@@ -11,3 +11,9 @@ data:
       - "temporitzador (de|d'|per|per a) {timer_seconds:seconds} segon[s]"
     example: "temporitzador de 30 segons"
     response: "default"
+  - sentences:
+      - "posa un temporitzador de {timer_seconds:seconds} segon[s]"
+      - "temporitzador de {timer_seconds:seconds} segon[s]"
+    example: "posa un temporitzador de 30 segons"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassTimerStatus/default.yaml
+++ b/sentences/ca/HassTimerStatus/default.yaml
@@ -9,3 +9,8 @@ data:
       - "estat (de|del) (temporitzador|compte enrere|minuter|cronòmetre)[s]"
     example: "quant queda del temporitzador"
     response: "default"
+  - sentences:
+      - "estat del temporitzador"
+    example: "estat del temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOff/area_domain.yaml
+++ b/sentences/ca/HassTurnOff/area_domain.yaml
@@ -19,3 +19,15 @@ data:
     example: "apaga els ventiladors de la cuina"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "apaga els llums a [<pronom_singular>]{area}"
+    example: "apaga els llums a el Cuina"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "apaga els ventiladors a [<pronom_singular>]{area}"
+    example: "apaga els ventiladors a el Cuina"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOff/domain_only.yaml
+++ b/sentences/ca/HassTurnOff/domain_only.yaml
@@ -19,3 +19,9 @@ data:
     example: "apaga els ventiladors"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "apaga els llums"
+    example: "apaga els llums"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOff/floor_domain.yaml
+++ b/sentences/ca/HassTurnOff/floor_domain.yaml
@@ -11,3 +11,9 @@ data:
     example: "apaga els llums de la planta baixa"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "apaga els llums a la {floor}"
+    example: "apaga els llums a la Planta baixa"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOff/name_only.yaml
+++ b/sentences/ca/HassTurnOff/name_only.yaml
@@ -40,3 +40,28 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "apaga [<pronom_singular>]{name}"
+    example: "apaga el Ventilador sostre"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "tanca [<pronom_singular>]{name}"
+    example: "tanca la Finestra cuina"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "desbloqueja [<pronom_singular>]{name}"
+    example: "desbloqueja la Porta A"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOn/area_domain.yaml
+++ b/sentences/ca/HassTurnOn/area_domain.yaml
@@ -19,3 +19,15 @@ data:
     example: "encén els ventiladors de la cuina"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "engega els llums a [<pronom_singular>]{area}"
+    example: "engega els llums a el Cuina"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "engega els ventiladors a [<pronom_singular>]{area}"
+    example: "engega els ventiladors a el Cuina"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOn/domain_only.yaml
+++ b/sentences/ca/HassTurnOn/domain_only.yaml
@@ -19,3 +19,9 @@ data:
     example: "encén els ventiladors"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "engega els llums"
+    example: "engega els llums"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOn/floor_domain.yaml
+++ b/sentences/ca/HassTurnOn/floor_domain.yaml
@@ -12,3 +12,9 @@ data:
     example: "encén els llums de la planta baixa"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "engega els llums a la {floor}"
+    example: "engega els llums a la Planta baixa"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOn/name_area.yaml
+++ b/sentences/ca/HassTurnOn/name_area.yaml
@@ -40,3 +40,14 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "engega [<pronom_singular>]{name} a [<pronom_singular>]{area}"
+    example: "engega el Ventilador sostre a el Cuina"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/ca/HassTurnOn/name_only.yaml
+++ b/sentences/ca/HassTurnOn/name_only.yaml
@@ -41,3 +41,28 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "engega [<pronom_singular>]{name}"
+    example: "engega el Ventilador sostre"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "obre [<pronom_singular>]{name}"
+    example: "obre la Finestra cuina"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "bloqueja [<pronom_singular>]{name}"
+    example: "bloqueja la Porta A"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/ca/HassUnpauseTimer/default.yaml
+++ b/sentences/ca/HassUnpauseTimer/default.yaml
@@ -7,3 +7,8 @@ data:
       - "<reactiva> [el|la|els|les] [meu|meva] (temporitzador|compte enrere|minuter|cronòmetre)"
     example: "reprèn el temporitzador"
     response: "default"
+  - sentences:
+      - "continua el temporitzador"
+    example: "continua el temporitzador"
+    response: "default"
+    speech_to_phrase: true

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,4 +1,4 @@
-"""Speech-to-Phrase subset verification (Method B).
+"""Speech-to-Phrase subset verification.
 
 A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
 the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
@@ -6,24 +6,31 @@ also has untagged (rich) blocks, Home Assistant drops the tagged block from its
 grammar (see ``partition_speech_to_phrase`` and the loader in
 ``test_slot_combinations.py``). That is only sound if the lean block's language
 is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
-recognise a phrasing HA never would.
+recognise a phrasing Home Assistant never would.
 
-We verify containment by enumeration rather than with an FST/OpenFST toolchain:
-lean blocks are finite and small by construction, so we expand every phrasing on
-both sides (slots rendered as literal ``{list}`` sentinels via
-``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
-complete for the lean side (no recursion, bounded fan-out) and needs no slot
-lists, entities, or intent context.
+Containment is checked by *matching*, not by enumerating both sides. The lean
+side is enumerated (it is small and non-recursive by construction) and each
+phrasing is then handed to hassil's recognizer built from the rich blocks: if
+the rich grammar accepts it, it is in the rich language. Enumerating the rich
+side instead is what the first version of this test did, and it does not scale
+-- English is small enough to get away with it, but e.g. the Spanish
+``HassTurnOn`` blocks expand into billions of phrasings and exhaust memory.
 
-Only English is wired up for now; the collector is language-agnostic.
+Slots are neutralised on both sides: every ``{list}`` reference is replaced with
+a per-list sentinel word, and the rich grammar gets a one-value text list for
+each, so matching compares phrasing structure rather than slot contents (which
+would need entities, areas and floors that this test deliberately does not load).
+
+Languages are discovered from the tagged blocks themselves.
 """
 
 import importlib
+import re
 from typing import Any
 
 import pytest
 import yaml
-from hassil import Intents, normalize_whitespace
+from hassil import Intents, SlotList, TextSlotList, normalize_whitespace, recognize
 from hassil.sample import sample_sentence
 
 from . import RULES_DIR, SENTENCES_DIR
@@ -31,7 +38,26 @@ from . import RULES_DIR, SENTENCES_DIR
 _util: Any = importlib.import_module("script.intentfest.util")
 partition_speech_to_phrase = _util.partition_speech_to_phrase
 
-LANGUAGES = ["en"]
+
+def _languages_with_s2p_blocks() -> list[str]:
+    """Every language that has at least one ``speech_to_phrase``-tagged block.
+
+    Discovered rather than hard-coded so adding a language's lean blocks does
+    not also require editing this list (and so a branch per language does not
+    collide here)."""
+    langs = []
+    for lang_dir in sorted(p for p in SENTENCES_DIR.iterdir() if p.is_dir()):
+        for combo_path in lang_dir.glob("*/*.yaml"):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            if any(b.get("speech_to_phrase") for b in data):
+                langs.append(lang_dir.name)
+                break
+    return langs
+
+
+LANGUAGES = _languages_with_s2p_blocks()
+
+_SLOT_REF = re.compile(r"\{([^{}]+)\}")
 
 
 def _load_expansion_rules(language: str) -> dict[str, str]:
@@ -44,10 +70,22 @@ def _load_expansion_rules(language: str) -> dict[str, str]:
     return rules
 
 
-def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
-    """Every phrasing a set of templates can produce, with slots left as literal
-    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
-    sides are compared on phrasing structure, not enumerated slot values."""
+def _list_name(ref: str) -> str:
+    """``timer_hours:hours`` -> ``timer_hours``; ``0..100`` -> ``_range``."""
+    name = ref.split(":", 1)[0].strip()
+    return "_range" if re.match(r"^-?\d+\s*\.\.", name) else name
+
+
+def _sentinel(list_name: str) -> str:
+    """A single word that cannot collide with real vocabulary."""
+    return "zz" + re.sub(r"[^a-z0-9]+", "", list_name.lower()) + "zz"
+
+
+def _lean_phrasings(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> set[str]:
+    """Every phrasing the lean templates produce, with each slot reference
+    replaced by its sentinel word."""
     intents = Intents.from_dict(
         {
             "language": language,
@@ -66,8 +104,47 @@ def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> se
                 expand_lists=False,
                 expand_ranges=False,
             ):
+                text = _SLOT_REF.sub(lambda m: _sentinel(_list_name(m.group(1))), text)
                 out.add(normalize_whitespace(text).strip())
     return out
+
+
+def _referenced_lists(sentences: list[str], rules: dict[str, str]) -> set[str]:
+    """List names reachable from these templates, following expansion rules."""
+    seen_rules: set[str] = set()
+    names: set[str] = set()
+    pending = list(sentences)
+    while pending:
+        text = pending.pop()
+        names.update(_list_name(m) for m in _SLOT_REF.findall(text))
+        for rule_name in re.findall(r"<([a-zA-Z0-9_]+)>", text):
+            if rule_name in rules and rule_name not in seen_rules:
+                seen_rules.add(rule_name)
+                pending.append(rules[rule_name])
+    return names
+
+
+def _rich_intents(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> tuple[Intents, dict[str, SlotList]]:
+    """Rich blocks as a recognizer, with every referenced list bound to its
+    sentinel so slot *contents* never affect the match."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {
+                "_S2P": {"data": [{"sentences": sentences, "slots": {"x": "y"}}]}
+            },
+            "expansion_rules": rules,
+        }
+    )
+    slot_lists: dict[str, SlotList] = {
+        name: TextSlotList.from_strings([_sentinel(name)])
+        for name in _referenced_lists(sentences, rules)
+    }
+    # An inline range (`{0..100}`) keeps its own ref text, so bind that too.
+    slot_lists.setdefault("_range", TextSlotList.from_strings([_sentinel("_range")]))
+    return intents, slot_lists
 
 
 def _collect() -> list[tuple[str, str, str]]:
@@ -98,17 +175,19 @@ def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
     ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
 
     rules = _load_expansion_rules(lang)
-    rich = _phrasings(
-        [s for block in ha_blocks for s in block["sentences"]], lang, rules
-    )
+    rich_sentences = [s for block in ha_blocks for s in block["sentences"]]
+    rich, slot_lists = _rich_intents(rich_sentences, lang, rules)
 
     for block in s2p_only:
-        lean = _phrasings(block["sentences"], lang, rules)
-        extra = lean - rich
+        extra = [
+            phrasing
+            for phrasing in sorted(_lean_phrasings(block["sentences"], lang, rules))
+            if recognize(phrasing, rich, slot_lists=slot_lists) is None
+        ]
         assert not extra, (
             f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
             f"not recognised by the Home Assistant (rich) block(s): "
-            f"{sorted(extra)[:10]}"
+            f"{extra[:10]}"
         )
 
 


### PR DESCRIPTION
Speech-to-Phrase builds a constrained FST grammar instead of matching with
hassil, so it consumes the `speech_to_phrase`-tagged subset of each slot
combination rather than the full block. Only English had those blocks, so the
add-on could not serve Catalan even though a Catalan acoustic model exists.

This adds **56 tagged blocks** covering the same 26 intents as English.

### How the sentences were chosen

Every sentence is a **restriction of Catalan's own untagged templates** — taken
from what the rich blocks already accept, not newly invented phrasing. Home
Assistant's grammar is therefore unchanged: `partition_speech_to_phrase` drops
the tagged block whenever an untagged sibling exists, and the subset check
proves the lean language is contained in the rich one.

Templates use the `del` contraction rather than `de` followed by an article
slot, which would render "de el X" — not Catalan, and not decodable.

### Verification

Each block's `example` was synthesized with the Catalan Home Assistant Cloud TTS
voice and decoded through the real Speech-to-Phrase grammar (`stt_ca_conformer_ctc_large`), then
scored on whether hassil resolves the transcript back to the command that was
spoken — not on string equality, since the decoder legitimately picks a
different in-grammar realization (articles drop, numbers are spelled out).

**56/56 examples resolve to the correct command.**

`script/test` and `python3 -m script.intentfest validate --language ca` both pass.

### Note on the shared test change

`tests/test_speech_to_phrase.py` now discovers languages from the tagged blocks
instead of a hard-coded `["en"]`, and checks containment by *matching* each lean
phrasing against the rich blocks rather than enumerating both sides. Enumeration
does not scale past English — the Spanish `HassTurnOn` blocks expand far enough
to exhaust memory — while matching is linear in the (small) lean side and gives
the same answer. Verified against a planted violation to confirm it still fails
when it should.

That change is **byte-identical in all seven of these language PRs**, so
whichever merges first makes it a no-op for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)