### PR TITLE
[es] Add Speech-to-Phrase lean sentence blocks

### DIFF
--- a/sentences/es/HassCancelTimer/default.yaml
+++ b/sentences/es/HassCancelTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "<timer_cancel> [mi] <temporizador>"
     example: "cancelar temporizador"
     response: "default"
+  - sentences:
+      - "cancela [el ]temporizador"
+    example: "cancela el temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/es/HassClimateGetTemperature/area_only.yaml
@@ -13,3 +13,8 @@ data:
       - "hace (frío|calor) [([en|de] [el|la|los|las]|del)] {area}"
     example: "¿qué temperatura hace en la cocina?"
     response: "default"
+  - sentences:
+      - "cuál es la temperatura (en el|en la) {area}"
+    example: "cuál es la temperatura en el Cocina"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassClimateGetTemperature/default.yaml
+++ b/sentences/es/HassClimateGetTemperature/default.yaml
@@ -10,3 +10,8 @@ data:
       - "[a] (cuánta|cuánto|cuántos|qué) <temp> (hace|hay|estamos) [ahora [mismo]|actual[mente]|en este momento]"
     example: "¿cuál es la temperatura?"
     response: "default"
+  - sentences:
+      - "cuál es la temperatura"
+    example: "cuál es la temperatura"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/es/HassClimateGetTemperature/name_only.yaml
@@ -14,3 +14,10 @@ data:
     name_domains:
       - "climate"
     response: "default"
+  - sentences:
+      - "cuál es la temperatura del {name}"
+    example: "cuál es la temperatura del Termostato cocina"
+    name_domains:
+      - "climate"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/es/HassDecreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "(<quita>|<baja>|<resta>) ([a|de] [mi]|al|del|de el) <temporizador> [en|por] <nb_hours> hora[s]"
     example: "quitar 1 hora del temporizador"
     response: "default"
+  - sentences:
+      - "quita {timer_hours:hours} (hora|horas) al temporizador"
+    example: "quita 2 hora al temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/es/HassDecreaseTimer/minutes_only.yaml
@@ -11,3 +11,8 @@ data:
       - "(<quita>|<baja>|<resta>) ([a|de] [mi]|al|del|de el) <temporizador> [en|por] {timer_half:minutes} hora"
     example: "quitar 5 minutos del temporizador"
     response: "default"
+  - sentences:
+      - "quita {timer_minutes:minutes} (minuto|minutos) al temporizador"
+    example: "quita 5 minuto al temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/es/HassDecreaseTimer/seconds_only.yaml
@@ -11,3 +11,8 @@ data:
       - "(<quita>|<baja>|<resta>) ([a|de] [mi]|al|del|de el) <temporizador> [en|por] {timer_half:seconds} minuto"
     example: "quitar 30 segundos del temporizador"
     response: "default"
+  - sentences:
+      - "quita {timer_seconds:seconds} (segundo|segundos) al temporizador"
+    example: "quita 30 segundo al temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassFanSetSpeed/default.yaml
+++ b/sentences/es/HassFanSetSpeed/default.yaml
@@ -12,3 +12,8 @@ data:
       - "[<establece>] [la] velocidad [del|de los] ventilador[es] [<de_aqui>] [al] {fan_speed:percentage}[%| por[ ]cien[to]]"
     example: "establece la velocidad del ventilador al 50%"
     response: "default"
+  - sentences:
+      - "pon la velocidad del ventilador al {fan_speed:percentage} por ciento"
+    example: "pon la velocidad del ventilador al 50 por ciento"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassFanSetSpeed/name_only.yaml
+++ b/sentences/es/HassFanSetSpeed/name_only.yaml
@@ -14,3 +14,10 @@ data:
     name_domains:
       - "fan"
     response: "default"
+  - sentences:
+      - "pon la velocidad del {name} al {fan_speed:percentage} por ciento"
+    example: "pon la velocidad del Ventilador de techo al 50 por ciento"
+    name_domains:
+      - "fan"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassGetCurrentDate/default.yaml
+++ b/sentences/es/HassGetCurrentDate/default.yaml
@@ -11,3 +11,8 @@ data:
       - "<cual_es> (fecha|día) [de hoy]"
     example: "qué día es hoy"
     response: "default"
+  - sentences:
+      - "qué día es hoy"
+    example: "qué día es hoy"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassGetCurrentTime/default.yaml
+++ b/sentences/es/HassGetCurrentTime/default.yaml
@@ -11,3 +11,8 @@ data:
       - "hora actual"
     example: "qué hora es"
     response: "default"
