### PR TITLE
Require a media noun in Speech-to-Phrase media commands

### DIFF
--- a/rules/en/media.yaml
+++ b/rules/en/media.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+
+expansion_rules:
+  # Media nouns, used to give transport commands something to hang on.
+  # Speech-to-Phrase blocks require one of these so its constrained STT grammar
+  # never has to score a bare one-word command ("pause", "skip", "resume"),
+  # which is too short to recognise reliably.
+  track: "(song|track|item)"
+  media: "(music|movie|[tv] show[s]|media [player[s]]|<track>)"

--- a/sentences/ca/HassMediaPause/default.yaml
+++ b/sentences/ca/HassMediaPause/default.yaml
@@ -6,12 +6,15 @@
 language: "ca"
 data:
   - sentences:
-      - "pausa[r]"
+      - "pausa[r] [[la|la meva] (música|reproducció|sèrie|reproductor)]"
       - "(atura|para|deté)[r] [la reproducció|la música]"
     example: "pausa"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pausa".
   - sentences:
-      - "pausa"
-    example: "pausa"
+      - "pausa la (música|reproducció|sèrie)"
+      - "atura la (reproducció|música)"
+    example: "pausa la música"
     response: "default"
     speech_to_phrase: true

--- a/sentences/ca/HassMediaPlayerMute/default.yaml
+++ b/sentences/ca/HassMediaPlayerMute/default.yaml
@@ -14,8 +14,12 @@ data:
       - "silencia la (m(u|ú)sica) [aqui]"
     example: "silencia"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "silencia".
   - sentences:
-      - "silencia"
-    example: "silencia"
+      - "silencia la música"
+      - "silencia el reproductor"
+      - "treu el so"
+    example: "silencia la música"
     response: "default"
     speech_to_phrase: true

--- a/sentences/ca/HassMediaUnpause/default.yaml
+++ b/sentences/ca/HassMediaUnpause/default.yaml
@@ -6,11 +6,13 @@
 language: "ca"
 data:
   - sentences:
-      - "<reactiva>"
+      - "<reactiva> [[la|la meva] (música|reproducció|sèrie|reproductor)]"
     example: "reprèn"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "continua".
   - sentences:
-      - "continua"
-    example: "continua"
+      - "(continua|reprèn|reanuda) la (música|reproducció|sèrie)"
+    example: "continua la música"
     response: "default"
     speech_to_phrase: true

--- a/sentences/ca/HassNevermind/default.yaml
+++ b/sentences/ca/HassNevermind/default.yaml
@@ -11,9 +11,12 @@ data:
       - "(deixa|oblida)-ho [tot]"
     example: "deixa-ho"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above. Both phrasings are
+  # natural interjections; only the single-syllable "res" is dropped, since
+  # the constrained STT grammar cannot score an utterance that short.
   - sentences:
-      - "res"
       - "deixa-ho"
-    example: "res"
+      - "oblida-ho"
+    example: "deixa-ho"
     response: "default"
     speech_to_phrase: true

--- a/sentences/cs/HassMediaPause/default.yaml
+++ b/sentences/cs/HassMediaPause/default.yaml
@@ -10,8 +10,10 @@ data:
       - "([po]zastav[it]|[za]pauz[uj|ovat]) (písničk[u|y]|stopu|skladbu|program)"
     example: "pauza"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pauza".
   - sentences:
-      - "pauza"
-    example: "pauza"
+      - "(zastav|pozastav|pauzuj|zapauzuj) (písničku|skladbu|program)"
+    example: "zastav písničku"
     response: "default"
     speech_to_phrase: true

--- a/sentences/de/HassMediaPause/default.yaml
+++ b/sentences/de/HassMediaPause/default.yaml
@@ -11,8 +11,11 @@ data:
       - "[(die|das|mein|meine) ]<media_type> [<hier> ](pausieren|pause|anhalten|stop[p]|stoppen|aus[schalten])"
     example: "pausiere die Musik"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pause".
   - sentences:
-      - "(pause|pausiere|stopp)"
-    example: "pause"
+      - "(pausiere|stoppe) die (musik|sendung)"
+      - "(musik|sendung) (pausieren|anhalten|stoppen)"
+    example: "pausiere die Musik"
     response: "default"
     speech_to_phrase: true

--- a/sentences/de/HassMediaUnpause/default.yaml
+++ b/sentences/de/HassMediaUnpause/default.yaml
@@ -12,10 +12,10 @@ data:
       - "lass [(die|das|mein|meine) ]<media_type> [<hier> ]weiter(spielen|laufen)"
     example: "Musik fortsetzen"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "fortsetzen".
   - sentences:
-      - "fortsetzen"
-      - "weiter machen"
-      - "musik fortsetzen"
-    example: "fortsetzen"
+      - "[die ](musik|sendung) (fortsetzen|weiter machen)"
+    example: "musik fortsetzen"
     response: "default"
     speech_to_phrase: true

--- a/sentences/en/HassMediaNext/default.yaml
+++ b/sentences/en/HassMediaNext/default.yaml
@@ -6,8 +6,17 @@
 language: "en"
 data:
   - sentences:
-      - "next [track|item]"
-      - "(skip [(to [the] next [(song|track)]|([the] (song|track)|this [(song|track)]))])"
+      - "next [<track>]"
+      - "skip [this] [<track>]"
+      - "skip the <track>"
+      - "skip to [the] next [<track>]"
     example: "next track"
+    response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "next"/"skip".
+  - sentences:
+      - "next <track>"
+      - "skip [this|the] <track>"
+      - "skip to [the] next <track>"
     response: "default"
     speech_to_phrase: true

--- a/sentences/en/HassMediaPause/default.yaml
+++ b/sentences/en/HassMediaPause/default.yaml
@@ -6,8 +6,14 @@
 language: "en"
 data:
   - sentences:
-      - "pause"
-      - "stop [playing]"
+      - "pause [[<the>] <media>]"
+      - "stop [playing] [[<the>] <media>]"
     example: "pause"
+    response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pause".
+  - sentences:
+      - "pause [<the>] <media>"
+      - "stop [playing] [<the>] <media>"
     response: "default"
     speech_to_phrase: true

--- a/sentences/en/HassMediaPlayerMute/default.yaml
+++ b/sentences/en/HassMediaPlayerMute/default.yaml
@@ -6,12 +6,12 @@
 language: "en"
 data:
   - sentences:
-      - "mute"
-      - "mute ([the] (music|media [player[s]])) [<here>]"
+      - "mute [[<the>] <media>] [<here>]"
     example: "mute"
     response: "default"
-  # Speech-to-Phrase: lean subset of the block above.
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "mute".
   - sentences:
-      - "mute"
+      - "mute [<the>] <media>"
     response: "default"
     speech_to_phrase: true

--- a/sentences/en/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/en/HassMediaPlayerUnmute/default.yaml
@@ -6,12 +6,12 @@
 language: "en"
 data:
   - sentences:
-      - "unmute"
-      - "unmute ([the] (music|media [player[s]])) [<here>]"
+      - "unmute [[<the>] <media>] [<here>]"
     example: "unmute"
     response: "default"
-  # Speech-to-Phrase: lean subset of the block above.
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "unmute".
   - sentences:
-      - "unmute"
+      - "unmute [<the>] <media>"
     response: "default"
     speech_to_phrase: true

--- a/sentences/en/HassMediaPrevious/default.yaml
+++ b/sentences/en/HassMediaPrevious/default.yaml
@@ -6,10 +6,18 @@
 language: "en"
 data:
   - sentences:
-      - "previous (track|item)"
-      - "go back [to the (previous|last) (song|track)]"
-      - "replay [the (previous|last) (song|track)] [again]"
-      - "play [the] (previous|last) [(song|track)] [again]"
+      - "previous <track>"
+      - "go back [to the (previous|last) <track>]"
+      - "replay [the (previous|last) <track>] [again]"
+      - "play [the] (previous|last) [<track>] [again]"
     example: "previous track"
