### PR TITLE
[fr] Add Speech-to-Phrase lean sentence blocks

### DIFF
--- a/sentences/fr/HassCancelTimer/default.yaml
+++ b/sentences/fr/HassCancelTimer/default.yaml
@@ -7,3 +7,8 @@ data:
       - "<eteins> [<le>|<mon>] <minuteur>"
     example: "supprime le minuteur"
     response: "default"
+  - sentences:
+      - "annule [le ]minuteur"
+    example: "annule le minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/fr/HassClimateGetTemperature/area_only.yaml
@@ -10,3 +10,8 @@ data:
       - "Il fait combien <dans> [<le>]{area}"
     example: "quelle est la température dans le salon"
     response: "default"
+  - sentences:
+      - "Quelle est la température dans [<le>]{area}"
+    example: "Quelle est la température dans le Cuisine"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassClimateGetTemperature/default.yaml
+++ b/sentences/fr/HassClimateGetTemperature/default.yaml
@@ -10,3 +10,8 @@ data:
       - "Il fait combien"
     example: "quelle est la température"
     response: "default"
+  - sentences:
+      - "Quelle est la température"
+    example: "Quelle est la température"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/fr/HassClimateGetTemperature/name_only.yaml
@@ -12,3 +12,10 @@ data:
       - "climate"
     example: "quelle est la température du thermostat du bureau"
     response: "default"
+  - sentences:
+      - "Quelle est la température de [<le>]{name}"
+    example: "Quelle est la température de le Thermostat du salon"
+    name_domains:
+      - "climate"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/fr/HassDecreaseTimer/hours_only.yaml
@@ -8,3 +8,8 @@ data:
       - "<enleve> {timer_hours:hours} <hour_unit> (sur|dans) [<le>|<mon>] <minuteur>"
     example: "enlève 1 heure au minuteur"
     response: "default"
+  - sentences:
+      - "enlève {timer_hours:hours} (heure|heures) au minuteur"
+    example: "enlève 2 heure au minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/fr/HassDecreaseTimer/minutes_only.yaml
@@ -8,3 +8,8 @@ data:
       - "<enleve> {timer_minutes:minutes} <minute_unit> (sur|dans) [<le>|<mon>] <minuteur>"
     example: "enlève 5 minutes au minuteur"
     response: "default"
+  - sentences:
+      - "enlève {timer_minutes:minutes} (minute|minutes) au minuteur"
+    example: "enlève 5 minute au minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/fr/HassDecreaseTimer/seconds_only.yaml
@@ -8,3 +8,8 @@ data:
       - "<enleve> {timer_seconds:seconds} <second_unit> (sur|dans) [<le>|<mon>] <minuteur>"
     example: "enlève 30 secondes au minuteur"
     response: "default"
+  - sentences:
+      - "enlève {timer_seconds:seconds} (seconde|secondes) au minuteur"
+    example: "enlève 30 seconde au minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassFanSetSpeed/default.yaml
+++ b/sentences/fr/HassFanSetSpeed/default.yaml
@@ -7,3 +7,8 @@ data:
       - "<regle> [la] vitesse [<de>] [<le>]<ventilateur> [<ici>] [(à|sur)] {fan_speed:percentage}<pourcent>"
     response: "default"
     example: "règle le ventilateur à 50%"
+  - sentences:
+      - "règle la vitesse du ventilateur à {fan_speed:percentage} pour cent"
+    example: "règle la vitesse du ventilateur à 50 pour cent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassFanSetSpeed/name_only.yaml
+++ b/sentences/fr/HassFanSetSpeed/name_only.yaml
@@ -9,3 +9,10 @@ data:
       - "fan"
     response: "default"
     example: "règle le ventilateur de plafond à 30%"
+  - sentences:
+      - "règle la vitesse de [<le>]{name} à {fan_speed:percentage} pour cent"
+    example: "règle la vitesse de le ventilateur de plafond à 50 pour cent"
+    name_domains:
+      - "fan"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassGetCurrentDate/default.yaml
+++ b/sentences/fr/HassGetCurrentDate/default.yaml
@@ -17,3 +17,9 @@ data:
       - "Quel jour est il"
     example: "quelle est la date"
     response: "default"
+  - sentences:
+      - "Quelle est la date du jour"
+      - "Quel jour sommes-nous"
+    example: "Quelle est la date du jour"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassGetCurrentTime/default.yaml
+++ b/sentences/fr/HassGetCurrentTime/default.yaml
@@ -9,3 +9,8 @@ data:
       - "Il est quelle heure[ maintenant]"
     example: "quelle heure est-il"
     response: "default"