+  - sentences:
+      - "qué hora es"
+    example: "qué hora es"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassGetState/name_only.yaml
+++ b/sentences/es/HassGetState/name_only.yaml
@@ -20,3 +20,10 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  - sentences:
+      - "cuál es el valor de {name}"
+    example: "cuál es el valor de Temperatura Exterior"
+    name_domains:
+      - sensor
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/es/HassGetState/name_state.yaml
+++ b/sentences/es/HassGetState/name_state.yaml
@@ -49,3 +49,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  - sentences:
+      - "está (el|la) {name} {on_off_states:state}"
+    example: "está el Ventilador de techo encendidos"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "está (el|la) {name} {cover_states:state}"
+    example: "está el Ventana Salón abiertos"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "está (el|la) {name} {lock_states:state}"
+    example: "está el Puerta Delantera cerrados con llave"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/es/HassGetWeather/default.yaml
+++ b/sentences/es/HassGetWeather/default.yaml
@@ -9,3 +9,8 @@ data:
       - "cómo está el tiempo[ hoy| ahora]"
     example: "qué tiempo hace"
     response: "default"
+  - sentences:
+      - "qué tiempo hace"
+    example: "qué tiempo hace"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/es/HassIncreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> [en] <nb_hours> hora[s]"
     example: "añadir 1 hora al temporizador"
     response: "default"
+  - sentences:
+      - "añade {timer_hours:hours} (hora|horas) al temporizador"
+    example: "añade 2 hora al temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/es/HassIncreaseTimer/minutes_only.yaml
@@ -11,3 +11,8 @@ data:
       - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> [en] {timer_half:minutes} hora"
     example: "añadir 5 minutos al temporizador"
     response: "default"
+  - sentences:
+      - "añade {timer_minutes:minutes} (minuto|minutos) al temporizador"
+    example: "añade 5 minuto al temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/es/HassIncreaseTimer/seconds_only.yaml
@@ -11,3 +11,8 @@ data:
       - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> [en] {timer_half:seconds} minuto"
     example: "añadir 30 segundos al temporizador"
     response: "default"
+  - sentences:
+      - "añade {timer_seconds:seconds} (segundo|segundos) al temporizador"
+    example: "añade 30 segundo al temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassLightSet/area_brightness.yaml
+++ b/sentences/es/HassLightSet/area_brightness.yaml
@@ -21,3 +21,9 @@ data:
     example: "subir brillo de dormitorio al máximo"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "pon el brillo (en el|en la) {area} al {brightness} por ciento"
+    example: "pon el brillo en el Cocina al 50 por ciento"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/es/HassLightSet/brightness_only.yaml
+++ b/sentences/es/HassLightSet/brightness_only.yaml
@@ -17,3 +17,9 @@ data:
     example: "pon el brillo al 50%"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "pon el brillo al {brightness} por ciento"
+    example: "pon el brillo al 50 por ciento"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/es/HassLightSet/floor_brightness.yaml
+++ b/sentences/es/HassLightSet/floor_brightness.yaml
@@ -21,3 +21,9 @@ data:
     example: "subir brillo de la primera planta al máximo"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "pon el brillo en la planta {floor} al {brightness} por ciento"
+    example: "pon el brillo en la planta Primera planta al 50 por ciento"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/es/HassLightSet/name_brightness.yaml
+++ b/sentences/es/HassLightSet/name_brightness.yaml
@@ -25,3 +25,10 @@ data:
     name_domains:
       - "light"
     response: "brightness"
+  - sentences:
+      - "pon el brillo de (el|la) {name} al {brightness} por ciento"
+    example: "pon el brillo de el Luz A al 50 por ciento"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/es/HassMediaNext/default.yaml
+++ b/sentences/es/HassMediaNext/default.yaml
@@ -10,3 +10,8 @@ data:
       - "<salta>[ (a[l] [el |la ](siguiente [<pista>]|<pista> siguiente)|[est[a|e] ]<pista>|est[a|e|o])]"
     example: "siguiente pista"
     response: "default"
+  - sentences:
+      - "siguiente canción"
+    example: "siguiente canción"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassMediaPause/default.yaml
+++ b/sentences/es/HassMediaPause/default.yaml
@@ -10,3 +10,9 @@ data:
       - "<pausa> [la |el |mi ](música|programa|vídeo|video|reproducción|reproductor)"
     example: "pausa"
     response: "default"
