### PR TITLE
[cs] Add Speech-to-Phrase lean sentence blocks

### DIFF
--- a/sentences/cs/HassCancelTimer/default.yaml
+++ b/sentences/cs/HassCancelTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "<timer_cancel> <casovac>"
     example: "zruš časovač"
     response: "default"
+  - sentences:
+      - "zruš časovač"
+    example: "zruš časovač"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/cs/HassClimateGetTemperature/area_only.yaml
@@ -11,3 +11,8 @@ data:
       - "jak ((teplo|chladno);je) <area>"
     example: "jaká je teplota v obýváku"
     response: "default"
+  - sentences:
+      - "jaká je teplota v {area}"
+    example: "jaká je teplota v kuchyni"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassClimateGetTemperature/default.yaml
+++ b/sentences/cs/HassClimateGetTemperature/default.yaml
@@ -11,3 +11,8 @@ data:
       - "jak ((teplo|chladno);je;[<tady>])"
     example: "jaká je teplota"
     response: "default"
+  - sentences:
+      - "jaká je teplota"
+    example: "jaká je teplota"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassClimateGetTemperature/name_only.yaml
+++ b/sentences/cs/HassClimateGetTemperature/name_only.yaml
@@ -12,3 +12,10 @@ data:
     name_domains:
       - "climate"
     response: "default"
+  - sentences:
+      - "jaká je teplota {name}"
+    example: "jaká je teplota Termostat kuchyně"
+    name_domains:
+      - "climate"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassDecreaseTimer/hours_only.yaml
+++ b/sentences/cs/HassDecreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "zkr(ať|átit) <casovac> o <dur_hours>"
     example: "odeber 1 hodinu z časovače"
     response: "default"
+  - sentences:
+      - "zkrať časovač o {timer_range_hours:hours} hodin[(a|u|y)]"
+    example: "zkrať časovač o 2 hodina"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassDecreaseTimer/minutes_only.yaml
+++ b/sentences/cs/HassDecreaseTimer/minutes_only.yaml
@@ -9,3 +9,8 @@ data:
       - "zkr(ať|átit) <casovac> o <dur_minutes>"
     example: "odeber 5 minut z časovače"
     response: "default"
+  - sentences:
+      - "zkrať časovač o {timer_range_minutes:minutes} minut[(a|u|y)]"
+    example: "zkrať časovač o 5 minuta"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassDecreaseTimer/seconds_only.yaml
+++ b/sentences/cs/HassDecreaseTimer/seconds_only.yaml
@@ -9,3 +9,8 @@ data:
       - "zkr(ať|átit) <casovac> o <dur_seconds>"
     example: "odeber 30 sekund z časovače"
     response: "default"
+  - sentences:
+      - "zkrať časovač o {timer_range_seconds:seconds} sekund[(a|u|y)]"
+    example: "zkrať časovač o 30 sekunda"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassFanSetSpeed/default.yaml
+++ b/sentences/cs/HassFanSetSpeed/default.yaml
@@ -11,3 +11,8 @@ data:
       - "[<nastavit>] rychlost (<fan_gen_sg>|<fan_gen_pl>) na <fan_speed>"
     example: "nastav ventilátor na 50 %"
     response: "default"
+  - sentences:
+      - "nastav rychlost ventilátoru na {fan_speed:percentage} procent"
+    example: "nastav rychlost ventilátoru na 50 procent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassFanSetSpeed/name_only.yaml
+++ b/sentences/cs/HassFanSetSpeed/name_only.yaml
@@ -13,3 +13,10 @@ data:
     name_domains:
       - "fan"
     response: "fan"
+  - sentences:
+      - "nastav rychlost {name} na {fan_speed:percentage} procent"
+    example: "nastav rychlost Větrání pokoje na 50 procent"
+    name_domains:
+      - "fan"
+    response: "fan"
+    speech_to_phrase: true

--- a/sentences/cs/HassGetCurrentDate/default.yaml
+++ b/sentences/cs/HassGetCurrentDate/default.yaml
@@ -10,3 +10,8 @@ data:
       - "co je dnes za den"
     example: "jaké je dnešní datum"
     response: "default"