+    response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "replay".
+  - sentences:
+      - "previous <track>"
+      - "go back to the (previous|last) <track>"
+      - "replay the (previous|last) <track> [again]"
+      - "play [the] (previous|last) <track> [again]"
     response: "default"
     speech_to_phrase: true

--- a/sentences/en/HassMediaUnpause/default.yaml
+++ b/sentences/en/HassMediaUnpause/default.yaml
@@ -6,7 +6,12 @@
 language: "en"
 data:
   - sentences:
-      - "(unpause|resume)"
+      - "(unpause|resume) [[<the>] <media>]"
     example: "resume"
+    response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "resume".
+  - sentences:
+      - "(unpause|resume) [<the>] <media>"
     response: "default"
     speech_to_phrase: true

--- a/sentences/es/HassMediaPause/default.yaml
+++ b/sentences/es/HassMediaPause/default.yaml
@@ -10,9 +10,10 @@ data:
       - "<pausa> [la |el |mi ](música|programa|vídeo|video|reproducción|reproductor)"
     example: "pausa"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pausa".
   - sentences:
-      - "pausa"
-      - "pausa la música"
-    example: "pausa"
+      - "pausa (la música|el programa|la reproducción)"
+    example: "pausa la música"
     response: "default"
     speech_to_phrase: true

--- a/sentences/es/HassMediaPlayerMute/default.yaml
+++ b/sentences/es/HassMediaPlayerMute/default.yaml
@@ -13,9 +13,11 @@ data:
       - "pon [en] silencio ([el|la] (música|audio|sonido|reproducción|reproductor[es])) [<de_aqui>]"
     example: "silenciar"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "silenciar".
   - sentences:
-      - "silenciar"
-      - "quita el sonido"
-    example: "silenciar"
+      - "silencia (la música|el audio|la reproducción)"
+      - "quita el (sonido|volumen)"
+    example: "silencia la música"
     response: "default"
     speech_to_phrase: true

--- a/sentences/es/HassMediaUnpause/default.yaml
+++ b/sentences/es/HassMediaUnpause/default.yaml
@@ -11,9 +11,10 @@ data:
       - "<reproduce> [la |el |mi ](música|programa|vídeo|video|reproducción|reproductor)"
     example: "continúa"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "continúa".
   - sentences:
-      - "continúa"
-      - "reanuda la reproducción"
-    example: "continúa"
+      - "(continúa|reanuda) (la música|el programa|la reproducción)"
+    example: "continúa la música"
     response: "default"
     speech_to_phrase: true

--- a/sentences/fr/HassMediaPause/default.yaml
+++ b/sentences/fr/HassMediaPause/default.yaml
@@ -13,9 +13,11 @@ data:
       - "<mets> [<le>]<media> (sur|en) pause"
     example: "arrête la musique"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pause".
   - sentences:
-      - "pause"
-      - "arrête la lecture"
+      - "arrête la (lecture|musique)"
+      - "mets la musique en pause"
     example: "arrête la lecture"
     response: "default"
     speech_to_phrase: true

--- a/sentences/fr/HassMediaPlayerMute/default.yaml
+++ b/sentences/fr/HassMediaPlayerMute/default.yaml
@@ -12,9 +12,11 @@ data:
       - "charrue"
     example: "sourdine"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "sourdine".
   - sentences:
       - "mets le son en sourdine"
-      - "sourdine"
+      - "coupe le son"
     example: "mets le son en sourdine"
     response: "default"
     speech_to_phrase: true

--- a/sentences/it/HassMediaPause/default.yaml
+++ b/sentences/it/HassMediaPause/default.yaml
@@ -10,9 +10,11 @@ data:
       - "(metti in pausa|pausa) [il |i |su |sul |sui ]media player"
     example: "metti in pausa la musica"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pausa".
   - sentences:
-      - "pausa"
       - "metti in pausa la musica"
-    example: "pausa"
+      - "pausa (la musica|il programma|il media player)"
+    example: "metti in pausa la musica"
     response: "default"
     speech_to_phrase: true