+  - sentences:
+      - "Quelle heure est il"
+    example: "Quelle heure est il"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassGetState/name_only.yaml
+++ b/sentences/fr/HassGetState/name_only.yaml
@@ -21,3 +21,10 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  - sentences:
+      - "quelle est la valeur de [<le>]{name}"
+    example: "quelle est la valeur de le température extérieure"
+    name_domains:
+      - sensor
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/fr/HassGetState/name_state.yaml
+++ b/sentences/fr/HassGetState/name_state.yaml
@@ -48,3 +48,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  - sentences:
+      - "[<le>]{name} est {on_off_states:state}"
+    example: "le ventilateur de plafond est allumées"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "[<le>]{name} est {cover_states:state}"
+    example: "le Fenêtre Salon est ouvertes"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "[<le>]{name} est {lock_states:state}"
+    example: "le Porte Avant est verrouilleeréées"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/fr/HassGetWeather/default.yaml
+++ b/sentences/fr/HassGetWeather/default.yaml
@@ -15,14 +15,17 @@ data:
       - "(<quelest>|<donnemoi>) (le|la|les) (temps|météo) (détaillé[e]|en détail)"
       - "<donnemoi> le temps qu'il fait en détail"
       - "<donnemoi> le détail du temps qu'il fait"
+    example: "donne-moi un bulletin météo détaillé"
     response: "detailed_weather"
 
   - sentences:
       - "[(<quelest>|<donnemoi>) la] pression atmosphérique [<aujourdhui>]"
+    example: "quelle est la pression atmosphérique"
     response: "pressure"
 
   - sentences:
       - "[(<quelest>|<donnemoi>) l']indice UV [<aujourdhui>]"
+    example: "quel est l'indice UV"
     response: "uv"
 
   - sentences:
@@ -31,4 +34,10 @@ data:
       - "[(<quelest>|<donnemoi>) la] météo du vent [<aujourdhui>]"
       - "(<quelest>|<donnemoi>) le détail du vent [<aujourdhui>]"
       - "<yatil> du vent [<aujourdhui>]"
+    example: "quelle est la vitesse du vent"
     response: "wind"
+  - sentences:
+      - "Quel est le temps"
+    example: "Quel est le temps"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/fr/HassIncreaseTimer/hours_only.yaml
@@ -8,3 +8,8 @@ data:
       - "<ajoute> {timer_hours:hours} <hour_unit> (sur|dans) [<le>|<mon>] <minuteur>"
     example: "ajoute 1 heure au minuteur"
     response: "default"
+  - sentences:
+      - "ajoute {timer_hours:hours} (heure|heures) au minuteur"
+    example: "ajoute 2 heure au minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/fr/HassIncreaseTimer/minutes_only.yaml
@@ -8,3 +8,8 @@ data:
       - "<ajoute> {timer_minutes:minutes} <minute_unit> (sur|dans) [<le>|<mon>] <minuteur>"
     example: "ajoute 5 minutes au minuteur"
     response: "default"
+  - sentences:
+      - "ajoute {timer_minutes:minutes} (minute|minutes) au minuteur"
+    example: "ajoute 5 minute au minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/fr/HassIncreaseTimer/seconds_only.yaml
@@ -8,3 +8,8 @@ data:
       - "<ajoute> {timer_seconds:seconds} <second_unit> (sur|dans) [<le>|<mon>] <minuteur>"
     example: "ajoute 30 secondes au minuteur"
     response: "default"
+  - sentences:
+      - "ajoute {timer_seconds:seconds} (seconde|secondes) au minuteur"
+    example: "ajoute 30 seconde au minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassLightSet/area_brightness.yaml
+++ b/sentences/fr/HassLightSet/area_brightness.yaml
@@ -14,3 +14,9 @@ data:
     inferred_domain: "light"
     example: "règle la luminosité de la cuisine à 50%"
     response: "brightness"
+  - sentences:
+      - "règle la luminosité dans [<le>]{area} à {brightness} pour cent"
+    example: "règle la luminosité dans le Cuisine à 50 pour cent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/fr/HassLightSet/brightness_only.yaml
+++ b/sentences/fr/HassLightSet/brightness_only.yaml
@@ -11,3 +11,9 @@ data:
     inferred_domain: "light"
     example: "règle la luminosité à 40%"
     response: "brightness"