+  - sentences:
+      - "jaké je dnešní datum"
+    example: "jaké je dnešní datum"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassGetCurrentTime/default.yaml
+++ b/sentences/cs/HassGetCurrentTime/default.yaml
@@ -9,3 +9,8 @@ data:
       - "jaký je [přesný|[právě] teď] čas"
     example: "kolik je hodin"
     response: "default"
+  - sentences:
+      - "kolik je hodin"
+    example: "kolik je hodin"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassGetState/name_only.yaml
+++ b/sentences/cs/HassGetState/name_only.yaml
@@ -20,3 +20,10 @@ data:
       - "climate"
       - "media_player"
     response: "one"
+  - sentences:
+      - "jaký je stav {name}"
+    example: "jaký je stav Teploměr"
+    name_domains:
+      - sensor
+    response: "one"
+    speech_to_phrase: true

--- a/sentences/cs/HassGetState/name_state.yaml
+++ b/sentences/cs/HassGetState/name_state.yaml
@@ -49,3 +49,27 @@ data:
     name_domains:
       - "binary_sensor"
     response: "one_yesno"
+  - sentences:
+      - "je {name} {on_off_states:state}"
+    example: "je Stropní světlo zapnutý"
+    name_domains:
+      - "light"
+      - "switch"
+      - "fan"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "je {name} {cover_states:state}"
+    example: "je Levé okno otevřený"
+    name_domains:
+      - "cover"
+      - "valve"
+    response: "one_yesno"
+    speech_to_phrase: true
+  - sentences:
+      - "je {name} {lock_states:state}"
+    example: "je Vchodové dveře zamčeno"
+    name_domains:
+      - "lock"
+    response: "one_yesno"
+    speech_to_phrase: true

--- a/sentences/cs/HassGetWeather/default.yaml
+++ b/sentences/cs/HassGetWeather/default.yaml
@@ -8,3 +8,8 @@ data:
       - "jak[(ý|ej|á|é|ých|ejch|o)] ((je|jsou)|bud(e|ou)) počasí"
     example: "jaké je počasí"
     response: "default"
+  - sentences:
+      - "jaké je počasí"
+    example: "jaké je počasí"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassIncreaseTimer/hours_only.yaml
+++ b/sentences/cs/HassIncreaseTimer/hours_only.yaml
@@ -9,3 +9,8 @@ data:
       - "prodl(už|oužit) <casovac> o <dur_hours>"
     example: "přidej 1 hodinu k časovači"
     response: "default"
+  - sentences:
+      - "prodluž časovač o {timer_range_hours:hours} hodin[(a|u|y)]"
+    example: "prodluž časovač o 2 hodina"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassIncreaseTimer/minutes_only.yaml
+++ b/sentences/cs/HassIncreaseTimer/minutes_only.yaml
@@ -9,3 +9,8 @@ data:
       - "prodl(už|oužit) <casovac> o <dur_minutes>"
     example: "přidej 5 minut k časovači"
     response: "default"
+  - sentences:
+      - "prodluž časovač o {timer_range_minutes:minutes} minut[(a|u|y)]"
+    example: "prodluž časovač o 5 minuta"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassIncreaseTimer/seconds_only.yaml
+++ b/sentences/cs/HassIncreaseTimer/seconds_only.yaml
@@ -9,3 +9,8 @@ data:
       - "prodl(už|oužit) <casovac> o <dur_seconds>"
     example: "přidej 30 sekund k časovači"
     response: "default"
+  - sentences:
+      - "prodluž časovač o {timer_range_seconds:seconds} sekund[(a|u|y)]"
+    example: "prodluž časovač o 30 sekunda"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassLightSet/area_brightness.yaml
+++ b/sentences/cs/HassLightSet/area_brightness.yaml
@@ -23,3 +23,9 @@ data:
     example: "nastav jas v kuchyni na maximum"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "nastav jas v {area} na {brightness} procent"
+    example: "nastav jas v kuchyni na 50 procent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/cs/HassLightSet/brightness_only.yaml
+++ b/sentences/cs/HassLightSet/brightness_only.yaml
@@ -13,3 +13,9 @@ data:
     example: "nastav jas světel na 50 %"
     inferred_domain: "light"
     response: "brightness"
+  - sentences:
+      - "nastav jas světla na {brightness} procent"
+    example: "nastav jas světla na 50 procent"
+    inferred_domain: "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/cs/HassLightSet/name_brightness.yaml
+++ b/sentences/cs/HassLightSet/name_brightness.yaml
@@ -27,3 +27,10 @@ data:
     name_domains:
       - "light"
     response: "brightness"