--- a/sentences/it/HassMediaUnpause/default.yaml
+++ b/sentences/it/HassMediaUnpause/default.yaml
@@ -10,9 +10,10 @@ data:
       - "riprendi [il |i |su |sul |sui ]media player"
     example: "riprendi la musica"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "riprendi".
   - sentences:
-      - "riprendi"
-      - "riprendi la musica"
-    example: "riprendi"
+      - "riprendi (la musica|il programma|il media player)"
+    example: "riprendi la musica"
     response: "default"
     speech_to_phrase: true

--- a/sentences/nl/HassMediaPause/default.yaml
+++ b/sentences/nl/HassMediaPause/default.yaml
@@ -12,8 +12,10 @@ data:
       - "[zet [[de|het] (lied[je[s]]|nummer[s]|track[s]|item[s]|aflevering[en]|video[s]|film[pje][s]|muziek[je[s]]|playlist[s]|afspeellijst[en])] op] (pauze|stop)"
     example: "pauzeren"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "pauzeer".
   - sentences:
-      - "pauzeer"
-    example: "pauzeer"
+      - "(pauzeer|stop) de (muziek|aflevering|film)"
+    example: "pauzeer de muziek"
     response: "default"
     speech_to_phrase: true

--- a/sentences/nl/HassMediaUnpause/default.yaml
+++ b/sentences/nl/HassMediaUnpause/default.yaml
@@ -12,8 +12,10 @@ data:
       - "ga verder met [de|het] <media_item>"
     example: "hervatten"
     response: "default"
+  # Speech-to-Phrase: lean subset of the block above, with the media noun
+  # required so the STT grammar never has to recognise a bare "hervat".
   - sentences:
-      - "hervat"
-    example: "hervat"
+      - "hervat de (muziek|aflevering|film)"
+    example: "hervat de muziek"
     response: "default"
     speech_to_phrase: true

--- a/tests/ca/HassMediaPause/default.yaml
+++ b/tests/ca/HassMediaPause/default.yaml
@@ -1,0 +1,16 @@
+---
+# HassMediaPause - default
+
+language: ca
+tests:
+  - sentences:
+      - pausa
+      - pausar
+      - atura la reproducció
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - pausa la música
+      - pausa la reproducció
+      - pausa la sèrie
+      - atura la música
+    response: Reproducció en pausa

--- a/tests/ca/HassMediaPlayerMute/default.yaml
+++ b/tests/ca/HassMediaPlayerMute/default.yaml
@@ -11,4 +11,6 @@ tests:
       - treu el so
       - posa silenci
       - muteja
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - silencia el reproductor
     response: So desactivat

--- a/tests/ca/HassMediaUnpause/default.yaml
+++ b/tests/ca/HassMediaUnpause/default.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaUnpause - default
+
+language: ca
+tests:
+  - sentences:
+      - reprèn
+      - continua
+      - reactiva
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - continua la música
+      - reprèn la reproducció
+      - reanuda la sèrie
+    response: Continuant amb la reproducció

--- a/tests/cs/HassMediaPause/default.yaml
+++ b/tests/cs/HassMediaPause/default.yaml
@@ -8,4 +8,6 @@ tests:
       - "zastav písničku"
       - "pozastav skladbu"
       - "zapauzuj program"
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - "pauzuj skladbu"
     response: "Zastaveno"

--- a/tests/de/HassMediaPause/default.yaml
+++ b/tests/de/HassMediaPause/default.yaml
@@ -35,4 +35,7 @@ tests:
       - "die Fernsehsendung hier im Raum anhalten"
       - "die Musik im Raum ausschalten"
       - "die Fernsehsendung hier im raum stoppen"
+      # Speech-to-Phrase phrasings that must keep working here too.
+      - "stoppe die Musik"
+      - "Sendung anhalten"
     response: "Pausiert"

--- a/tests/de/HassMediaUnpause/default.yaml
+++ b/tests/de/HassMediaUnpause/default.yaml
@@ -44,4 +44,7 @@ tests:
       - "lass die Musik im Raum wieder laufen"
       - "lass die Musik hier im Raum weiter spielen"
       - "lass die Musik hier im Raum weiter laufen"