+  - sentences:
+      - "pausa"
+      - "pausa la música"
+    example: "pausa"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassMediaPlayerMute/default.yaml
+++ b/sentences/es/HassMediaPlayerMute/default.yaml
@@ -13,3 +13,9 @@ data:
       - "pon [en] silencio ([el|la] (música|audio|sonido|reproducción|reproductor[es])) [<de_aqui>]"
     example: "silenciar"
     response: "default"
+  - sentences:
+      - "silenciar"
+      - "quita el sonido"
+    example: "silenciar"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/es/HassMediaPlayerUnmute/default.yaml
@@ -13,3 +13,9 @@ data:
       - "restaur(a|e) [el] (sonido|audio|volumen) [<de_aqui>]"
     example: "quita el silencio"
     response: "default"
+  - sentences:
+      - "quita el silencio"
+      - "pon el sonido"
+    example: "quita el silencio"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassMediaPrevious/default.yaml
+++ b/sentences/es/HassMediaPrevious/default.yaml
@@ -10,3 +10,8 @@ data:
       - "(<salta>|<vuelve>) a[l] [<reproduce> ][<otra_vez> ][el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
     example: "pista anterior"
     response: "default"
+  - sentences:
+      - "la canción anterior"
+    example: "la canción anterior"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassMediaUnpause/default.yaml
+++ b/sentences/es/HassMediaUnpause/default.yaml
@@ -11,3 +11,9 @@ data:
       - "<reproduce> [la |el |mi ](música|programa|vídeo|video|reproducción|reproductor)"
     example: "continúa"
     response: "default"
+  - sentences:
+      - "continúa"
+      - "reanuda la reproducción"
+    example: "continúa"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassNevermind/default.yaml
+++ b/sentences/es/HassNevermind/default.yaml
@@ -14,3 +14,9 @@ data:
       - "da igual"
     example: "da igual"
     response: "default"
+  - sentences:
+      - "da igual"
+      - "No importa"
+    example: "da igual"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassPauseTimer/default.yaml
+++ b/sentences/es/HassPauseTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "<pausa> [mi] <temporizador>"
     example: "pausar temporizador"
     response: "default"
+  - sentences:
+      - "pausa el temporizador"
+    example: "pausa el temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassSetPosition/name_only.yaml
+++ b/sentences/es/HassSetPosition/name_only.yaml
@@ -14,3 +14,11 @@ data:
       - "cover"
       - "valve"
     response: "default"
+  - sentences:
+      - "pon la posición del {name} al {position} por ciento"
+    example: "pon la posición del Ventana Salón al 50 por ciento"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassSetVolume/default.yaml
+++ b/sentences/es/HassSetVolume/default.yaml
@@ -10,3 +10,8 @@ data:
       - "<establece_sube_baja> [el ]volumen a[l] {volume:volume_level} [<porciento>]"
     example: "poner volumen al 90 por ciento"
     response: "default"
+  - sentences:
+      - "pon el volumen al {volume:volume_level} por ciento"
+    example: "pon el volumen al 50 por ciento"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassSetVolumeRelative/default.yaml
+++ b/sentences/es/HassSetVolumeRelative/default.yaml
@@ -9,7 +9,7 @@ data:
   - sentences:
       - "<sube> <vol>"
       - "más volumen"
-    slots:
+    slots: &id001
       volume_step: "up"
     example: "sube el volumen"
     response: "default"
@@ -22,7 +22,7 @@ data:
   - sentences:
       - "<baja> <vol>"
       - "menos volumen"
-    slots:
+    slots: &id002
       volume_step: "down"
     example: "baja el volumen"
     response: "default"
@@ -31,3 +31,25 @@ data:
       - "<baja> <vol> [en] [un ]{volume_step_down:volume_step}[%| por ciento]"
     example: "baja el volumen 20%"
     response: "default"
+  - sentences:
+      - "sube el volumen"
+    example: "sube el volumen"
+    slots: *id001
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "sube el volumen un {volume_step_up:volume_step} por ciento"
+    example: "sube el volumen un 10 por ciento"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "baja el volumen"
+    example: "baja el volumen"
+    slots: *id002
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "baja el volumen un {volume_step_down:volume_step} por ciento"
+    example: "baja el volumen un 10 por ciento"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassStartTimer/hours_only.yaml
+++ b/sentences/es/HassStartTimer/hours_only.yaml
@@ -8,3 +8,8 @@ data:
       - "[<timer_set>] [un|una|mi] <temporizador> (dentro de|de|en|para) <nb_hours> hora[s]"
     example: "inicia temporizador de 1 hora"
     response: "default"