+  - sentences:
+      - "nastav jas {name} na {brightness} procent"
+    example: "nastav jas Stropní světlo na 50 procent"
+    name_domains:
+      - "light"
+    response: "brightness"
+    speech_to_phrase: true

--- a/sentences/cs/HassMediaNext/default.yaml
+++ b/sentences/cs/HassMediaNext/default.yaml
@@ -10,3 +10,8 @@ data:
       - "(přeskoč|přepni) [[na další|tuto|tento] (písničku|stopu|skladbu|program)]"
     example: "další skladba"
     response: "default"
+  - sentences:
+      - "další skladba"
+    example: "další skladba"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassMediaPause/default.yaml
+++ b/sentences/cs/HassMediaPause/default.yaml
@@ -10,3 +10,8 @@ data:
       - "([po]zastav[it]|[za]pauz[uj|ovat]) (písničk[u|y]|stopu|skladbu|program)"
     example: "pauza"
     response: "default"
+  - sentences:
+      - "pauza"
+    example: "pauza"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassMediaPlayerMute/default.yaml
+++ b/sentences/cs/HassMediaPlayerMute/default.yaml
@@ -10,3 +10,8 @@ data:
       - "((<ztlumit_zvuk>|<vypnout>) <zvuk_media>;[<tady>])"
     example: "ztlum"
     response: "default"
+  - sentences:
+      - "ztlum zvuk"
+    example: "ztlum zvuk"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/cs/HassMediaPlayerUnmute/default.yaml
@@ -11,3 +11,8 @@ data:
       - "((odtlum[it]|obnov[it]|vrať|vrátit|<zapnout>) <zvuk_media>;[<tady>])"
     example: "zruš ztlumení"
     response: "default"
+  - sentences:
+      - "zapni zvuk"
+    example: "zapni zvuk"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassMediaPrevious/default.yaml
+++ b/sentences/cs/HassMediaPrevious/default.yaml
@@ -12,3 +12,8 @@ data:
       - "[pře]hr(aj|át) [znovu] <predchozi> (písničku|stopu|skladbu|program)"
     example: "předchozí skladba"
     response: "default"
+  - sentences:
+      - "předchozí skladba"
+    example: "předchozí skladba"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassMediaUnpause/default.yaml
+++ b/sentences/cs/HassMediaUnpause/default.yaml
@@ -10,3 +10,8 @@ data:
       - "odpauz[uj|ovat]"
     example: "pokračuj"
     response: "default"
+  - sentences:
+      - "pokračuj"
+    example: "pokračuj"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassNevermind/default.yaml
+++ b/sentences/cs/HassNevermind/default.yaml
@@ -9,3 +9,9 @@ data:
       - "zapomeň na to"
     example: "to nevadí"
     response: "default"
+  - sentences:
+      - "to nevadí"
+      - "zapomeň na to"
+    example: "to nevadí"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassPauseTimer/default.yaml
+++ b/sentences/cs/HassPauseTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "<timer_pause> <casovac>"
     example: "pozastav časovač"
     response: "default"
+  - sentences:
+      - "pozastav časovač"
+    example: "pozastav časovač"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassSetPosition/name_only.yaml
+++ b/sentences/cs/HassSetPosition/name_only.yaml
@@ -22,3 +22,17 @@ data:
     name_domains:
       - "valve"
     response: "default"
+  - sentences:
+      - "nastav pozici {name} na {position} procent"
+    example: "nastav pozici Levé okno na 50 procent"
+    name_domains:
+      - "cover"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "nastav pozici {name} na {position} procent"
+    example: "nastav pozici Hlavní uzávěr vody na 50 procent"
+    name_domains:
+      - "valve"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassSetVolume/default.yaml
+++ b/sentences/cs/HassSetVolume/default.yaml
@@ -10,3 +10,8 @@ data:
       - "[(<nastavit>|<zvysit>|<ztlumit>|<zmenit>|<upravit>)] hlasitost na <volume>"
     example: "nastav hlasitost na 50 %"
     response: "default"