+      # Speech-to-Phrase phrasings that must keep working here too.
+      - "die Musik fortsetzen"
+      - "Sendung weiter machen"
     response: "Fortgesetzt"

--- a/tests/en/HassMediaNext/default.yaml
+++ b/tests/en/HassMediaNext/default.yaml
@@ -13,4 +13,11 @@ tests:
       - "skip the track"
       - "skip"
       - "skip this"
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - "next song"
+      - "next track"
+      - "skip item"
+      - "skip this item"
+      - "skip to the next item"
     response: "Playing next"

--- a/tests/en/HassMediaPause/default.yaml
+++ b/tests/en/HassMediaPause/default.yaml
@@ -6,4 +6,13 @@ tests:
   - sentences:
       - "pause"
       - "stop playing"
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - "pause music"
+      - "pause the music"
+      - "pause my show"
+      - "pause the movie"
+      - "pause the media player"
+      - "stop the music"
+      - "stop playing the song"
     response: "Paused"

--- a/tests/en/HassMediaPlayerMute/default.yaml
+++ b/tests/en/HassMediaPlayerMute/default.yaml
@@ -7,4 +7,10 @@ tests:
       - "mute"
       - "mute the music"
       - "mute the media in here"
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - "mute music"
+      - "mute the movie"
+      - "mute the media player"
+      - "mute my show"
     response: "Muted"

--- a/tests/en/HassMediaPlayerUnmute/default.yaml
+++ b/tests/en/HassMediaPlayerUnmute/default.yaml
@@ -7,4 +7,10 @@ tests:
       - "unmute"
       - "unmute the music"
       - "unmute the media in here"
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - "unmute music"
+      - "unmute the movie"
+      - "unmute the media player"
+      - "unmute my show"
     response: "Unmuted"

--- a/tests/en/HassMediaPrevious/default.yaml
+++ b/tests/en/HassMediaPrevious/default.yaml
@@ -11,4 +11,11 @@ tests:
       - "replay the last track"
       - "play the last song again"
       - "replay"
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - "previous song"
+      - "previous item"
+      - "go back to the previous item"
+      - "replay the previous song"
+      - "play the previous track"
     response: "Playing previous"

--- a/tests/en/HassMediaUnpause/default.yaml
+++ b/tests/en/HassMediaUnpause/default.yaml
@@ -6,4 +6,11 @@ tests:
   - sentences:
       - "unpause"
       - "resume"
+      # Speech-to-Phrase phrasings: a media noun is required there, so these
+      # must keep working here too.
+      - "resume music"
+      - "resume the music"
+      - "resume my show"
+      - "unpause the movie"
+      - "unpause the media player"
     response: "Resumed"

--- a/tests/es/HassMediaPause/default.yaml
+++ b/tests/es/HassMediaPause/default.yaml
@@ -8,4 +8,6 @@ tests:
       - pausa la música
       - detén la música
       - pausa la reproducción
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - pausa el programa
     response: Reproducción en pausa

--- a/tests/fr/HassMediaPause/default.yaml
+++ b/tests/fr/HassMediaPause/default.yaml
@@ -9,4 +9,6 @@ tests:
       - "Arrête la lecture"
       - "Pause"
       - "Mets la chanson en pause"
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - "Mets la musique en pause"
     response: "Lecture en pause"

--- a/tests/fr/HassMediaPlayerMute/default.yaml
+++ b/tests/fr/HassMediaPlayerMute/default.yaml
@@ -9,4 +9,6 @@ tests:
       - "sourdine"
       - "Coupe le son"
       - "charrue"
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - "Mets le son en sourdine"
     response: "Son coupé"

--- a/tests/it/HassMediaPause/default.yaml
+++ b/tests/it/HassMediaPause/default.yaml
@@ -12,4 +12,6 @@ tests:
       - metti in pausa episodio
       - pausa il media player
       - metti in pausa i media player
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - pausa il programma
     response: Messo in pausa

--- a/tests/it/HassMediaUnpause/default.yaml
+++ b/tests/it/HassMediaUnpause/default.yaml
@@ -11,4 +11,6 @@ tests:
       - riprendi episodio
       - riprendi il media player
       - riprendi i media player
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - riprendi il programma
     response: Ripreso