+  - sentences:
+      - "règle la luminosité à {brightness} pour cent"
+    example: "règle la luminosité à 50 pour cent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/fr/HassLightSet/floor_brightness.yaml
+++ b/sentences/fr/HassLightSet/floor_brightness.yaml
@@ -14,3 +14,9 @@ data:
     inferred_domain: "light"
     example: "règle la luminosité du rez-de-chaussée à 50%"
     response: "brightness"
+  - sentences:
+      - "règle la luminosité dans [<le>]{floor} à {brightness} pour cent"
+    example: "règle la luminosité dans le Premier Étage à 50 pour cent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/fr/HassLightSet/name_brightness.yaml
+++ b/sentences/fr/HassLightSet/name_brightness.yaml
@@ -15,3 +15,10 @@ data:
       - "light"
     example: "règle la luminosité de la lampe de chevet à 50%"
     response: "brightness"
+  - sentences:
+      - "règle la luminosité de [<le>]{name} à {brightness} pour cent"
+    example: "règle la luminosité de le Lampe A à 50 pour cent"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/fr/HassMediaNext/default.yaml
+++ b/sentences/fr/HassMediaNext/default.yaml
@@ -11,3 +11,9 @@ data:
       - "<mets> (<le>|au |à la )<media> suivant[e]"
     example: "suivant"
     response: "default"
+  - sentences:
+      - "morceau suivant"
+      - "mets le morceau suivant"
+    example: "morceau suivant"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassMediaPause/default.yaml
+++ b/sentences/fr/HassMediaPause/default.yaml
@@ -11,5 +11,11 @@ data:
       - "<eteins> <le> <lecture>"
       - "pause"
       - "<mets> [<le>]<media> (sur|en) pause"
-    example: "pause"
+    example: "arrête la musique"
     response: "default"
+  - sentences:
+      - "pause"
+      - "arrête la lecture"
+    example: "arrête la lecture"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassMediaPlayerMute/default.yaml
+++ b/sentences/fr/HassMediaPlayerMute/default.yaml
@@ -12,3 +12,9 @@ data:
       - "charrue"
     example: "sourdine"
     response: "default"
+  - sentences:
+      - "mets le son en sourdine"
+      - "sourdine"
+    example: "mets le son en sourdine"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/fr/HassMediaPlayerUnmute/default.yaml
@@ -11,3 +11,9 @@ data:
       - "<enleve> la sourdine [<ici>]"
     example: "enlève la sourdine"
     response: "default"
+  - sentences:
+      - "enlève la sourdine"
+      - "remets le son"
+    example: "enlève la sourdine"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassMediaPrevious/default.yaml
+++ b/sentences/fr/HassMediaPrevious/default.yaml
@@ -11,3 +11,9 @@ data:
       - "<mets> (<le>|au |à la )<media> précédent[e]"
     example: "précédent"
     response: "default"
+  - sentences:
+      - "morceau précédent"
+      - "mets le morceau précédent"
+    example: "morceau précédent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassMediaUnpause/default.yaml
+++ b/sentences/fr/HassMediaUnpause/default.yaml
@@ -15,3 +15,8 @@ data:
       - "<reprends> <le> <lecture> <en_route>"
     example: "lecture"
     response: "default"
+  - sentences:
+      - "reprends la lecture"
+    example: "reprends la lecture"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassNevermind/default.yaml
+++ b/sentences/fr/HassNevermind/default.yaml
@@ -13,3 +13,9 @@ data:
       - "silence"
     example: "oublie"
     response: "default"
+  - sentences:
+      - "oublie"
+      - "annule"
+    example: "oublie"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassPauseTimer/default.yaml
+++ b/sentences/fr/HassPauseTimer/default.yaml
@@ -7,3 +7,8 @@ data:
       - "<mets> (en|sur) pause [<le>|<mon>] <minuteur>"
     example: "mets le minuteur en pause"
     response: "default"
+  - sentences:
+      - "mets le minuteur en pause"
+    example: "mets le minuteur en pause"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassSetPosition/name_only.yaml
+++ b/sentences/fr/HassSetPosition/name_only.yaml
@@ -6,6 +6,7 @@ data:
   - sentences:
       - "<regle> [la position] [<de>] [<le>]{name} [(à|sur)] {position}<pourcent>"
       - "(<ouvre>|<ferme>) [<le>]{name} [à] {position}<pourcent>"