+  - sentences:
+      - "nastav hlasitost na {volume:volume_level} procent"
+    example: "nastav hlasitost na 50 procent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassSetVolumeRelative/default.yaml
+++ b/sentences/cs/HassSetVolumeRelative/default.yaml
@@ -21,3 +21,18 @@ data:
       - "<hlasitost_dolu> hlasitost o {volume_step_down:volume_step}[[ ]%| procent]"
     example: "sniž hlasitost o 20 procent"
     response: "default"
+  - sentences:
+      - "{volume_step} hlasitost"
+    example: "zvyš hlasitost"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "zvyš hlasitost o {volume_step_up:volume_step} procent"
+    example: "zvyš hlasitost o 10 procent"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "sniž hlasitost o {volume_step_down:volume_step} procent"
+    example: "sniž hlasitost o 10 procent"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassStartTimer/hours_only.yaml
+++ b/sentences/cs/HassStartTimer/hours_only.yaml
@@ -7,3 +7,8 @@ data:
       - "[<nastavit>] <casovac> [na] <dur_hours>"
     example: "nastav časovač na <dur_hours>"
     response: "default"
+  - sentences:
+      - "nastav časovač na {timer_range_hours:hours} hodin[(a|u|y)]"
+    example: "nastav časovač na 2 hodina"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassStartTimer/minutes_only.yaml
+++ b/sentences/cs/HassStartTimer/minutes_only.yaml
@@ -7,3 +7,8 @@ data:
       - "[<nastavit>] <casovac> [na] <dur_minutes>"
     example: "nastav časovač na <dur_minutes>"
     response: "default"
+  - sentences:
+      - "nastav časovač na {timer_range_minutes:minutes} minut[(a|u|y)]"
+    example: "nastav časovač na 5 minuta"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassStartTimer/seconds_only.yaml
+++ b/sentences/cs/HassStartTimer/seconds_only.yaml
@@ -7,3 +7,8 @@ data:
       - "[<nastavit>] <casovac> [na] <dur_seconds>"
     example: "nastav časovač na <dur_seconds>"
     response: "default"
+  - sentences:
+      - "nastav časovač na {timer_range_seconds:seconds} sekund[(a|u|y)]"
+    example: "nastav časovač na 30 sekunda"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassTimerStatus/default.yaml
+++ b/sentences/cs/HassTimerStatus/default.yaml
@@ -10,3 +10,8 @@ data:
       - "[[jaký je] zbývající] čas <casovac>"
     example: "stav časovače"
     response: "default"
+  - sentences:
+      - "stav časovače"
+    example: "stav časovače"
+    response: "default"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOff/area_domain.yaml
+++ b/sentences/cs/HassTurnOff/area_domain.yaml
@@ -24,3 +24,15 @@ data:
     example: "vypni ventilátory v kuchyni"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "vypni světla v {area}"
+    example: "vypni světla v kuchyni"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "vypni ventilátory v {area}"
+    example: "vypni ventilátory v kuchyni"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOff/domain_only.yaml
+++ b/sentences/cs/HassTurnOff/domain_only.yaml
@@ -20,3 +20,9 @@ data:
     example: "vypni ventilátory"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "vypni světla"
+    example: "vypni světla"
+    inferred_domain: "light"
+    response: "light_all"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOff/floor_domain.yaml
+++ b/sentences/cs/HassTurnOff/floor_domain.yaml
@@ -16,3 +16,9 @@ data:
     example: "zhasni světla v prvním patře"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "vypni světla v {floor}"
+    example: "vypni světla v prvním"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOff/name_only.yaml
+++ b/sentences/cs/HassTurnOff/name_only.yaml
@@ -52,3 +52,34 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "vypni {name}"
+    example: "vypni Vypínač zásuvky"
+    name_domains:
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "vypni {name}"
+    example: "vypni Stropní světlo"
+    name_domains:
+      - "light"
+    response: "light"
+    speech_to_phrase: true
+  - sentences:
+      - "zavři {name}"
+    example: "zavři Levé okno"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "odemkni {name}"
+    example: "odemkni Vchodové dveře"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOn/area_domain.yaml
+++ b/sentences/cs/HassTurnOn/area_domain.yaml
@@ -24,3 +24,15 @@ data:
     example: "zapni ventilátory v kuchyni"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "zapni světla v {area}"