--- a/tests/nl/HassMediaPause/default.yaml
+++ b/tests/nl/HassMediaPause/default.yaml
@@ -10,4 +10,7 @@ tests:
       - de muziek stoppen
       - zet muziek op pauze
       - zet de muziek op stop
+      # Speech-to-Phrase phrasings that must keep working here too.
+      - stop de muziek
+      - pauzeer de aflevering
     response: Gepauzeerd

--- a/tests/nl/HassMediaUnpause/default.yaml
+++ b/tests/nl/HassMediaUnpause/default.yaml
@@ -9,4 +9,6 @@ tests:
       - liedjes hervatten
       - zet de muziek weer op afspelen
       - ga verder met de liedjes
+      # Speech-to-Phrase phrasing that must keep working here too.
+      - hervat de aflevering
     response: Hervat


### PR DESCRIPTION
## Problem

Speech-to-Phrase's constrained STT grammar cannot score very short utterances reliably. Bare one-word transport commands — `pause`, `mute`, `skip`, `resume` — are routinely misrecognised, and they act as attractors for out-of-vocabulary audio.

## Approach

Split the affected media combos into two data blocks:

- an untagged **rich** block that Home Assistant keeps using, which still accepts the bare `pause`;
- a `speech_to_phrase: true` **lean** block that requires a media noun (`pause the music`).

The subset check in `tests/test_speech_to_phrase.py` keeps the two in sync, so the lean grammar can never accept a phrasing HA would reject.

## English

New `rules/en/media.yaml` defines `<track>` = `(song|track|item)` and `<media>` = that plus `music|movie|[tv] show[s]|media [player[s]]`. Applied to `HassMediaPause`, `HassMediaUnpause`, `HassMediaNext`, `HassMediaPrevious`, `HassMediaPlayerMute`, `HassMediaPlayerUnmute`.

Two rich blocks widen as a side effect — `pause the music` and `resume the music` previously only resolved with an area (`pause music in the living room`), never in the `default` combo.

## Other languages

Only eight languages have tagged blocks. The remaining seven get the same treatment, preferring phrasings each language's own files already contained over new grammar:

| lang | was | now |
|---|---|---|
| ca | `pausa`, `continua`, `silencia` | `pausa la música`, `continua la música`, `silencia la música` |
| cs | `pauza` | `zastav písničku` |
| de | `pause`/`pausiere`/`stopp`, `fortsetzen` | `pausiere die Musik`, `musik fortsetzen` |
| es | `pausa`, `continúa`, `silenciar` | `pausa la música`, `continúa la música`, `silencia la música` |
| fr | `pause`, `sourdine` | `arrête la lecture`, `mets le son en sourdine` |
| it | `pausa`, `riprendi` | `metti in pausa la musica`, `riprendi la musica` |
| nl | `pauzeer`, `hervat` | `pauzeer de muziek`, `hervat de muziek` |

Catalan's `default` `HassMediaPause`/`HassMediaUnpause` blocks gain the noun phrasing lifted verbatim from their `area_only` siblings, plus the two missing `tests/ca/HassMedia{Pause,Unpause}/default.yaml`.

## What is deliberately *not* changed

`HassNevermind` is an interjection, not a command. `never mind` / `egal` / `niente` / `annuleer` is what people reflexively say to abort, and there is no natural longer paraphrase — substituting one would trade recognition accuracy for phrasings users never utter. Length here is better handled by acoustic confidence thresholds on the Speech-to-Phrase side.

The single exception is Catalan's `res`, one syllable, replaced by the `deixa-ho` and `oblida-ho` the rich block already offered.

## Needs a native speaker

`cs` `HassMediaUnpause`: `pokračuj` is the only phrasing anywhere in the Czech files — `default`, `area_only` and `name_only` all lack a noun variant to select. Something like `pokračuj v přehrávání` would close it, but I did not want to invent Czech grammar.

## Testing

Full suite passes (14555 tests); `python -m script.intentfest validate` is clean for all eight touched languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)