+  - sentences:
+      - "pon un temporizador de {timer_hours:hours} (hora|horas)"
+    example: "pon un temporizador de 2 hora"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassStartTimer/minutes_only.yaml
+++ b/sentences/es/HassStartTimer/minutes_only.yaml
@@ -9,3 +9,8 @@ data:
       - "[<timer_set>] [un|una|mi] <temporizador> (dentro de|de|en|para) {timer_half:minutes} hora"
     example: "temporizador en 10 minutos"
     response: "default"
+  - sentences:
+      - "pon un temporizador de {timer_minutes:minutes} (minuto|minutos)"
+    example: "pon un temporizador de 5 minuto"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassStartTimer/seconds_only.yaml
+++ b/sentences/es/HassStartTimer/seconds_only.yaml
@@ -9,3 +9,8 @@ data:
       - "[<timer_set>] [un|una|mi] <temporizador> (dentro de|de|en|para) {timer_half:seconds} minuto"
     example: "inicia temporizador de 30 segundos"
     response: "default"
+  - sentences:
+      - "pon un temporizador de {timer_seconds:seconds} (segundo|segundos)"
+    example: "pon un temporizador de 30 segundo"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassTimerStatus/default.yaml
+++ b/sentences/es/HassTimerStatus/default.yaml
@@ -9,3 +9,8 @@ data:
       - "(cu(a|á)nto|qu(é|e)) [tiempo] [le] (falta|queda|resta) (para|a[l]|de[l]) [mi[s]] <temporizadores>"
     example: "estado de temporizadores"
     response: "default"
+  - sentences:
+      - "cuánto tiempo queda para el temporizador"
+    example: "cuánto tiempo queda para el temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassTurnOff/area_domain.yaml
+++ b/sentences/es/HassTurnOff/area_domain.yaml
@@ -21,3 +21,15 @@ data:
     example: "apaga los ventiladores del salón"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "apaga las luces (en el|en la) {area}"
+    example: "apaga las luces en el Cocina"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "apaga los ventiladores (en el|en la) {area}"
+    example: "apaga los ventiladores en el Cocina"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/es/HassTurnOff/domain_only.yaml
+++ b/sentences/es/HassTurnOff/domain_only.yaml
@@ -19,3 +19,9 @@ data:
     example: "apaga los ventiladores"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "apaga las luces"
+    example: "apaga las luces"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/es/HassTurnOff/name_only.yaml
+++ b/sentences/es/HassTurnOff/name_only.yaml
@@ -44,3 +44,28 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "apaga (el|la) {name}"
+    example: "apaga el Ventilador de techo"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "cierra (el|la) {name}"
+    example: "cierra el Ventana Salón"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "abre (el|la) {name}"
+    example: "abre el Puerta Delantera"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/es/HassTurnOn/area_domain.yaml
+++ b/sentences/es/HassTurnOn/area_domain.yaml
@@ -21,3 +21,15 @@ data:
     example: "enciende los ventiladores de la cocina"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "enciende las luces (en el|en la) {area}"
+    example: "enciende las luces en el Cocina"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "enciende los ventiladores (en el|en la) {area}"
+    example: "enciende los ventiladores en el Cocina"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/es/HassTurnOn/domain_only.yaml
+++ b/sentences/es/HassTurnOn/domain_only.yaml
@@ -27,3 +27,9 @@ data:
     example: "enciende los ventiladores"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "enciende las luces"
+    example: "enciende las luces"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true

--- a/sentences/es/HassTurnOn/name_area.yaml
+++ b/sentences/es/HassTurnOn/name_area.yaml
@@ -51,3 +51,14 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "enciende (el|la) {name} (en el|en la) {area}"
+    example: "enciende el Ventilador de techo en el Cocina"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/es/HassTurnOn/name_only.yaml
+++ b/sentences/es/HassTurnOn/name_only.yaml
@@ -50,3 +50,28 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "enciende (el|la) {name}"
+    example: "enciende el Ventilador de techo"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "abre (el|la) {name}"
+    example: "abre el Ventana Salón"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "cierra con llave (el|la) {name}"
+    example: "cierra con llave el Puerta Delantera"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/es/HassUnpauseTimer/default.yaml
+++ b/sentences/es/HassUnpauseTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "<continúa> [con] [mi] <temporizador>"
     example: "continúa cuenta atrás"
     response: "default"