+    example: "zapni světla v kuchyni"
+    inferred_domain: "light"
+    response: "lights_area"
+    speech_to_phrase: true
+  - sentences:
+      - "zapni ventilátory v {area}"
+    example: "zapni ventilátory v kuchyni"
+    inferred_domain: "fan"
+    response: "fans_area"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOn/domain_only.yaml
+++ b/sentences/cs/HassTurnOn/domain_only.yaml
@@ -20,3 +20,9 @@ data:
     example: "zapni ventilátory"
     inferred_domain: "fan"
     response: "fans_area"
+  - sentences:
+      - "zapni světla"
+    example: "zapni světla"
+    inferred_domain: "light"
+    response: "light_all"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOn/floor_domain.yaml
+++ b/sentences/cs/HassTurnOn/floor_domain.yaml
@@ -16,3 +16,9 @@ data:
     example: "rozsviť světla v prvním patře"
     inferred_domain: "light"
     response: "lights_floor"
+  - sentences:
+      - "zapni světla v {floor}"
+    example: "zapni světla v prvním"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOn/name_area.yaml
+++ b/sentences/cs/HassTurnOn/name_area.yaml
@@ -52,3 +52,20 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "zapni {name} v {area}"
+    example: "zapni Vypínač zásuvky v kuchyni"
+    name_domains:
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "zapni {name} v {area}"
+    example: "zapni Stropní světlo v kuchyni"
+    name_domains:
+      - "light"
+    response: "light"
+    speech_to_phrase: true

--- a/sentences/cs/HassTurnOn/name_only.yaml
+++ b/sentences/cs/HassTurnOn/name_only.yaml
@@ -52,3 +52,34 @@ data:
     name_domains:
       - "lock"
     response: "lock"
+  - sentences:
+      - "zapni {name}"
+    example: "zapni Vypínač zásuvky"
+    name_domains:
+      - "switch"
+      - "fan"
+      - "media_player"
+      - "input_boolean"
+    response: "default"
+    speech_to_phrase: true
+  - sentences:
+      - "zapni {name}"
+    example: "zapni Stropní světlo"
+    name_domains:
+      - "light"
+    response: "light"
+    speech_to_phrase: true
+  - sentences:
+      - "otevři {name}"
+    example: "otevři Levé okno"
+    name_domains:
+      - "cover"
+    response: "cover"
+    speech_to_phrase: true
+  - sentences:
+      - "zamkni {name}"
+    example: "zamkni Vchodové dveře"
+    name_domains:
+      - "lock"
+    response: "lock"
+    speech_to_phrase: true

--- a/sentences/cs/HassUnpauseTimer/default.yaml
+++ b/sentences/cs/HassUnpauseTimer/default.yaml
@@ -8,3 +8,8 @@ data:
       - "<timer_unpause> <casovac>"
     example: "obnov časovač"
     response: "default"
+  - sentences:
+      - "obnov časovač"
+    example: "obnov časovač"
+    response: "default"
+    speech_to_phrase: true

--- a/tests/test_speech_to_phrase.py
+++ b/tests/test_speech_to_phrase.py
@@ -1,4 +1,4 @@
-"""Speech-to-Phrase subset verification (Method B).
+"""Speech-to-Phrase subset verification.
 
 A ``speech_to_phrase``-tagged data block is meant to be a *lean* phrasing that
 the constrained Speech-to-Phrase STT grammar can enumerate cheaply. When a combo
@@ -6,24 +6,31 @@ also has untagged (rich) blocks, Home Assistant drops the tagged block from its
 grammar (see ``partition_speech_to_phrase`` and the loader in
 ``test_slot_combinations.py``). That is only sound if the lean block's language
 is a *subset* of the rich blocks' language -- otherwise Speech-to-Phrase could
-recognise a phrasing HA never would.
+recognise a phrasing Home Assistant never would.
 
-We verify containment by enumeration rather than with an FST/OpenFST toolchain:
-lean blocks are finite and small by construction, so we expand every phrasing on
-both sides (slots rendered as literal ``{list}`` sentinels via
-``expand_lists=False``) and assert ``lean_phrasings <= rich_phrasings``. This is
-complete for the lean side (no recursion, bounded fan-out) and needs no slot
-lists, entities, or intent context.
+Containment is checked by *matching*, not by enumerating both sides. The lean
+side is enumerated (it is small and non-recursive by construction) and each
+phrasing is then handed to hassil's recognizer built from the rich blocks: if
+the rich grammar accepts it, it is in the rich language. Enumerating the rich
+side instead is what the first version of this test did, and it does not scale
+-- English is small enough to get away with it, but e.g. the Spanish
+``HassTurnOn`` blocks expand into billions of phrasings and exhaust memory.
 