+    example: "règle la position de la Fenêtre Salon à 50 pour cent"
     name_domains:
       - "cover"
     response: "default"
@@ -14,6 +15,21 @@ data:
   - sentences:
       - "<regle> [la position de] [<le>]{name} à {position}<pourcent>"
       - "(<ouvre>|<ferme>) [<le>]{name} à {position}<pourcent>"
+    example: "règle la position de la valve principale à 50 pour cent"
     name_domains:
       - "valve"
     response: "default"
+  - sentences:
+      - "règle la position de [<le>]{name} à {position} pour cent"
+    example: "règle la position de le Fenêtre Salon à 50 pour cent"
+    name_domains:
+      - "cover"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "règle la position de [<le>]{name} à {position} pour cent"
+    example: "règle la position de le valve principale à 50 pour cent"
+    name_domains:
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassSetVolume/default.yaml
+++ b/sentences/fr/HassSetVolume/default.yaml
@@ -10,3 +10,8 @@ data:
       - "(<regle>|<monte>|<baisse>) [<le>]<volume> [à|sur] {volume:volume_level}<pourcent>"
     example: "règle le volume à 50%"
     response: "default"
+  - sentences:
+      - "règle le volume à {volume:volume_level} pour cent"
+    example: "règle le volume à 50 pour cent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassSetVolumeRelative/default.yaml
+++ b/sentences/fr/HassSetVolumeRelative/default.yaml
@@ -11,7 +11,8 @@ data:
       - "(<augmente>|<monte>) [<le>]<volume> [<ici>]"
       - "plus (fort|forte|haut|haute) [<ici>]"
       - "les watts [<ici>]"
-    slots:
+    example: "monte le son"
+    slots: &id001
       volume_step: "up"
     response: "default"
 
@@ -19,6 +20,19 @@ data:
   - sentences:
       - "(<diminue>|<baisse>) [<le>]<volume> [<ici>]"
       - "moins (fort|forte|bas|basse) [<ici>]"
-    slots:
+    example: "baisse le son"
+    slots: &id002
       volume_step: "down"
     response: "default"
+  - sentences:
+      - "augmente le volume"
+    example: "augmente le volume"
+    slots: *id001
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "diminue le volume"
+    example: "diminue le volume"
+    slots: *id002
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassStartTimer/hours_only.yaml
+++ b/sentences/fr/HassStartTimer/hours_only.yaml
@@ -11,3 +11,9 @@ data:
       - "<mets> un <minuteur> de {timer_hours:hours} <hour_unit>"
     example: "minuteur de 1 heure"
     response: "default"
+  - sentences:
+      - "mets un minuteur de {timer_hours:hours} (heure|heures)"
+      - "minuteur de {timer_hours:hours} (heure|heures)"
+    example: "mets un minuteur de 2 heure"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassStartTimer/minutes_only.yaml
+++ b/sentences/fr/HassStartTimer/minutes_only.yaml
@@ -11,3 +11,9 @@ data:
       - "<mets> un <minuteur> de {timer_minutes:minutes} <minute_unit>"
     example: "minuteur de 5 minutes"
     response: "default"
+  - sentences:
+      - "mets un minuteur de {timer_minutes:minutes} (minute|minutes)"
+      - "minuteur de {timer_minutes:minutes} (minute|minutes)"
+    example: "mets un minuteur de 5 minute"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassStartTimer/seconds_only.yaml
+++ b/sentences/fr/HassStartTimer/seconds_only.yaml
@@ -11,3 +11,9 @@ data:
       - "<mets> un <minuteur> de {timer_seconds:seconds} <second_unit>"
     example: "minuteur de 30 secondes"
     response: "default"
+  - sentences:
+      - "mets un minuteur de {timer_seconds:seconds} (seconde|secondes)"
+      - "minuteur de {timer_seconds:seconds} (seconde|secondes)"
+    example: "mets un minuteur de 30 seconde"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassTimerStatus/default.yaml
+++ b/sentences/fr/HassTimerStatus/default.yaml
@@ -11,3 +11,8 @@ data:
       - "[Il reste] [encore] combien [de temps] (sur|dans) [<le>|<mon>] <minuteur>"
     example: "combien de temps reste-t-il"
     response: "default"