+  - sentences:
+      - "continúa el temporizador"
+    example: "continúa el temporizador"
+    response: "default"
+    speech_to_phrase: true

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,4 +1,4 @@
-"""Speech-to-Phrase subset verification (Method B).
+"""Speech-to-Phrase subset verification.
 
 A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
 the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
@@ -6,24 +6,31 @@ also has untagged (rich) blocks, Home Assistant drops the tagged block from its
 grammar (see ``partition_speech_to_phrase`` and the loader in
 ``test_slot_combinations.py``). That is only sound if the lean block's language
 is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
-recognise a phrasing HA never would.
+recognise a phrasing Home Assistant never would.
 
-We verify containment by enumeration rather than with an FST/OpenFST toolchain:
-lean blocks are finite and small by construction, so we expand every phrasing on
-both sides (slots rendered as literal ``{list}`` sentinels via
-``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
-complete for the lean side (no recursion, bounded fan-out) and needs no slot
-lists, entities, or intent context.
+Containment is checked by *matching*, not by enumerating both sides. The lean
+side is enumerated (it is small and non-recursive by construction) and each
+phrasing is then handed to hassil's recognizer built from the rich blocks: if
+the rich grammar accepts it, it is in the rich language. Enumerating the rich
+side instead is what the first version of this test did, and it does not scale
+-- English is small enough to get away with it, but e.g. the Spanish
+``HassTurnOn`` blocks expand into billions of phrasings and exhaust memory.
 
-Only English is wired up for now; the collector is language-agnostic.
+Slots are neutralised on both sides: every ``{list}`` reference is replaced with
+a per-list sentinel word, and the rich grammar gets a one-value text list for
+each, so matching compares phrasing structure rather than slot contents (which
+would need entities, areas and floors that this test deliberately does not load).
+
+Languages are discovered from the tagged blocks themselves.
 """
 
 import importlib
+import re
 from typing import Any
 
 import pytest
 import yaml
-from hassil import Intents, normalize_whitespace
+from hassil import Intents, SlotList, TextSlotList, normalize_whitespace, recognize
 from hassil.sample import sample_sentence
 
 from . import RULES_DIR, SENTENCES_DIR
@@ -31,7 +38,26 @@ from . import RULES_DIR, SENTENCES_DIR
 _util: Any = importlib.import_module("script.intentfest.util")
 partition_speech_to_phrase = _util.partition_speech_to_phrase
 
-LANGUAGES = ["en"]
+
+def _languages_with_s2p_blocks() -> list[str]:
+    """Every language that has at least one ``speech_to_phrase``-tagged block.
+
+    Discovered rather than hard-coded so adding a language's lean blocks does
+    not also require editing this list (and so a branch per language does not
+    collide here)."""
+    langs = []
+    for lang_dir in sorted(p for p in SENTENCES_DIR.iterdir() if p.is_dir()):
+        for combo_path in lang_dir.glob("*/*.yaml"):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            if any(b.get("speech_to_phrase") for b in data):
+                langs.append(lang_dir.name)
+                break
+    return langs
+
+
+LANGUAGES = _languages_with_s2p_blocks()
+
+_SLOT_REF = re.compile(r"\{([^{}]+)\}")
 
 
 def _load_expansion_rules(language: str) -> dict[str, str]:
@@ -44,10 +70,22 @@ def _load_expansion_rules(language: str) -> dict[str, str]:
     return rules
 
 
-def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
-    """Every phrasing a set of templates can produce, with slots left as literal
-    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
-    sides are compared on phrasing structure, not enumerated slot values."""
+def _list_name(ref: str) -> str:
+    """``timer_hours:hours`` -> ``timer_hours``; ``0..100`` -> ``_range``."""
+    name = ref.split(":", 1)[0].strip()
+    return "_range" if re.match(r"^-?\d+\s*\.\.", name) else name
+
+
+def _sentinel(list_name: str) -> str:
+    """A single word that cannot collide with real vocabulary."""
+    return "zz" + re.sub(r"[^a-z0-9]+", "", list_name.lower()) + "zz"
+
+
+def _lean_phrasings(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> set[str]:
+    """Every phrasing the lean templates produce, with each slot reference
+    replaced by its sentinel word."""
     intents = Intents.from_dict(
         {
             "language": language,
@@ -66,8 +104,47 @@ def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> se
                 expand_lists=False,
                 expand_ranges=False,
             ):
+                text = _SLOT_REF.sub(lambda m: _sentinel(_list_name(m.group(1))), text)
                 out.add(normalize_whitespace(text).strip())
     return out
+
+
+def _referenced_lists(sentences: list[str], rules: dict[str, str]) -> set[str]:
+    """List names reachable from these templates, following expansion rules."""
+    seen_rules: set[str] = set()
+    names: set[str] = set()
+    pending = list(sentences)
+    while pending:
+        text = pending.pop()
+        names.update(_list_name(m) for m in _SLOT_REF.findall(text))
+        for rule_name in re.findall(r"<([a-zA-Z0-9_]+)>", text):
+            if rule_name in rules and rule_name not in seen_rules:
+                seen_rules.add(rule_name)
+                pending.append(rules[rule_name])
+    return names
+
+
+def _rich_intents(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> tuple[Intents, dict[str, SlotList]]:
+    """Rich blocks as a recognizer, with every referenced list bound to its
+    sentinel so slot *contents* never affect the match."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {
+                "_S2P": {"data": [{"sentences": sentences, "slots": {"x": "y"}}]}
+            },
+            "expansion_rules": rules,
+        }
+    )
+    slot_lists: dict[str, SlotList] = {
+        name: TextSlotList.from_strings([_sentinel(name)])
+        for name in _referenced_lists(sentences, rules)
+    }
+    # An inline range (`{0..100}`) keeps its own ref text, so bind that too.
+    slot_lists.setdefault("_range", TextSlotList.from_strings([_sentinel("_range")]))
+    return intents, slot_lists
 
 
 def _collect() -> list[tuple[str, str, str]]:
@@ -98,17 +175,19 @@ def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
     ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
 
     rules = _load_expansion_rules(lang)
-    rich = _phrasings(
-        [s for block in ha_blocks for s in block["sentences"]], lang, rules
-    )
+    rich_sentences = [s for block in ha_blocks for s in block["sentences"]]
+    rich, slot_lists = _rich_intents(rich_sentences, lang, rules)
 
     for block in s2p_only:
-        lean = _phrasings(block["sentences"], lang, rules)
-        extra = lean - rich
+        extra = [
+            phrasing
+            for phrasing in sorted(_lean_phrasings(block["sentences"], lang, rules))
+            if recognize(phrasing, rich, slot_lists=slot_lists) is None
+        ]
         assert not extra, (
             f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
             f"not recognised by the Home Assistant (rich) block(s): "
-            f"{sorted(extra)[:10]}"
+            f"{extra[:10]}"
         )
 
 


### PR DESCRIPTION
Speech-to-Phrase builds a constrained FST grammar instead of matching with
hassil, so it consumes the `speech_to_phrase`-tagged subset of each slot
combination rather than the full block. Only English had those blocks, so the
add-on could not serve Spanish even though a Spanish acoustic model exists.

This adds **55 tagged blocks** covering the same 26 intents as English.

### How the sentences were chosen

Every sentence is a **restriction of Spanish's own untagged templates** — taken
from what the rich blocks already accept, not newly invented phrasing. Home
Assistant's grammar is therefore unchanged: `partition_speech_to_phrase` drops
the tagged block whenever an untagged sibling exists, and the subset check
proves the lean language is contained in the rich one.

Spanish ships no `HassTurnOn/floor_domain` or `HassTurnOff/floor_domain` combo
file, so those two are not covered here.

`HassMediaPause` uses "pausa la música" rather than a bare "para". Two phonemes
and a very common Spanish word, "para" scored 9.16 on its own audio and
swallowed other commands — "apaga el ventilador de techo" decoded as "para" at
7.80. Without it, that clip decodes correctly at 2.71.

### Verification

Each block's `example` was synthesized with the Spanish Home Assistant Cloud TTS
voice and decoded through the real Speech-to-Phrase grammar (`stt_es_citrinet_512`), then
scored on whether hassil resolves the transcript back to the command that was
spoken — not on string equality, since the decoder legitimately picks a
different in-grammar realization (articles drop, numbers are spelled out).

**55/55 examples resolve to the correct command.**

`script/test` and `python3 -m script.intentfest validate --language es` both pass.

### Note on the shared test change

`tests/test_speech_to_phrase.py` now discovers languages from the tagged blocks
instead of a hard-coded `["en"]`, and checks containment by *matching* each lean
phrasing against the rich blocks rather than enumerating both sides. Enumeration
does not scale past English — the Spanish `HassTurnOn` blocks expand far enough
to exhaust memory — while matching is linear in the (small) lean side and gives
the same answer. Verified against a planted violation to confirm it still fails
when it should.

That change is **byte-identical in all seven of these language PRs**, so
whichever merges first makes it a no-op for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)