### PR TITLE
[DE] Add imperative templates for media player mute and unmute

### DIFF
--- a/sentences/de/HassMediaPlayerMute/default.yaml
+++ b/sentences/de/HassMediaPlayerMute/default.yaml
@@ -7,6 +7,7 @@ language: de
 data:
   - sentences:
       - "[<source_of_noise> ][<hier> ]<media_mute>"
+      - "(<schalten>|<machen>|stell[e]) [<source_of_noise> ][<hier> ]stumm"
     example: Musik muten
     response: default
   - sentences:

--- a/sentences/de/HassMediaPlayerMute/name_only.yaml
+++ b/sentences/de/HassMediaPlayerMute/name_only.yaml
@@ -6,6 +6,7 @@ language: de
 data:
   - sentences:
       - "[<source_of_noise> ((auf|von)[ dem]|vom) ][<artikel_bestimmt> ]{name} <media_mute>"
+      - "(<schalten>|<machen>|stell[e]) [<artikel_bestimmt> ]{name} stumm"
     example: TV muten
     name_domains:
       - media_player

--- a/sentences/de/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/de/HassMediaPlayerUnmute/default.yaml
@@ -7,6 +7,9 @@ language: de
 data:
   - sentences:
       - "[<source_of_noise> ][<hier> ]<media_unmute>"
+      - "entmut[e] [<source_of_noise> ][<hier>]"
+      - "heb[e] die Stummschaltung [<hier> ]auf"
+      - "(<schalten>|<machen>) [<source_of_noise> ][<hier> ][wieder ]laut"
     example: Musik entmuten
     response: default
   - sentences:

--- a/sentences/de/HassMediaPlayerUnmute/name_only.yaml
+++ b/sentences/de/HassMediaPlayerUnmute/name_only.yaml
@@ -6,6 +6,9 @@ language: de
 data:
   - sentences:
       - "[<source_of_noise> ((auf|von)[ dem]|vom) ][<artikel_bestimmt> ]{name} <media_unmute>"
+      - "entmut[e] [<artikel_bestimmt> ]{name}"
+      - "heb[e] die Stummschaltung <von_dem> [<artikel_bestimmt> ]{name} auf"
+      - "(<schalten>|<machen>) [<artikel_bestimmt> ]{name} [wieder ]laut"
     example: TV entmuten
     name_domains:
       - media_player

--- a/tests/de/HassMediaPlayerMute/default.yaml
+++ b/tests/de/HassMediaPlayerMute/default.yaml
@@ -14,4 +14,7 @@ tests:
       - den Fernseher im Zimmer stumm schalten
       - das Radio hier in diesem Raum stumm schalten
       - das Radio hier in diesem Zimmer stumm schalten
+      - schalte die Musik stumm
+      - stelle den Fernseher stumm
+      - mach das Radio hier stumm
     response: Stumm geschaltet

--- a/tests/de/HassMediaPlayerMute/name_only.yaml
+++ b/tests/de/HassMediaPlayerMute/name_only.yaml
@@ -16,6 +16,9 @@ tests:
       - TV Stummschaltung an
       - TV Stummschaltung ein
       - TV Stummschaltung aktivieren
+      - schalte den TV stumm
+      - stelle den TV stumm
+      - mach den TV stumm
     slots:
       name: TV
     response: Stumm geschaltet

--- a/tests/de/HassMediaPlayerUnmute/default.yaml
+++ b/tests/de/HassMediaPlayerUnmute/default.yaml
@@ -14,4 +14,7 @@ tests:
       - Fernseher im Zimmer Ton einschalten
       - Radio hier in diesem Raum Ton einschalten
       - Radio hier in diesem Zimmer Ton einschalten
+      - entmute die Musik
+      - hebe die Stummschaltung auf
+      - schalte den Fernseher wieder laut
     response: Stummschaltung aus

--- a/tests/de/HassMediaPlayerUnmute/name_only.yaml
+++ b/tests/de/HassMediaPlayerUnmute/name_only.yaml
@@ -15,6 +15,9 @@ tests:
       - TV Stummschaltung aufheben
       - TV Stummschaltung aus
       - TV Stummschaltung deaktivieren
+      - entmute den TV
+      - hebe die Stummschaltung vom TV auf
+      - schalte den TV wieder laut
     slots:
       name: TV
     response: Stummschaltung aus


### PR DESCRIPTION
German only has verb-final templates for muting, so "Fernseher stummschalten" is recognized but "schalte den Fernseher stumm" is not. The imperative with a separable verb is the phrasing people actually use, and English already has it ("mute the TV"), so this adds it to both mute and unmute using the same pattern HassTurnOn uses in German.