+  - sentences:
+      - "Il reste combien de temps"
+    example: "Il reste combien de temps"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOff/area_domain.yaml
+++ b/sentences/fr/HassTurnOff/area_domain.yaml
@@ -22,3 +22,15 @@ data:
     inferred_domain: "fan"
     example: "éteins les ventilateurs du salon"
     response: "fans"
+  - sentences:
+      - "éteins les lumières dans [<le>]{area}"
+    example: "éteins les lumières dans le Cuisine"
+    inferred_domain: "light"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "éteins les ventilateurs dans [<le>]{area}"
+    example: "éteins les ventilateurs dans le Cuisine"
+    inferred_domain: "fan"
+    response: "fans"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOff/domain_only.yaml
+++ b/sentences/fr/HassTurnOff/domain_only.yaml
@@ -24,3 +24,9 @@ data:
     inferred_domain: "fan"
     example: "éteins les ventilateurs"
     response: "fans"
+  - sentences:
+      - "éteins les lumières"
+    example: "éteins les lumières"
+    inferred_domain: "light"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOff/floor_domain.yaml
+++ b/sentences/fr/HassTurnOff/floor_domain.yaml
@@ -16,3 +16,9 @@ data:
     example: "éteins les lumières du premier étage"
     inferred_domain: "light"
     response: "default"
+  - sentences:
+      - "éteins les lumières dans [<le>]{floor}"
+    example: "éteins les lumières dans le Premier Étage"
+    inferred_domain: "light"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOff/name_only.yaml
+++ b/sentences/fr/HassTurnOff/name_only.yaml
@@ -41,3 +41,28 @@ data:
       - "valve"
     example: "ferme la valve principale"
     response: "valve"
+  - sentences:
+      - "éteins [<le>]{name}"
+    example: "éteins le ventilateur de plafond"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "ferme [<le>]{name}"
+    example: "ferme le Fenêtre Salon"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "déverrouille [<le>]{name}"
+    example: "déverrouille le Porte Avant"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOn/area_domain.yaml
+++ b/sentences/fr/HassTurnOn/area_domain.yaml
@@ -22,3 +22,15 @@ data:
     example: "allume les ventilateurs du salon"
     inferred_domain: "fan"
     response: "fans"
+  - sentences:
+      - "allume les lumières dans [<le>]{area}"
+    example: "allume les lumières dans le Cuisine"
+    inferred_domain: "light"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "allume les ventilateurs dans [<le>]{area}"
+    example: "allume les ventilateurs dans le Cuisine"
+    inferred_domain: "fan"
+    response: "fans"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOn/domain_only.yaml
+++ b/sentences/fr/HassTurnOn/domain_only.yaml
@@ -22,3 +22,9 @@ data:
     example: "allume les ventilateurs"
     inferred_domain: "fan"
     response: "fans"
+  - sentences:
+      - "allume les lumières"
+    example: "allume les lumières"
+    inferred_domain: "light"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOn/floor_domain.yaml
+++ b/sentences/fr/HassTurnOn/floor_domain.yaml
@@ -17,3 +17,9 @@ data:
     example: "allume les lumières du premier étage"
     inferred_domain: "light"
     response: "default"
+  - sentences:
+      - "allume les lumières dans [<le>]{floor}"
+    example: "allume les lumières dans le Premier Étage"
+    inferred_domain: "light"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOn/name_area.yaml
+++ b/sentences/fr/HassTurnOn/name_area.yaml
@@ -42,3 +42,14 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "allume [<le>]{name} dans [<le>]{area}"
+    example: "allume le ventilateur de plafond dans le Cuisine"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/fr/HassTurnOn/name_only.yaml
+++ b/sentences/fr/HassTurnOn/name_only.yaml
@@ -40,3 +40,28 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "allume [<le>]{name}"
+    example: "allume le ventilateur de plafond"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "ouvre [<le>]{name}"
+    example: "ouvre le Fenêtre Salon"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "verrouille [<le>]{name}"
+    example: "verrouille le Porte Avant"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/fr/HassUnpauseTimer/default.yaml
+++ b/sentences/fr/HassUnpauseTimer/default.yaml
@@ -6,3 +6,8 @@ data:
       - "<reprends> [<le>|<mon>] <minuteur>"
     example: "reprends le minuteur"
     response: "default"
+  - sentences:
+      - "reprends le minuteur"
+    example: "reprends le minuteur"
+    response: "default"
+    speech_to_phrase: true

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,4 +1,4 @@
-"""Speech-to-Phrase subset verification (Method B).
+"""Speech-to-Phrase subset verification.
 
 A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
 the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