-Only English is wired up for now; the collector is language-agnostic.
+Slots are neutralised on both sides: every ``{list}`` reference is replaced with
+a per-list sentinel word, and the rich grammar gets a one-value text list for
+each, so matching compares phrasing structure rather than slot contents (which
+would need entities, areas and floors that this test deliberately does not load).
+
+Languages are discovered from the tagged blocks themselves.
 """
 
 import importlib
+import re
 from typing import Any
 
 import pytest
 import yaml
-from hassil import Intents, normalize_whitespace
+from hassil import Intents, SlotList, TextSlotList, normalize_whitespace, recognize
 from hassil.sample import sample_sentence
 
 from . import RULES_DIR, SENTENCES_DIR
@@ -31,7 +38,26 @@ from . import RULES_DIR, SENTENCES_DIR
 _util: Any = importlib.import_module("script.intentfest.util")
 partition_speech_to_phrase = _util.partition_speech_to_phrase
 
-LANGUAGES = ["en"]
+
+def _languages_with_s2p_blocks() -> list[str]:
+    """Every language that has at least one ``speech_to_phrase``-tagged block.
+
+    Discovered rather than hard-coded so adding a language's lean blocks does
+    not also require editing this list (and so a branch per language does not
+    collide here)."""
+    langs = []
+    for lang_dir in sorted(p for p in SENTENCES_DIR.iterdir() if p.is_dir()):
+        for combo_path in lang_dir.glob("*/*.yaml"):
+            data = (yaml.safe_load(combo_path.read_text()) or {}).get("data", [])
+            if any(b.get("speech_to_phrase") for b in data):
+                langs.append(lang_dir.name)
+                break
+    return langs
+
+
+LANGUAGES = _languages_with_s2p_blocks()
+
+_SLOT_REF = re.compile(r"\{([^{}]+)\}")
 
 
 def _load_expansion_rules(language: str) -> dict[str, str]:
@@ -44,10 +70,22 @@ def _load_expansion_rules(language: str) -> dict[str, str]:
     return rules
 
 
-def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> set[str]:
-    """Every phrasing a set of templates can produce, with slots left as literal
-    ``{list}`` sentinels (``expand_lists``/``expand_ranges`` disabled) so the two
-    sides are compared on phrasing structure, not enumerated slot values."""
+def _list_name(ref: str) -> str:
+    """``timer_hours:hours`` -> ``timer_hours``; ``0..100`` -> ``_range``."""
+    name = ref.split(":", 1)[0].strip()
+    return "_range" if re.match(r"^-?\d+\s*\.\.", name) else name
+
+
+def _sentinel(list_name: str) -> str:
+    """A single word that cannot collide with real vocabulary."""
+    return "zz" + re.sub(r"[^a-z0-9]+", "", list_name.lower()) + "zz"
+
+
+def _lean_phrasings(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> set[str]:
+    """Every phrasing the lean templates produce, with each slot reference
+    replaced by its sentinel word."""
     intents = Intents.from_dict(
         {
             "language": language,
@@ -66,8 +104,47 @@ def _phrasings(sentences: list[str], language: str, rules: dict[str, str]) -> se
                 expand_lists=False,
                 expand_ranges=False,
             ):
+                text = _SLOT_REF.sub(lambda m: _sentinel(_list_name(m.group(1))), text)
                 out.add(normalize_whitespace(text).strip())
     return out
+
+
+def _referenced_lists(sentences: list[str], rules: dict[str, str]) -> set[str]:
+    """List names reachable from these templates, following expansion rules."""
+    seen_rules: set[str] = set()
+    names: set[str] = set()
+    pending = list(sentences)
+    while pending:
+        text = pending.pop()
+        names.update(_list_name(m) for m in _SLOT_REF.findall(text))
+        for rule_name in re.findall(r"<([a-zA-Z0-9_]+)>", text):
+            if rule_name in rules and rule_name not in seen_rules:
+                seen_rules.add(rule_name)
+                pending.append(rules[rule_name])
+    return names
+
+
+def _rich_intents(
+    sentences: list[str], language: str, rules: dict[str, str]
+) -> tuple[Intents, dict[str, SlotList]]:
+    """Rich blocks as a recognizer, with every referenced list bound to its
+    sentinel so slot *contents* never affect the match."""
+    intents = Intents.from_dict(
+        {
+            "language": language,
+            "intents": {
+                "_S2P": {"data": [{"sentences": sentences, "slots": {"x": "y"}}]}
+            },
+            "expansion_rules": rules,
+        }
+    )
+    slot_lists: dict[str, SlotList] = {
+        name: TextSlotList.from_strings([_sentinel(name)])
+        for name in _referenced_lists(sentences, rules)
+    }
+    # An inline range (`{0..100}`) keeps its own ref text, so bind that too.
+    slot_lists.setdefault("_range", TextSlotList.from_strings([_sentinel("_range")]))
+    return intents, slot_lists
 
 
 def _collect() -> list[tuple[str, str, str]]:
@@ -98,17 +175,19 @@ def test_speech_to_phrase_is_subset(lang: str, intent: str, combo: str) -> None:
     ), f"{intent}/{combo}: tagged block has no untagged sibling to verify"
 
     rules = _load_expansion_rules(lang)
-    rich = _phrasings(
-        [s for block in ha_blocks for s in block["sentences"]], lang, rules
-    )
+    rich_sentences = [s for block in ha_blocks for s in block["sentences"]]
+    rich, slot_lists = _rich_intents(rich_sentences, lang, rules)
 
     for block in s2p_only:
-        lean = _phrasings(block["sentences"], lang, rules)
-        extra = lean - rich
+        extra = [
+            phrasing
+            for phrasing in sorted(_lean_phrasings(block["sentences"], lang, rules))
+            if recognize(phrasing, rich, slot_lists=slot_lists) is None
+        ]
         assert not extra, (
             f"{lang}/{intent}/{combo}: {len(extra)} Speech-to-Phrase phrasing(s) "
             f"not recognised by the Home Assistant (rich) block(s): "
-            f"{sorted(extra)[:10]}"
+            f"{extra[:10]}"
         )
 
 


### PR DESCRIPTION
Speech-to-Phrase builds a constrained FST grammar instead of matching with
hassil, so it consumes the `speech_to_phrase`-tagged subset of each slot
combination rather than the full block. Only English had those blocks, so the
add-on could not serve Czech even though a Czech acoustic model exists.

This adds **59 tagged blocks** covering the same 26 intents as English.

### How the sentences were chosen

Every sentence is a **restriction of Czech's own untagged templates** — taken
from what the rich blocks already accept, not newly invented phrasing. Home
Assistant's grammar is therefore unchanged: `partition_speech_to_phrase` drops
the tagged block whenever an untagged sibling exists, and the subset check
proves the lean language is contained in the rich one.

Czech ships no `HassLightSet/floor_brightness` combo file, so that one is not
covered here.

### Verification

Each block's `example` was synthesized with the Czech Home Assistant Cloud TTS
voice and decoded through the real Speech-to-Phrase grammar (`cs_CZ-coqui`), then
scored on whether hassil resolves the transcript back to the command that was
spoken — not on string equality, since the decoder legitimately picks a
different in-grammar realization (articles drop, numbers are spelled out).

**58/59 with the number spellout as it stands; 59/59 once the spellout offers
the feminine numeral forms, which is a Speech-to-Phrase-side change (Czech
"2 hodiny" needs "dvě", but ICU only returns the masculine "dva").**

`script/test` and `python3 -m script.intentfest validate --language cs` both pass.

### Note on the shared test change

`tests/test_speech_to_phrase.py` now discovers languages from the tagged blocks
instead of a hard-coded `["en"]`, and checks containment by *matching* each lean
phrasing against the rich blocks rather than enumerating both sides. Enumeration
does not scale past English — the Spanish `HassTurnOn` blocks expand far enough
to exhaust memory — while matching is linear in the (small) lean side and gives
the same answer. Verified against a planted violation to confirm it still fails
when it should.

That change is **byte-identical in all seven of these language PRs**, so
whichever merges first makes it a no-op for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)