@@ -6,24 +6,31 @@ also has untagged (rich) blocks, Home Assistant drops the tagged block from its
 grammar (see ``partition_speech_to_phrase`` and the loader in
 ``test_slot_combinations.py``). That is only sound if the lean block's language
 is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
-recognise a phrasing HA never would.
+recognise a phrasing Home Assistant never would.
 
-We verify containment by enumeration rather than with an FST/OpenFST toolchain:
-lean blocks are finite and small by construction, so we expand every phrasing on
-both sides (slots rendered as literal ``{list}`` sentinels via
-``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
-complete for the lean side (no recursion, bounded fan-out) and needs no slot
-lists, entities, or intent context.
+Containment is checked by *matching*, not by enumerating both sides. The lean
+side is enumerated (it is small and non-recursive by construction) and each
+phrasing is then handed to hassil's recognizer built from the rich blocks: if
+the rich grammar accepts it, it is in the rich language. Enumerating the rich
+side instead is what the first version of this test did, and it does not scale
+-- English is small enough to get away with it, but e.g. the Spanish
+``HassTurnOn`` blocks expand into billions of phrasings and exhaust memory.
 
-Only English is wired up for now; the collector is language-agnostic.
+Slots are neutralised on both sides: every ``{list}`` reference is replaced with
+a per-list sentinel word, and the rich grammar gets a one-value text list for
+each, so matching compares phrasing structure rather than slot contents (which
+would need entities, areas and floors that this test deliberately does not load).
+
+Languages are discovered from the tagged blocks themselves.
 """
 
 import importlib
+import re
 from typing import Any
 
 import pytest
 import yaml
-from hassil import Intents, normalize_whitespace
+from hassil import Intents, SlotList, TextSlotList, normalize_whitespace, recognize
 from hassil.sample import sample_sentence
 
 from . import RULES_DIR, SENTENCES_DIR
@@ -31,7 +38,26 @@ from . import RULES_DIR, SENTENCES_DIR
 _util: Any = importlib.import_module("script.intentfest.util")
 partition_speech_to_phrase = _util.partition_speech_to_phrase
 
-LANGUAGES = ["en"]
+
+def _languages_with_s2p_blocks() -> list[str]:
+    """Every language that has at least one ``speech_to_phrase``-tagged block.
+
+    Discovered rather than hard-coded so adding a language's lean blocks does
+    not also require editing this list (and so a branch per language does not
+    collide here)."""
+    langs = []
+    for lang_dir in sorted(p for p in SENTENCES_DIR.iterdir() if p.is_dir()):
+        for combo_path in lang_dir.glob("*/*.yaml"):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            if any(b.get("speech_to_phrase") for b in data):
+                langs.append(lang_dir.name)
+                break
+    return langs
+
+
+LANGUAGES = _languages_with_s2p_blocks()
+
+_SLOT_REF = re.compile(r"\{([^{}]+)\}")
 
 
 def _load_expansion_rules(language: str) -> dict[str, str]:
@@ -44,10 +70,22 @@ def _load_expansion_rules(language: str) -> dict[str, str]:
     return rules
 
 
-def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
-    """Every phrasing a set of templates can produce, with slots left as literal
-    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
-    sides are compared on phrasing structure, not enumerated slot values."""
+def _list_name(ref: str) -> str:
+    """``timer_hours:hours`` -> ``timer_hours``; ``0..100`` -> ``_range``."""
+    name = ref.split(":", 1)[0].strip()
+    return "_range" if re.match(r"^-?\d+\s*\.\.", name) else name
+
+
+def _sentinel(list_name: str) -> str:
+    """A single word that cannot collide with real vocabulary."""
+    return "zz" + re.sub(r"[^a-z0-9]+", "", list_name.lower()) + "zz"
+
+
+def _lean_phrasings(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> set[str]:
+    """Every phrasing the lean templates produce, with each slot reference
+    replaced by its sentinel word."""
     intents = Intents.from_dict(
         {
             "language": language,
@@ -66,8 +104,47 @@ def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> se
                 expand_lists=False,
                 expand_ranges=False,
             ):
+                text = _SLOT_REF.sub(lambda m: _sentinel(_list_name(m.group(1))), text)
                 out.add(normalize_whitespace(text).strip())
     return out
+
+
+def _referenced_lists(sentences: list[str], rules: dict[str, str]) -> set[str]:
+    """List names reachable from these templates, following expansion rules."""
+    seen_rules: set[str] = set()
+    names: set[str] = set()
+    pending = list(sentences)
+    while pending:
+        text = pending.pop()
+        names.update(_list_name(m) for m in _SLOT_REF.findall(text))
+        for rule_name in re.findall(r"<([a-zA-Z0-9_]+)>", text):
+            if rule_name in rules and rule_name not in seen_rules:
+                seen_rules.add(rule_name)
+                pending.append(rules[rule_name])
+    return names
+
+
+def _rich_intents(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> tuple[Intents, dict[str, SlotList]]:
+    """Rich blocks as a recognizer, with every referenced list bound to its
+    sentinel so slot *contents* never affect the match."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {
+                "_S2P": {"data": [{"sentences": sentences, "slots": {"x": "y"}}]}
+            },
+            "expansion_rules": rules,
+        }
+    )
+    slot_lists: dict[str, SlotList] = {
+        name: TextSlotList.from_strings([_sentinel(name)])
+        for name in _referenced_lists(sentences, rules)
+    }
+    # An inline range (`{0..100}`) keeps its own ref text, so bind that too.
+    slot_lists.setdefault("_range", TextSlotList.from_strings([_sentinel("_range")]))
+    return intents, slot_lists
 
 
 def _collect() -> list[tuple[str, str, str]]:
@@ -98,17 +175,19 @@ def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
     ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
 
     rules = _load_expansion_rules(lang)
-    rich = _phrasings(
-        [s for block in ha_blocks for s in block["sentences"]], lang, rules
-    )
+    rich_sentences = [s for block in ha_blocks for s in block["sentences"]]
+    rich, slot_lists = _rich_intents(rich_sentences, lang, rules)
 
     for block in s2p_only:
-        lean = _phrasings(block["sentences"], lang, rules)
-        extra = lean - rich
+        extra = [
+            phrasing
+            for phrasing in sorted(_lean_phrasings(block["sentences"], lang, rules))
+            if recognize(phrasing, rich, slot_lists=slot_lists) is None
+        ]
         assert not extra, (
             f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
             f"not recognised by the Home Assistant (rich) block(s): "
-            f"{sorted(extra)[:10]}"
+            f"{extra[:10]}"
         )
 
 


### PR DESCRIPTION
Speech-to-Phrase builds a constrained FST grammar instead of matching with
hassil, so it consumes the `speech_to_phrase`-tagged subset of each slot
combination rather than the full block. Only English had those blocks, so the
add-on could not serve French even though a French acoustic model exists.

This adds **56 tagged blocks** covering the same 26 intents as English.

### How the sentences were chosen

Every sentence is a **restriction of French's own untagged templates** — taken
from what the rich blocks already accept, not newly invented phrasing. Home
Assistant's grammar is therefore unchanged: `partition_speech_to_phrase` drops
the tagged block whenever an untagged sibling exists, and the subset check
proves the lean language is contained in the rich one.

Two phrasings deliberately avoid a hyphen ("quelle heure est il", not
"est-il"): the FST drops hyphens, so a hyphenated sentence comes back
unhyphenated and Home Assistant's hyphenated template no longer matches it.

### Verification

Each block's `example` was synthesized with the French Home Assistant Cloud TTS
voice and decoded through the real Speech-to-Phrase grammar (`stt_fr_conformer_ctc_large`), then
scored on whether hassil resolves the transcript back to the command that was
spoken — not on string equality, since the decoder legitimately picks a
different in-grammar realization (articles drop, numbers are spelled out).

**55/56 on the model that was configured at the time; 56/56 after switching
French to `stt_fr_conformer_ctc_large`, which is a Speech-to-Phrase-side change.**

`script/test` and `python3 -m script.intentfest validate --language fr` both pass.

### Note on the shared test change

`tests/test_speech_to_phrase.py` now discovers languages from the tagged blocks
instead of a hard-coded `["en"]`, and checks containment by *matching* each lean
phrasing against the rich blocks rather than enumerating both sides. Enumeration
does not scale past English — the Spanish `HassTurnOn` blocks expand far enough
to exhaust memory — while matching is linear in the (small) lean side and gives
the same answer. Verified against a planted violation to confirm it still fails
when it should.

That change is **byte-identical in all seven of these language PRs**, so
whichever merges first makes it a no-op for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)