### PR TITLE
Add climate to HassTurnOn/HassTurnOff for all languages

### DIFF
--- a/sentences/af/HassTurnOff/name_only.yaml
+++ b/sentences/af/HassTurnOff/name_only.yaml
@@ -6,12 +6,7 @@ data:
       - "<switch> af [<the>] {name}"
       - "<deactivate> [<the>] {name}"
     example: "skakel die plafonlig af"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/af/HassTurnOn/name_only.yaml
+++ b/sentences/af/HassTurnOn/name_only.yaml
@@ -7,12 +7,7 @@ data:
       - "<activate> [<the>] {name}"
       - "[<the>] {name}"
     example: "skakel die plafonlig aan"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/ar/HassTurnOff/name_area.yaml
+++ b/sentences/ar/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<turn_off> [<light> | <switch>] [ال]{name} <in> [ال]{area}"
       - "<turn_off> [<light> | <switch>] [ال]{area} [ال]{name}"
     example: "اطفئ الضوء العلوي في المطبخ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ar/HassTurnOff/name_floor.yaml
+++ b/sentences/ar/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<turn_off> [<light> | <switch>] [ال]{name} <in> [الطابق] {floor}"
     example: "اطفئ الضوء العلوي في الطابق الأول"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ar/HassTurnOff/name_only.yaml
+++ b/sentences/ar/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<turn_off> [<light> | <switch>] [ال]{name}"
     example: "اطفئ مروحة السقف"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light word

--- a/sentences/ar/HassTurnOn/name_area.yaml
+++ b/sentences/ar/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<turn_on> [<light> | <switch>] [ال]{name} <in> [ال]{area}"
       - "<turn_on> [<light> | <switch>] [ال]{area} [ال]{name}"
     example: "شغل الضوء العلوي في المطبخ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ar/HassTurnOn/name_floor.yaml
+++ b/sentences/ar/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<turn_on> [<light> | <switch>] [ال]{name} <in> [الطابق] {floor}"
     example: "شغل الضوء العلوي في الطابق الأول"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ar/HassTurnOn/name_only.yaml
+++ b/sentences/ar/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<turn_on> [<light> | <switch>] [ال]{name}"
     example: "شغل مروحة السقف"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light word

--- a/sentences/bg/HassTurnOff/name_area.yaml
+++ b/sentences/bg/HassTurnOff/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off> {name} [в|на|във] {area}"
       - "<turn_off> [в|на|във] {area} {name}"
     example: "изключи горната лампа в кухнята"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/bg/HassTurnOff/name_floor.yaml
+++ b/sentences/bg/HassTurnOff/name_floor.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<turn_off> {name} на {floor}"
     example: "изключи горната лампа на първия етаж"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/bg/HassTurnOff/name_only.yaml
+++ b/sentences/bg/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<turn_off> {name}"
     example: "изключи горната лампа"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/bg/HassTurnOn/name_area.yaml
+++ b/sentences/bg/HassTurnOn/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on> {name} [в|на|във] {area}"
       - "<turn_on> [в|на|във] {area} {name}"
     example: "включи горната лампа в кухнята"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/bg/HassTurnOn/name_floor.yaml
+++ b/sentences/bg/HassTurnOn/name_floor.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<turn_on> {name} на {floor}"
     example: "включи горната лампа на първия етаж"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/bg/HassTurnOn/name_only.yaml
+++ b/sentences/bg/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on> {name}"
       - "{name} [да] свети"
     example: "включи горната лампа"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/bn/HassTurnOff/name_only.yaml
+++ b/sentences/bn/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<bondho> {name}"
       - "{name} <bondho>"
     example: "শয়নকক্ষ বাতি বন্ধ করুন"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/bn/HassTurnOn/name_only.yaml
+++ b/sentences/bn/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<chalu> {name}"
       - "{name} <chalu>"
     example: "শয়নকক্ষ বাতি চালু করুন"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/ca/HassTurnOff/name_area.yaml
+++ b/sentences/ca/HassTurnOff/name_area.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<apaga> [<pronom_singular>]{name} <in> [<pronom_singular>]{area}"
     example: "apaga el llum del sostre de la cuina"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/ca/HassTurnOff/name_floor.yaml
+++ b/sentences/ca/HassTurnOff/name_floor.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<apaga> [<pronom_singular>]{name} <in> [planta|pis] {floor}"
     example: "apaga el llum del sostre de la planta baixa"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/ca/HassTurnOff/name_only.yaml
+++ b/sentences/ca/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<apaga> [<pronom_singular>]{name}"
     example: "apaga el llum del sostre"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ca/HassTurnOn/name_area.yaml
+++ b/sentences/ca/HassTurnOn/name_area.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<engega> [<pronom_singular>]{name} <in> [<pronom_singular>]{area}"
     example: "encén el llum del sostre de la cuina"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ca/HassTurnOn/name_floor.yaml
+++ b/sentences/ca/HassTurnOn/name_floor.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<engega> [<pronom_singular>]{name} <in> [planta|pis] {floor}"
     example: "encén el llum del sostre de la planta baixa"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ca/HassTurnOn/name_only.yaml
+++ b/sentences/ca/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<engega> [<pronom_singular>]{name} [en marxa]"
       - "[<pronom_singular>]{name}"
     example: "encén el llum del sostre"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/cs/HassTurnOff/name_area.yaml
+++ b/sentences/cs/HassTurnOff/name_area.yaml
@@ -17,6 +17,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/cs/HassTurnOff/name_only.yaml
+++ b/sentences/cs/HassTurnOff/name_only.yaml
@@ -15,6 +15,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/cs/HassTurnOn/name_area.yaml
+++ b/sentences/cs/HassTurnOn/name_area.yaml
@@ -17,6 +17,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/cs/HassTurnOn/name_only.yaml
+++ b/sentences/cs/HassTurnOn/name_only.yaml
@@ -15,6 +15,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/cy/HassTurnOff/name_area.yaml
+++ b/sentences/cy/HassTurnOff/name_area.yaml
@@ -6,13 +6,7 @@ data:
       - "<troi> (i ffwrdd|bant|allan) [<y>|<fy>|<ein>] {name} <yn> [<y>|<fy>|<ein>] {area}"
       - "<diffodd>[ <y>|<y>| <fy>| <ein>] {name} <yn> [<y>|<fy>|<ein>] {area}"
     example: "troi'r golau uwchben i ffwrdd yn y gegin"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
-      - "climate"
+    name_domains: "default"
     response: "default"
 
   # Goleuadau ag enw yn cynnwys gair golau / lights with trailing light word

--- a/sentences/cy/HassTurnOff/name_floor.yaml
+++ b/sentences/cy/HassTurnOff/name_floor.yaml
@@ -6,13 +6,7 @@ data:
       - "<troi> (i ffwrdd|bant|allan) [<y>|<fy>|<ein>] {name} ar [<y>] {floor} [llawr]"
       - "<diffodd>[ <y>|<y>| <fy>| <ein>] {name} ar [<y>] {floor} [llawr]"
     example: "troi'r golau uwchben i ffwrdd ar y llawr cyntaf"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
-      - "climate"
+    name_domains: "default"
     response: "default"
 
   # Goleuadau ag enw yn cynnwys gair golau / lights with trailing light word

--- a/sentences/cy/HassTurnOff/name_only.yaml
+++ b/sentences/cy/HassTurnOff/name_only.yaml
@@ -7,13 +7,7 @@ data:
       - "<diffodd>[ <y>|<y>| <fy>| <ein>] {name}"
       - "<rhoi>[ <y>|<y>| <fy>| <ein>] {name} (i ffwrdd|bant|allan)"
     example: "troi'r golau uwchben i ffwrdd"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
-      - "climate"
+    name_domains: "default"
     response: "default"
 
   # Goleuadau ag enw yn cynnwys gair golau / lights with trailing light word

--- a/sentences/da/HassTurnOff/name_area.yaml
+++ b/sentences/da/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<sluk> <navn> <i_på> <område>"
       - "<stop> <navn> <i_på> <område>"
     example: "sluk loftslyset i køkkenet"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/da/HassTurnOff/name_floor.yaml
+++ b/sentences/da/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
       - "<sluk> <navn> <i_på> <etage>"
       - "<stop> <navn> <i_på> <etage>"
     example: "sluk loftslyset på første sal"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/da/HassTurnOff/name_only.yaml
+++ b/sentences/da/HassTurnOff/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "<stop> <navn>"
       - "<navn> fra"
     example: "sluk loftslyset"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light/lamp word

--- a/sentences/da/HassTurnOn/name_area.yaml
+++ b/sentences/da/HassTurnOn/name_area.yaml
@@ -13,12 +13,7 @@ data:
       - "<tænd> <navn> <i_på> <område>"
       - "<start> <navn> <i_på> <område>"
     example: "tænd loftslyset i køkkenet"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light/lamp word

--- a/sentences/da/HassTurnOn/name_floor.yaml
+++ b/sentences/da/HassTurnOn/name_floor.yaml
@@ -12,12 +12,7 @@ data:
       - "<tænd> <navn> <i_på> <etage>"
       - "<start> <navn> <i_på> <etage>"
     example: "tænd loftslyset på første sal"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light/lamp word

--- a/sentences/da/HassTurnOn/name_only.yaml
+++ b/sentences/da/HassTurnOn/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "<start> <navn>"
       - "<navn> [til]"
     example: "tænd loftslyset"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light/lamp word

--- a/sentences/de-CH/HassTurnOff/name_area.yaml
+++ b/sentences/de-CH/HassTurnOff/name_area.yaml
@@ -16,6 +16,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de-CH/HassTurnOff/name_only.yaml
+++ b/sentences/de-CH/HassTurnOff/name_only.yaml
@@ -14,6 +14,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de-CH/HassTurnOn/name_area.yaml
+++ b/sentences/de-CH/HassTurnOn/name_area.yaml
@@ -16,6 +16,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de-CH/HassTurnOn/name_only.yaml
+++ b/sentences/de-CH/HassTurnOn/name_only.yaml
@@ -14,6 +14,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de/HassTurnOff/name_area.yaml
+++ b/sentences/de/HassTurnOff/name_area.yaml
@@ -20,6 +20,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de/HassTurnOff/name_floor.yaml
+++ b/sentences/de/HassTurnOff/name_floor.yaml
@@ -20,6 +20,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de/HassTurnOff/name_only.yaml
+++ b/sentences/de/HassTurnOff/name_only.yaml
@@ -18,6 +18,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de/HassTurnOn/name_area.yaml
+++ b/sentences/de/HassTurnOn/name_area.yaml
@@ -20,6 +20,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de/HassTurnOn/name_floor.yaml
+++ b/sentences/de/HassTurnOn/name_floor.yaml
@@ -20,6 +20,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/de/HassTurnOn/name_only.yaml
+++ b/sentences/de/HassTurnOn/name_only.yaml
@@ -18,6 +18,7 @@ data:
       - "fan"
       - "media_player"
       - "input_boolean"
+      - "climate"
     response: "default"
 
   # lights by name

--- a/sentences/el/HassTurnOff/name_area.yaml
+++ b/sentences/el/HassTurnOff/name_area.yaml
@@ -4,12 +4,7 @@ data:
       - "<turn_off> [<the>] {area} [<the>] {name}"
       - "<turn_off> [<the>] {name} <in> [<the>] {area}"
     example: σβήσε το φως οροφής στην κουζίνα
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
   - sentences:
       - "<turn_off> [<the>] {name} <lights> <in> [<the>] {area}"

--- a/sentences/el/HassTurnOff/name_floor.yaml
+++ b/sentences/el/HassTurnOff/name_floor.yaml
@@ -3,12 +3,7 @@ data:
   - sentences:
       - "<turn_off> [<the>] {name} <in> [<the>] {floor} [όροφο]"
     example: σβήσε το φως οροφής στον πρώτο όροφο
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
   - sentences:
       - "<close> [<the>] {name} <in> [<the>] {floor} [όροφο]"

--- a/sentences/el/HassTurnOff/name_only.yaml
+++ b/sentences/el/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
       - "<turn_off> [<the>] {name}"
       - "[<the>] {name} <turn_off>"
     example: σβήσε το φως οροφής
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
   - sentences:
       - "<turn_off> [<the>] {name} <lights>"

--- a/sentences/el/HassTurnOn/name_area.yaml
+++ b/sentences/el/HassTurnOn/name_area.yaml
@@ -4,12 +4,7 @@ data:
       - "<turn_on> [<the>] {area} [<the>] {name}"
       - "<turn_on> [<the>] {name} <in> [<the>] {area}"
     example: άναψε το φως οροφής στην κουζίνα
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
   - sentences:
       - "<turn_on> [<the>] {name} <lights> <in> [<the>] {area}"

--- a/sentences/el/HassTurnOn/name_floor.yaml
+++ b/sentences/el/HassTurnOn/name_floor.yaml
@@ -3,12 +3,7 @@ data:
   - sentences:
       - "<turn_on> [<the>] {name} <in> [<the>] {floor} [όροφο]"
     example: άναψε το φως οροφής στον πρώτο όροφο
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
   - sentences:
       - "<open> [<the>] {name} <in> [<the>] {floor} [όροφο]"

--- a/sentences/el/HassTurnOn/name_only.yaml
+++ b/sentences/el/HassTurnOn/name_only.yaml
@@ -4,12 +4,7 @@ data:
       - "<turn_on> [<the>] {name}"
       - "[<the>] {name} <turn_on>"
     example: άναψε το φως οροφής
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
   - sentences:
       - "<turn_on> [<the>] {name} <lights>"

--- a/sentences/et/HassTurnOff/name_area.yaml
+++ b/sentences/et/HassTurnOff/name_area.yaml
@@ -13,12 +13,7 @@ data:
       - "lülita [<the>] {area} [<the>] {name} välja"
       - "[<the>] {area} [<the>] {name} välja"
     example: "lülita välja köögi laelamp"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/et/HassTurnOff/name_floor.yaml
+++ b/sentences/et/HassTurnOff/name_floor.yaml
@@ -13,12 +13,7 @@ data:
       - "lülita [<the>] {name} {floor} korrusel välja"
       - "[<the>] {name} {floor} korrusel välja"
     example: "lülita välja laelamp esimesel korrusel"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/et/HassTurnOff/name_only.yaml
+++ b/sentences/et/HassTurnOff/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "lülita [<the>] {name} välja"
       - "[<the>] {name} välja"
     example: "lülita välja laelamp"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/et/HassTurnOn/name_area.yaml
+++ b/sentences/et/HassTurnOn/name_area.yaml
@@ -13,12 +13,7 @@ data:
       - "lülita [<the>] {area} [<the>] {name} sisse"
       - "[<the>] {area} [<the>] {name} põlema"
     example: "lülita sisse köögi laelamp"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/et/HassTurnOn/name_floor.yaml
+++ b/sentences/et/HassTurnOn/name_floor.yaml
@@ -13,12 +13,7 @@ data:
       - "lülita [<the>] {name} {floor} korrusel sisse"
       - "[<the>] {name} {floor} korrusel põlema"
     example: "lülita sisse laelamp esimesel korrusel"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/et/HassTurnOn/name_only.yaml
+++ b/sentences/et/HassTurnOn/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "lülita [<the>] {name} sisse"
       - "[<the>] {name} põlema"
     example: "lülita sisse laelamp"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/eu/HassTurnOff/name_area.yaml
+++ b/sentences/eu/HassTurnOff/name_area.yaml
@@ -7,12 +7,7 @@ data:
       - "{name} <itzali> {area}n"
       - "{area}ko {name} <itzali>"
     example: "itzali flexoa logelan"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # covers

--- a/sentences/eu/HassTurnOff/name_only.yaml
+++ b/sentences/eu/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<itzali> {name}"
       - "{name} <itzali>"
     example: "itzali logelako lanpara"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # covers

--- a/sentences/eu/HassTurnOn/name_area.yaml
+++ b/sentences/eu/HassTurnOn/name_area.yaml
@@ -7,12 +7,7 @@ data:
       - "{name} <piztu> {area}n"
       - "{area}ko {name} <piztu>"
     example: "piztu egongelako haizegailua egongelan"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # covers

--- a/sentences/eu/HassTurnOn/name_only.yaml
+++ b/sentences/eu/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<piztu> {name}"
       - "{name} <piztu>"
     example: "piztu egongelako haizegailua"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # covers

--- a/sentences/fa/HassTurnOff/name_only.yaml
+++ b/sentences/fa/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{name} [(را|رو)] <turn_off>"
     example: "چراغ اتاق خواب را خاموش کن"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fa/HassTurnOn/name_only.yaml
+++ b/sentences/fa/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{name} [(را|رو)] <turn_on>"
     example: "چراغ اتاق خواب را روشن کن"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fi/HassTurnOff/name_area.yaml
+++ b/sentences/fi/HassTurnOff/name_area.yaml
@@ -10,12 +10,7 @@ data:
       - "[<laita>] (<alueessa>|<alueella>) {area} {name} <päältä>"
       - "<pysäytä> (<alueessa>|<alueella>) {area} {name}"
     example: "kytke pois päältä alueella olohuone kattokruunu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # off-able domains - area as conjugated name with suffix
@@ -24,12 +19,7 @@ data:
       - "[<laita>] {area}[e][ssa|ssä|sta|stä|n] {name} <päältä>"
       - "<pysäytä> {area}[e][ssa|ssä|sta|stä|n] {name}"
     example: "kytke pois päältä olohuoneen kattokruunu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # off-able domains - default areas
@@ -37,12 +27,7 @@ data:
       - "[<laita>] <päältä> {default_areas:area} {name}"
       - "[<laita>] {default_areas:area} {name} <päältä>"
     example: "kytke pois päältä yläkerran kattokruunu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fi/HassTurnOff/name_floor.yaml
+++ b/sentences/fi/HassTurnOff/name_floor.yaml
@@ -10,12 +10,7 @@ data:
       - "[<laita>] {name} (kerroksessa|kerroksen) {floor} <päältä>"
       - "<pysäytä> {name} (kerroksessa|kerroksen) {floor}"
     example: "kytke kattokruunu kerroksessa ensimmäinen pois päältä"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fi/HassTurnOff/name_only.yaml
+++ b/sentences/fi/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "[<laita>] <päältä> {name}"
       - "<pysäytä> {name}"
     example: "kytke kattokruunu pois päältä"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fi/HassTurnOn/name_area.yaml
+++ b/sentences/fi/HassTurnOn/name_area.yaml
@@ -10,12 +10,7 @@ data:
       - "[<laita>] (<alueessa>|<alueella>) {area} {name} <päälle>"
       - "<käynnistä> (<alueessa>|<alueella>) {area} {name}"
     example: "kytke päälle alueella olohuone kattokruunu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # on-able domains - area as conjugated name with suffix
@@ -24,12 +19,7 @@ data:
       - "[<laita>] {area}[e][ssa|ssä|sta|stä|n] {name} <päälle>"
       - "<käynnistä> {area}[e][ssa|ssä|sta|stä|n] {name}"
     example: "kytke päälle olohuoneen kattokruunu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # on-able domains - default areas
@@ -37,12 +27,7 @@ data:
       - "[<laita>] <päälle> {default_areas:area} {name}"
       - "[<laita>] {default_areas:area} {name} <päälle>"
     example: "kytke päälle yläkerran kattokruunu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fi/HassTurnOn/name_floor.yaml
+++ b/sentences/fi/HassTurnOn/name_floor.yaml
@@ -10,12 +10,7 @@ data:
       - "[<laita>] {name} (kerroksessa|kerroksen) {floor} <päälle>"
       - "<käynnistä> {name} (kerroksessa|kerroksen) {floor}"
     example: "kytke päälle kattokruunu kerroksessa ensimmäinen"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fi/HassTurnOn/name_only.yaml
+++ b/sentences/fi/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "[<laita>] <päälle> {name}"
       - "<käynnistä> {name}"
     example: "kytke päälle kattokruunu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights

--- a/sentences/fr/HassTurnOff/name_area.yaml
+++ b/sentences/fr/HassTurnOff/name_area.yaml
@@ -11,12 +11,7 @@ data:
   # off-able domains (light, switch, fan, media_player, input_boolean)
   - sentences:
       - "<eteins> [<le>]{name} [<dans>] [<le>]{area}"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     example: "éteins la lumière du plafond de la chambre"
     response: "default"
 

--- a/sentences/fr/HassTurnOff/name_floor.yaml
+++ b/sentences/fr/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   # off-able domains (light, switch, fan, media_player, input_boolean)
   - sentences:
       - "<eteins> [<le>]{name} [<dans>] [<le>]{floor}"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     example: "éteins la lumière du plafond du premier étage"
     response: "default"
 

--- a/sentences/fr/HassTurnOff/name_only.yaml
+++ b/sentences/fr/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   # off-able domains (light, switch, fan, media_player, input_boolean)
   - sentences:
       - "<eteins> [<le>]{name}"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     example: "éteins le ventilateur de plafond"
     response: "default"
 

--- a/sentences/fr/HassTurnOn/name_area.yaml
+++ b/sentences/fr/HassTurnOn/name_area.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<allume> [<le>]{name} [<dans>] [<le>]{area}"
     example: "allume le ventilateur de plafond du salon"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fr/HassTurnOn/name_floor.yaml
+++ b/sentences/fr/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<allume> [<le>]{name} [<dans>] [<le>]{floor}"
     example: "allume la lampe du bureau au premier étage"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/fr/HassTurnOn/name_only.yaml
+++ b/sentences/fr/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<allume> [<le>]{name}"
     example: "allume le ventilateur de plafond"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ga/HassTurnOff/name_area.yaml
+++ b/sentences/ga/HassTurnOff/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off> [<the>] {name} <in> [<the>] {area}"
       - "cuir [<the>] {name} <in> [<the>] {area} as"
     example: "múch an solas uachtair sa chistin"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/ga/HassTurnOff/name_floor.yaml
+++ b/sentences/ga/HassTurnOff/name_floor.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off> [<the>] {name} <in> [<the>] {floor}"
       - "cuir [<the>] {name} <in> [<the>] {floor} as"
     example: "múch an solas uachtair ar an gcéad urlár"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/ga/HassTurnOff/name_only.yaml
+++ b/sentences/ga/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off> [<the>] {name}"
       - "cuir [<the>] {name} as"
     example: "múch an solas uachtair"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/ga/HassTurnOn/name_area.yaml
+++ b/sentences/ga/HassTurnOn/name_area.yaml
@@ -6,12 +6,7 @@ data:
       - "cuir [<the>] {name} <in> [<the>] {area} ar siúl"
       - "<activate> [<the>] {name} <in> [<the>] {area}"
     example: "las an solas uachtair sa chistin"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/ga/HassTurnOn/name_floor.yaml
+++ b/sentences/ga/HassTurnOn/name_floor.yaml
@@ -6,12 +6,7 @@ data:
       - "cuir [<the>] {name} <in> [<the>] {floor} ar siúl"
       - "<activate> [<the>] {name} <in> [<the>] {floor}"
     example: "las an solas uachtair ar an gcéad urlár"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/ga/HassTurnOn/name_only.yaml
+++ b/sentences/ga/HassTurnOn/name_only.yaml
@@ -6,12 +6,7 @@ data:
       - "cuir [<the>] {name} ar siúl"
       - "<activate> [<the>] {name}"
     example: "las an solas uachtair"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/gl/HassTurnOff/name_area.yaml
+++ b/sentences/gl/HassTurnOff/name_area.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<apaga> [o |a |os |as ]{name} [en |no |na |d(o|a) ]{area}"
     example: apaga a luz do teito na cociña
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/gl/HassTurnOff/name_floor.yaml
+++ b/sentences/gl/HassTurnOff/name_floor.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<apaga> [o |a |os |as ]{name} [n(o|a) |d(o|a) ][a planta |o piso |planta |piso ]{floor}[ planta| piso]"
     example: apaga a luz do teito no primeiro piso
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/gl/HassTurnOff/name_only.yaml
+++ b/sentences/gl/HassTurnOff/name_only.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<apaga> [o |a |os |as ]{name}"
     example: apaga a luz do teito
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/gl/HassTurnOn/name_area.yaml
+++ b/sentences/gl/HassTurnOn/name_area.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<acende> [o |a |os |as ]{name} [en |no |na |d(o|a) ]{area}"
     example: acende a luz do teito na cociña
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/gl/HassTurnOn/name_floor.yaml
+++ b/sentences/gl/HassTurnOn/name_floor.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<acende> [o |a |os |as ]{name} [n(o|a) |d(o|a) ][a planta |o piso |planta |piso ]{floor}[ planta| piso]"
     example: acende a luz do teito no primeiro piso
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/gl/HassTurnOn/name_only.yaml
+++ b/sentences/gl/HassTurnOn/name_only.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<acende> [o |a |os |as ]{name}"
     example: acende a luz do teito
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/gu/HassTurnOff/name_only.yaml
+++ b/sentences/gu/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<bandh> {name}"
       - "{name} <bandh>"
     example: "શયનખંડ લાઈટ બંધ કરો"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/gu/HassTurnOn/name_only.yaml
+++ b/sentences/gu/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<chalu> {name}"
       - "{name} <chalu>"
     example: "શયનખંડ લાઈટ ચાલુ કરો"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/he/HassTurnOff/name_only.yaml
+++ b/sentences/he/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "(כב[ה|י]|כיבוי|לכבות|תכב[ה|י]) [את] [של] [ה]{name}"
     example: "כבה את האור הראשי"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/he/HassTurnOn/name_only.yaml
+++ b/sentences/he/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "(הדלק|הדליקי|הדלקה|להדליק|תדליק[י]) [את] [של] [ה]{name}"
     example: "הדלק את האור הראשי"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hi/HassTurnOff/name_only.yaml
+++ b/sentences/hi/HassTurnOff/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "{name} को <bandh>"
       - "{name} <bandh>"
     example: "शयनकक्ष का दीपक बंद करो"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/hi/HassTurnOn/name_only.yaml
+++ b/sentences/hi/HassTurnOn/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "{name} को <chalu>"
       - "{name} <chalu>"
     example: "शयनकक्ष का दीपक चालू करो"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/hr/HassTurnOff/name_area.yaml
+++ b/sentences/hr/HassTurnOff/name_area.yaml
@@ -8,12 +8,7 @@ data:
       - "<isključi> {name} [u|na] <area>"
       - "<isključi> <area> {name}"
     example: "isključi svjetlo u kuhinji"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default_name"
 
   # covers

--- a/sentences/hr/HassTurnOff/name_only.yaml
+++ b/sentences/hr/HassTurnOff/name_only.yaml
@@ -7,12 +7,7 @@ data:
   - sentences:
       - "<isključi> {name}"
     example: "isključi svjetlo u dnevnoj sobi"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default_name"
 
   # covers

--- a/sentences/hr/HassTurnOn/name_area.yaml
+++ b/sentences/hr/HassTurnOn/name_area.yaml
@@ -8,12 +8,7 @@ data:
       - "(<uključi>|<otvori>) {name} [u|na] <area>"
       - "(<uključi>|<otvori>) <area> {name}"
     example: "uključi svjetlo u kuhinji"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default_name"
 
   # covers

--- a/sentences/hr/HassTurnOn/name_only.yaml
+++ b/sentences/hr/HassTurnOn/name_only.yaml
@@ -7,12 +7,7 @@ data:
   - sentences:
       - "(<uključi>|<otvori>) {name}"
     example: "uključi svjetlo u dnevnoj sobi"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default_name"
 
   # covers

--- a/sentences/hu/HassTurnOff/name_only.yaml
+++ b/sentences/hu/HassTurnOff/name_only.yaml
@@ -8,12 +8,7 @@ language: "hu"
 data:
   - sentences:
       - "(<turn_off>; <name>)"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hu/HassTurnOff/name_only.yaml
+++ b/sentences/hu/HassTurnOff/name_only.yaml
@@ -8,12 +8,14 @@ language: "hu"
 data:
   - sentences:
       - "(<turn_off>; <name>)"
+    example: "kapcsold ki a mennyezeti világítást"
     name_domains: "default"
     response: "default"
 
   # covers
   - sentences:
       - "<close> <name>"
+    example: "zárd be a tolóajtót"
     name_domains:
       - "cover"
       - "valve"

--- a/sentences/hu/HassTurnOn/name_only.yaml
+++ b/sentences/hu/HassTurnOn/name_only.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "(<turn_on>; <name>)"
       - "<name>"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hu/HassTurnOn/name_only.yaml
+++ b/sentences/hu/HassTurnOn/name_only.yaml
@@ -8,12 +8,14 @@ data:
   - sentences:
       - "(<turn_on>; <name>)"
       - "<name>"
+    example: "kapcsold be a mennyezeti világítást"
     name_domains: "default"
     response: "default"
 
   # covers
   - sentences:
       - "<open> <name>"
+    example: "nyisd ki a tolóajtót"
     name_domains:
       - "cover"
       - "valve"

--- a/sentences/hy/HassTurnOff/name_area.yaml
+++ b/sentences/hy/HassTurnOff/name_area.yaml
@@ -11,12 +11,7 @@ data:
       - "<turn_off> {area}[ի] {name}[(ը|ն)]"
       - "ապաակտիվացրու {area}[ի] {name}[(ը|ն)]"
     example: "անջատիր առաստաղի լույսը խոհանոցում"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hy/HassTurnOff/name_floor.yaml
+++ b/sentences/hy/HassTurnOff/name_floor.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_off> {name}[(ը|ն)] {floor}[ում]"
       - "ապաակտիվացրու {name}[(ը|ն)] {floor}[ում]"
     example: "անջատիր առաստաղի լույսը առաջին հարկում"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hy/HassTurnOff/name_only.yaml
+++ b/sentences/hy/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_off> {name}[(ը|ն)]"
       - "ապաակտիվացրու {name}[(ը|ն)]"
     example: "անջատիր առաստաղի լույսը"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hy/HassTurnOn/name_area.yaml
+++ b/sentences/hy/HassTurnOn/name_area.yaml
@@ -11,12 +11,7 @@ data:
       - "<turn_on> {area}[ի] {name}[(ը|ն)]"
       - "ակտիվացրու {area}[ի] {name}[(ը|ն)]"
     example: "միացրու առաստաղի լույսը խոհանոցում"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hy/HassTurnOn/name_floor.yaml
+++ b/sentences/hy/HassTurnOn/name_floor.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_on> {name}[(ը|ն)] {floor}[ում]"
       - "ակտիվացրու {name}[(ը|ն)] {floor}[ում]"
     example: "միացրու առաստաղի լույսը առաջին հարկում"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/hy/HassTurnOn/name_only.yaml
+++ b/sentences/hy/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_on> {name}[(ը|ն)]"
       - "ակտիվացրու {name}[(ը|ն)]"
     example: "միացրու առաստաղի լույսը"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/id/HassTurnOff/name_only.yaml
+++ b/sentences/id/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<mati_imperatif> {name}"
     example: "matikan lampu tidur"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/id/HassTurnOn/name_only.yaml
+++ b/sentences/id/HassTurnOn/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<nyala_imperatif> {name}"
     example: "nyalakan lampu tidur"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/is/HassTurnOff/name_area.yaml
+++ b/sentences/is/HassTurnOff/name_area.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "(<turn_off>|<deactivate>) [á|í] {name}[(inu|nu|ið|ð|inni|nni|num)] (í|á) {area}[(inu|nu|ið|ð|inni|nni|num)]"
     example: "slökkt þú á gólflampanum í stofunni"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/is/HassTurnOff/name_only.yaml
+++ b/sentences/is/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "(<turn_off>|<deactivate>) [á|í] {name}[(inu|nu|ið|ð|inni|nni|num)]"
     example: "Slökktu á náttlampanum"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/is/HassTurnOn/name_area.yaml
+++ b/sentences/is/HassTurnOn/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "(<turn_on>|<activate>) [á|í] {name}[(inu|nu|ið|ð|inni|nni|num)] (í|á) {area}[(inu|nu|ið|ð|inni|nni|num)]"
       - "[(settu|sett þú|setja)] {name}[(inn|inu|nu|ið|ð|inni|nni|num|una|na)] (í|á) {area}[(inu|nu|ið|ð|inni|nni|num)] í gang"
     example: "kveikja á gólflampanum í stofunni"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/is/HassTurnOn/name_only.yaml
+++ b/sentences/is/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "(<turn_on>|<activate>) [á|í] {name}[(inu|nu|ið|ð|inni|nni|num)]"
       - "[(settu|sett þú|setja)] {name}[(inn|inu|nu|ið|ð|inni|nni|num|una|na)] í gang"
     example: "Kveiktu á loftviftunni"
-    name_domains:
-      - light
-      - switch
-      - fan
-      - media_player
-      - input_boolean
+    name_domains: default
     response: default
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/it/HassTurnOff/name_area.yaml
+++ b/sentences/it/HassTurnOff/name_area.yaml
@@ -13,12 +13,7 @@ data:
       - "<turn_off> (<in>|<of>) [<the>] {area} [<the>] {name}"
       - "(<in>|<of>) [<the>] {area} <turn_off> [<the>] {name}"
     example: "spegni la luce a soffitto in cucina"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/it/HassTurnOff/name_floor.yaml
+++ b/sentences/it/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<turn_off> [<the>] {name} (<in>|<of>|<at>|<on>) [<the>] {floor}"
     example: "spegni la luce a soffitto al primo piano"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/it/HassTurnOff/name_only.yaml
+++ b/sentences/it/HassTurnOff/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "<turn_off> [<the>] {name}"
       - "[<the>] {name} <turn_off>"
     example: "spegni la luce a soffitto"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/it/HassTurnOn/name_area.yaml
+++ b/sentences/it/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
   - sentences:
       - "<turn_on> [<the>] {name} (<in>|<of>) [<the>] {area}"
     example: "accendi la luce centrale in cucina"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a "light(s)/lamp(s)" word

--- a/sentences/it/HassTurnOn/name_floor.yaml
+++ b/sentences/it/HassTurnOn/name_floor.yaml
@@ -12,12 +12,7 @@ data:
   - sentences:
       - "<turn_on> [<the>] {name} (<in>|<of>|<at>|<to>) [<the>] {floor}"
     example: "accendi la luce centrale al primo piano"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a "light(s)/lamp(s)" word

--- a/sentences/it/HassTurnOn/name_only.yaml
+++ b/sentences/it/HassTurnOn/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "<turn_on> [<the>] {name}"
       - "[<the>] {name}"
     example: "accendi la luce centrale"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a "light(s)/lamp(s)" word

--- a/sentences/ja/HassTurnOff/name_only.yaml
+++ b/sentences/ja/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "{name}[を]<turn_off>"
     example: "寝室照明を消して"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ja/HassTurnOn/name_only.yaml
+++ b/sentences/ja/HassTurnOn/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "{name}[を]<turn_on>"
     example: "寝室照明を点けて"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ka/HassTurnOff/name_only.yaml
+++ b/sentences/ka/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off> {name}"
       - "{name} <turn_off>"
     example: "გამორთე საძინებლის ლამპა"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ka/HassTurnOn/name_only.yaml
+++ b/sentences/ka/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on> {name}"
       - "{name} <turn_on>"
     example: "დაქართულე საძინებლის ლამპა"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/kn/HassTurnOff/name_only.yaml
+++ b/sentences/kn/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<bandh> {name}"
       - "{name} <bandh>"
     example: "ಮಲಗುವ ಕೋಣೆ ಲೈಟ್ ಆಫ್ ಮಾಡಿ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/kn/HassTurnOn/name_only.yaml
+++ b/sentences/kn/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<chalu> {name}"
       - "{name} <chalu>"
     example: "ಮಲಗುವ ಕೋಣೆ ಲೈಟ್ ಆನ್ ಮಾಡಿ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/ko/HassTurnOff/name_area.yaml
+++ b/sentences/ko/HassTurnOff/name_area.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{area} {name} [<turn>] 꺼[줘|줄래]"
     example: "거실 무드등 꺼줘"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ko/HassTurnOff/name_only.yaml
+++ b/sentences/ko/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{name} [<turn>] 꺼[줘|줄래]"
     example: "무드등 꺼줘"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ko/HassTurnOn/name_area.yaml
+++ b/sentences/ko/HassTurnOn/name_area.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{area} {name} [<turn>] 켜[줘|줄래]"
     example: "거실 무드등 켜줘"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ko/HassTurnOn/name_only.yaml
+++ b/sentences/ko/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "{name} [<turn>] 켜[줘|줄래]"
       - "{name} 틀어[줘]"
     example: "무드등 켜줘"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/kw/HassTurnOff/name_area.yaml
+++ b/sentences/kw/HassTurnOff/name_area.yaml
@@ -14,12 +14,7 @@ data:
       - "[<turn>] [<the>] {name} <in> [<the>] {area} [dhe] yn farow"
       - "anbywha [<the>] {name} <in> [<the>] {area}"
     example: "skwych yn farow an lugarn chambour y'n gegin"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/kw/HassTurnOff/name_floor.yaml
+++ b/sentences/kw/HassTurnOff/name_floor.yaml
@@ -13,12 +13,7 @@ data:
       - "[<turn>] [<the>] {name} <in> [<the>] {floor} [leur] [dhe] yn farow"
       - "anbywha [<the>] {name} <in> [<the>] {floor} [leur]"
     example: "skwych yn farow an lugarn chambour war an kynsa leur"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/kw/HassTurnOff/name_only.yaml
+++ b/sentences/kw/HassTurnOff/name_only.yaml
@@ -12,12 +12,7 @@ data:
       - "[<turn>] [<the>] {name} [dhe] yn farow"
       - "anbywha [<the>] {name}"
     example: "skwych yn farow an lugarn chambour"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/kw/HassTurnOn/name_area.yaml
+++ b/sentences/kw/HassTurnOn/name_area.yaml
@@ -14,12 +14,7 @@ data:
       - "[<turn>] [<the>] {name} <in> [<the>] {area} [dhe] yn fyw"
       - "bywha [<the>] {name} <in> [<the>] {area}"
     example: "skwych yn fyw an lugarn chambour y'n gegin"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/kw/HassTurnOn/name_floor.yaml
+++ b/sentences/kw/HassTurnOn/name_floor.yaml
@@ -13,12 +13,7 @@ data:
       - "[<turn>] [<the>] {name} <in> [<the>] {floor} [leur] [dhe] yn fyw"
       - "bywha [<the>] {name} <in> [<the>] {floor} [leur]"
     example: "skwych yn fyw an lugarn chambour war an kynsa leur"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/kw/HassTurnOn/name_only.yaml
+++ b/sentences/kw/HassTurnOn/name_only.yaml
@@ -12,12 +12,7 @@ data:
       - "bywha [<the>] {name}"
       - "[<the>] {name}"
     example: "skwych yn fyw an gwynsell nen"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/lb/HassTurnOff/name_area.yaml
+++ b/sentences/lb/HassTurnOff/name_area.yaml
@@ -6,12 +6,7 @@ data:
       - "<maach> [<the>] [d']{name} [<in>] [<the>] [d']{area} aus"
       - "<maach> [<in>] [<the>] [d']{area} [<the>] [d']{name} aus"
     example: "Schalt d'Luucht an der Kichen aus"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lb/HassTurnOff/name_only.yaml
+++ b/sentences/lb/HassTurnOff/name_only.yaml
@@ -6,12 +6,7 @@ data:
       - "<maach> [<the>] [d']{name} aus"
       - "stopp [<the>] [d']{name}"
     example: "Schalt d'Luucht aus"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lb/HassTurnOn/name_area.yaml
+++ b/sentences/lb/HassTurnOn/name_area.yaml
@@ -7,12 +7,7 @@ data:
       - "<maach> [<in>] [<the>] [d']{area} [<the>] [d']{name} un"
       - "aktivéier [<the>] [d']{name} [<in>] [<the>] [d']{area}"
     example: "Schalt d'Luucht an der Kichen un"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lb/HassTurnOn/name_only.yaml
+++ b/sentences/lb/HassTurnOn/name_only.yaml
@@ -6,12 +6,7 @@ data:
       - "<maach> [<the>] [d']{name} un"
       - "aktivéier [<the>] [d']{name}"
     example: "Schalt d'Luucht un"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lt/HassTurnOff/name_area.yaml
+++ b/sentences/lt/HassTurnOff/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off> {area} {name}"
       - "<turn_off> {name} {area}"
     example: "išjunk svetainės lubų ventiliatorių"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lt/HassTurnOff/name_only.yaml
+++ b/sentences/lt/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<turn_off> {name}"
     example: "išjunk lubų ventiliatorių"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lt/HassTurnOn/name_area.yaml
+++ b/sentences/lt/HassTurnOn/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on> {area} {name}"
       - "<turn_on> {name} {area}"
     example: "įjunk svetainės lubų ventiliatorių"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lt/HassTurnOn/name_only.yaml
+++ b/sentences/lt/HassTurnOn/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<turn_on> {name}"
     example: "įjunk naktinę lempą"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lv/HassTurnOff/name_area.yaml
+++ b/sentences/lv/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<izslēgt> {area} {name}"
       - "<izslēgt> {name} {area}"
     example: "izslēdz virtuvē naktslampu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lv/HassTurnOff/name_only.yaml
+++ b/sentences/lv/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<izslēgt> {name}"
     example: "izslēdz naktslampu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lv/HassTurnOn/name_area.yaml
+++ b/sentences/lv/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<ieslēgt> {area} {name}"
       - "<ieslēgt> {name} {area}"
     example: "ieslēdz virtuvē naktslampu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/lv/HassTurnOn/name_only.yaml
+++ b/sentences/lv/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<ieslēgt> {name}"
     example: "ieslēdz naktslampu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ml/HassTurnOff/name_area.yaml
+++ b/sentences/ml/HassTurnOff/name_area.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_off> [<the>] {name} {area}<in>"
       - "[<the>] {area}<in> [<the>] {name} <turn_off>"
     example: "സ്വീകരണമുറിയിലെ കിടപ്പറ വിളക്ക് ഓഫാക്കൂ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ml/HassTurnOff/name_only.yaml
+++ b/sentences/ml/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_off> [<the>] {name}"
       - "[<the>] {name} <turn_off>"
     example: "കിടപ്പറ വിളക്ക് ഓഫാക്കൂ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ml/HassTurnOn/name_area.yaml
+++ b/sentences/ml/HassTurnOn/name_area.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_on> [<the>] {name} {area}<in>"
       - "[<the>] {area}<in> [<the>] {name} <turn_on>"
     example: "സ്വീകരണമുറിയിലെ കിടപ്പറ വിളക്ക് ഓണാക്കൂ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ml/HassTurnOn/name_only.yaml
+++ b/sentences/ml/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_on> [<the>] {name}"
       - "[<the>] {name} <turn_on>"
     example: "കിടപ്പറ വിളക്ക് ഓണാക്കൂ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/mn/HassTurnOff/name_only.yaml
+++ b/sentences/mn/HassTurnOff/name_only.yaml
@@ -12,4 +12,5 @@ data:
     name_domains:
       - "light"
       - "switch"
+      - "climate"
     response: "default"

--- a/sentences/mn/HassTurnOn/name_only.yaml
+++ b/sentences/mn/HassTurnOn/name_only.yaml
@@ -12,4 +12,5 @@ data:
     name_domains:
       - "light"
       - "switch"
+      - "climate"
     response: "default"

--- a/sentences/ms/HassTurnOff/name_only.yaml
+++ b/sentences/ms/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<imp_mati> {name}"
     example: "padamkan lampu bilik"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ms/HassTurnOn/name_only.yaml
+++ b/sentences/ms/HassTurnOn/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "<imp_hidup> {name}"
     example: "nyalakan lampu bilik"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/nb/HassTurnOff/name_area.yaml
+++ b/sentences/nb/HassTurnOff/name_area.yaml
@@ -4,12 +4,7 @@ data:
       - "<turn_off> [den ]{name} <in> [den ]{area}"
       - "<turn_off> [den ]{area} [den ]{name}"
     example: "skru av taklampen på kjøkkenet"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/nb/HassTurnOff/name_floor.yaml
+++ b/sentences/nb/HassTurnOff/name_floor.yaml
@@ -3,12 +3,7 @@ data:
   - sentences:
       - "<turn_off> [den ]{name} <in> [den ]{floor}[ etasje[n]]"
     example: "skru av taklampen i første etasje"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/nb/HassTurnOff/name_only.yaml
+++ b/sentences/nb/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
       - "<turn_off> [den ]{name}"
       - "(skru|slå) [den ]{name} av"
     example: "skru av taklampen"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/nb/HassTurnOn/name_area.yaml
+++ b/sentences/nb/HassTurnOn/name_area.yaml
@@ -6,12 +6,7 @@ data:
       - "<turn_on> [den ]{area} [den ]{name}"
       - "<activate> [den ]{name} <in> [den ]{area}"
     example: "skru på taklampen på kjøkkenet"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light word

--- a/sentences/nb/HassTurnOn/name_floor.yaml
+++ b/sentences/nb/HassTurnOn/name_floor.yaml
@@ -4,12 +4,7 @@ data:
       - "<turn_on> [den ]{name} <in> [den ]{floor}[ etasje[n]]"
       - "<activate> [den ]{name} <in> [den ]{floor}[ etasje[n]]"
     example: "skru på taklampen i første etasje"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/nb/HassTurnOn/name_only.yaml
+++ b/sentences/nb/HassTurnOn/name_only.yaml
@@ -6,12 +6,7 @@ data:
       - "(skru|slå) [den ]{name} på"
       - "<activate> [den ]{name}"
     example: "skru på taklampen"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing light word

--- a/sentences/ne/HassTurnOff/name_area.yaml
+++ b/sentences/ne/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "{area}[ कोठा| क्षेत्र| कक्क्ष][को|मा[ (भऐको|रहेको)]| भित्र| भित्रको] {name} (<extinguish_v>|<strike_v>|<kill_v>|<apply_v>)"
       - "{area}[ कोठा| क्षेत्र| कक्क्ष][को|मा[ (भऐको|रहेको)]| भित्र| भित्रको] {name} (अफ|बन्द) [<do_v>|<strike_v>]"
     example: "भान्साको ओभरहेड बत्ती निबाउनु"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ne/HassTurnOff/name_floor.yaml
+++ b/sentences/ne/HassTurnOff/name_floor.yaml
@@ -12,12 +12,7 @@ data:
       - "{floor}[ तल्ला| तह| फ्लोर][को|मा[ भऐको]| भित्र| भित्रको] {name} (<extinguish_v>|<strike_v>|<kill_v>|<apply_v>)"
       - "{floor}[ तल्ला| तह| फ्लोर][को|मा[ भऐको]| भित्र| भित्रको] {name} (अफ|बन्द) [<do_v>|<strike_v>]"
     example: "पहिलो तल्लाको ओभरहेड बत्ती निबाउनु"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ne/HassTurnOff/name_only.yaml
+++ b/sentences/ne/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "{name} (<extinguish_v>|<strike_v>|<kill_v>|<apply_v>)"
       - "{name} (अफ|बन्द) [<do_v>|<strike_v>]"
     example: "ओभरहेड बत्ती निबाउनु"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ne/HassTurnOn/name_area.yaml
+++ b/sentences/ne/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "{area}[ कोठा| क्षेत्र| कक्क्ष][को|मा[ (भऐको|रहेको)]| भित्र| भित्रको] {name} (<kindle_v>|<apply_v>|<open_v>)"
       - "{area}[ कोठा| क्षेत्र| कक्क्ष][को|मा[ (भऐको|रहेको)]| भित्र| भित्रको] {name} (अन|चालु|सुरू) [<do_v>|<strike_v>]"
     example: "भान्साको ओभरहेड बत्ती बाल्नु"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ne/HassTurnOn/name_floor.yaml
+++ b/sentences/ne/HassTurnOn/name_floor.yaml
@@ -12,12 +12,7 @@ data:
       - "{floor}[ तल्ला| तह| फ्लोर][को|मा[ भऐको]| भित्र| भित्रको] {name} (<kindle_v>|<apply_v>|<open_v>)"
       - "{floor}[ तल्ला| तह| फ्लोर][को|मा[ भऐको]| भित्र| भित्रको] {name} (अन|चालु|सुरू) [<do_v>|<strike_v>]"
     example: "पहिलो तल्लाको ओभरहेड बत्ती बाल्नु"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ne/HassTurnOn/name_only.yaml
+++ b/sentences/ne/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "{name} (<kindle_v>|<apply_v>|<open_v>)"
       - "{name} (अन|चालु|सुरू) [<do_v>|<strike_v>]"
     example: "ओभरहेड बत्ती बाल्नु"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/nl/HassTurnOff/name_area.yaml
+++ b/sentences/nl/HassTurnOff/name_area.yaml
@@ -14,12 +14,7 @@ data:
       - "[de|het] {name} [in|op|van|bij] [de|het] {area} (uit[ ](zetten|doen)|uit[ ]schakelen|doen)"
       - "[in|op|van|bij] [de|het] {area} [de|het] {name} (uit[ ](zetten|doen)|uit[ ]schakelen|doen)"
     example: "doe de bovenlamp in de keuken uit"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/nl/HassTurnOff/name_floor.yaml
+++ b/sentences/nl/HassTurnOff/name_floor.yaml
@@ -13,12 +13,7 @@ data:
       - "[<change>] [in|op|van|bij] [de|het] {floor} [de|het] {name} [<to>] uit"
       - "[de|het] {name} [in|op|van|bij] [de|het] {floor} (uit[ ](zetten|doen)|uit[ ]schakelen|doen)"
     example: "doe de bovenlamp op de eerste verdieping uit"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/nl/HassTurnOff/name_only.yaml
+++ b/sentences/nl/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "[<change>] [de|het] {name} [<to>] uit"
       - "[de|het] {name} (uit[ ](zetten|doen)|uit[ ]schakelen|doen)"
     example: "doe de bovenlamp uit"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/nl/HassTurnOn/name_area.yaml
+++ b/sentences/nl/HassTurnOn/name_area.yaml
@@ -16,12 +16,7 @@ data:
       - "[de|het] {name} [in|op|van|bij] [de|het] {area} (aan[ ](zetten|doen)|in[ ]schakelen)"
       - "[in|op|van|bij] [de|het] {area} [de|het] {name} (aan[ ](zetten|doen)|in[ ]schakelen)"
     example: "doe de bovenlamp in de keuken aan"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/nl/HassTurnOn/name_floor.yaml
+++ b/sentences/nl/HassTurnOn/name_floor.yaml
@@ -14,12 +14,7 @@ data:
       - "schakel [de|het] {name} [in|op|van|bij] [de|het] {floor} [<to>] in"
       - "[de|het] {name} [in|op|van|bij] [de|het] {floor} (aan[ ](zetten|doen)|in[ ]schakelen)"
     example: "doe de bovenlamp op de eerste verdieping aan"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/nl/HassTurnOn/name_only.yaml
+++ b/sentences/nl/HassTurnOn/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "schakel [de|het] {name} [<to>] in"
       - "[de|het] {name} (aan[ ](zetten|doen)|in[ ]schakelen)"
     example: "doe de bovenlamp aan"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/pa/HassTurnOff/name_area.yaml
+++ b/sentences/pa/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "{area} <in> [<the>] {name} [ਨੂੰ] <turn_off>"
       - "{area} ਦੀ {name} [ਨੂੰ] <turn_off>"
     example: "ਰਸੋਈ ਵਿੱਚ ਉੱਪਰਲੀ ਲਾਈਟ ਬੰਦ ਕਰੋ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/pa/HassTurnOff/name_floor.yaml
+++ b/sentences/pa/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "{floor} [ਮੰਜ਼ਿਲ] <in> [<the>] {name} [ਨੂੰ] <turn_off>"
     example: "ਪਹਿਲੀ ਮੰਜ਼ਿਲ ਉੱਤੇ ਉੱਪਰਲੀ ਲਾਈਟ ਬੰਦ ਕਰੋ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/pa/HassTurnOff/name_only.yaml
+++ b/sentences/pa/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "[<the>] {name} [ਨੂੰ] <turn_off>"
     example: "ਉੱਪਰਲੀ ਲਾਈਟ ਬੰਦ ਕਰੋ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/pa/HassTurnOn/name_area.yaml
+++ b/sentences/pa/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "{area} <in> [<the>] {name} [ਨੂੰ] <turn_on>"
       - "{area} ਦੀ {name} [ਨੂੰ] <turn_on>"
     example: "ਰਸੋਈ ਵਿੱਚ ਉੱਪਰਲੀ ਲਾਈਟ ਚਾਲੂ ਕਰੋ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/pa/HassTurnOn/name_floor.yaml
+++ b/sentences/pa/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "{floor} [ਮੰਜ਼ਿਲ] <in> [<the>] {name} [ਨੂੰ] <turn_on>"
     example: "ਪਹਿਲੀ ਮੰਜ਼ਿਲ ਉੱਤੇ ਉੱਪਰਲੀ ਲਾਈਟ ਚਾਲੂ ਕਰੋ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/pa/HassTurnOn/name_only.yaml
+++ b/sentences/pa/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "[<the>] {name} [ਨੂੰ] <turn_on>"
     example: "ਉੱਪਰਲੀ ਲਾਈਟ ਚਾਲੂ ਕਰੋ"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)/lamp(s)" word

--- a/sentences/pl/HassTurnOff/name_area.yaml
+++ b/sentences/pl/HassTurnOff/name_area.yaml
@@ -9,10 +9,5 @@ data:
       - "(<turn_off>|<turn_off_light>) {name} <area>"
       - "<area> (<turn_off>|<turn_off_light>) {name}"
     example: "wyłącz lampę w salonie"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"

--- a/sentences/pl/HassTurnOff/name_floor.yaml
+++ b/sentences/pl/HassTurnOff/name_floor.yaml
@@ -9,10 +9,5 @@ data:
       - "(<turn_off>|<turn_off_light>) {name} {floor} [piętro]"
       - "{floor} [piętro] (<turn_off>|<turn_off_light>) {name}"
     example: "wyłącz lampę na piętrze"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"

--- a/sentences/pl/HassTurnOff/name_only.yaml
+++ b/sentences/pl/HassTurnOff/name_only.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "(<turn_off>|<turn_off_light>) {name}"
     example: "wyłącz lampę"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/pl/HassTurnOn/name_area.yaml
+++ b/sentences/pl/HassTurnOn/name_area.yaml
@@ -9,10 +9,5 @@ data:
       - "(<turn_on>|<turn_on_light>) {name} <area>"
       - "<area> (<turn_on>|<turn_on_light>) {name}"
     example: "włącz lampę w salonie"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"

--- a/sentences/pl/HassTurnOn/name_floor.yaml
+++ b/sentences/pl/HassTurnOn/name_floor.yaml
@@ -9,10 +9,5 @@ data:
       - "(<turn_on>|<turn_on_light>) {name} {floor} [piętro]"
       - "{floor} [piętro] (<turn_on>|<turn_on_light>) {name}"
     example: "włącz lampę na piętrze"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"

--- a/sentences/pl/HassTurnOn/name_only.yaml
+++ b/sentences/pl/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "(<turn_on>|<turn_on_light>) {name}"
     example: "włącz lampę"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers (open)

--- a/sentences/pt-BR/HassTurnOff/name_area.yaml
+++ b/sentences/pt-BR/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<desligar> [(o|a|os|as)] {name} (em|no|na|do|da) {area}"
       - "<desligar> [(o|a|os|as)] {area} [(o|a|os|as)] {name}"
     example: "desliga a luz de teto da cozinha"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt-BR/HassTurnOff/name_floor.yaml
+++ b/sentences/pt-BR/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<desligar> [(o|a|os|as)] {name} (em|no|na|do|da) [andar|piso] {floor} [andar|piso]"
     example: "desliga a luz de teto do primeiro andar"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt-BR/HassTurnOff/name_only.yaml
+++ b/sentences/pt-BR/HassTurnOff/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "<desligar> [(o|a|os|as)] {name}"
       - "<desligar> [(o|a|os|as)] (interruptor[es]|tomada[s]) [de|do|da] [(o|a|os|as)] {name}"
     example: "desliga o exaustor"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt-BR/HassTurnOn/name_area.yaml
+++ b/sentences/pt-BR/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<ligar> [(o|a|os|as)] {name} (em|no|na|do|da) {area}"
       - "<ligar> [(o|a|os|as)] {area} [(o|a|os|as)] {name}"
     example: "liga a luz de teto da cozinha"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt-BR/HassTurnOn/name_floor.yaml
+++ b/sentences/pt-BR/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<ligar> [(o|a|os|as)] {name} (em|no|na|do|da) [andar|piso] {floor} [andar|piso]"
     example: "liga a luz de teto do primeiro andar"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt-BR/HassTurnOn/name_only.yaml
+++ b/sentences/pt-BR/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<ligar> [(o|a|os|as)] {name}"
       - "<ligar> [(o|a|os|as)] (interruptor[es]|tomada[s]) [de|do|da] [(o|a|os|as)] {name}"
     example: "liga o exaustor"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt/HassTurnOff/name_area.yaml
+++ b/sentences/pt/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<desligar> [(o|a|os|as)] {name} (em|no|na|do|da) {area}"
       - "<desligar> [(o|a|os|as)] {area} [(o|a|os|as)] {name}"
     example: "desliga a luz de teto da cozinha"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt/HassTurnOff/name_floor.yaml
+++ b/sentences/pt/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<desligar> [(o|a|os|as)] {name} (em|no|na|do|da) [andar|piso] {floor} [andar|piso]"
     example: "desliga a luz de teto do primeiro andar"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt/HassTurnOff/name_only.yaml
+++ b/sentences/pt/HassTurnOff/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "<desligar> [(o|a|os|as)] {name}"
       - "<desligar> [(o|a|os|as)] (interruptor[es]|tomada[s]) [de|do|da] [(o|a|os|as)] {name}"
     example: "desliga o exaustor"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt/HassTurnOn/name_area.yaml
+++ b/sentences/pt/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<ligar> [(o|a|os|as)] {name} (em|no|na|do|da) {area}"
       - "<ligar> [(o|a|os|as)] {area} [(o|a|os|as)] {name}"
     example: "liga a luz de teto da cozinha"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt/HassTurnOn/name_floor.yaml
+++ b/sentences/pt/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<ligar> [(o|a|os|as)] {name} (em|no|na|do|da) [andar|piso] {floor} [andar|piso]"
     example: "liga a luz de teto do primeiro andar"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a leading "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/pt/HassTurnOn/name_only.yaml
+++ b/sentences/pt/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<ligar> [(o|a|os|as)] {name}"
       - "<ligar> [(o|a|os|as)] (interruptor[es]|tomada[s]) [de|do|da] [(o|a|os|as)] {name}"
     example: "liga o exaustor"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "luz/luzes/candeeiro/lâmpada" word

--- a/sentences/ro/HassTurnOff/name_area.yaml
+++ b/sentences/ro/HassTurnOff/name_area.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<opreste> <name> <din_zona>"
     example: "oprește lampa din bucătărie"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/ro/HassTurnOff/name_floor.yaml
+++ b/sentences/ro/HassTurnOff/name_floor.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<opreste> <name> [<din>] <floor>"
     example: "oprește lampa de la etaj"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/ro/HassTurnOff/name_only.yaml
+++ b/sentences/ro/HassTurnOff/name_only.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<opreste> <name>"
     example: "oprește lampa"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/ro/HassTurnOn/name_area.yaml
+++ b/sentences/ro/HassTurnOn/name_area.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<porneste> <name> <din_zona>"
     example: "pornește lampa din bucătărie"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/ro/HassTurnOn/name_floor.yaml
+++ b/sentences/ro/HassTurnOn/name_floor.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<porneste> <name> [<din>] <floor>"
     example: "pornește lampa de la etaj"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/ro/HassTurnOn/name_only.yaml
+++ b/sentences/ro/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<porneste> <name>"
     example: "pornește lampa"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with trailing light word

--- a/sentences/ru/HassTurnOff/name_area.yaml
+++ b/sentences/ru/HassTurnOff/name_area.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_off> [в|во|на] {area} {name}"
       - "<turn_off> {name} [в|во|на] {area}"
     example: "выключи лампу в гостиной"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ru/HassTurnOff/name_only.yaml
+++ b/sentences/ru/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<turn_off> {name}"
     example: "выключи лампу"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ru/HassTurnOn/name_area.yaml
+++ b/sentences/ru/HassTurnOn/name_area.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_on> [в|во|на] {area} {name}"
       - "<turn_on> {name} [в|во|на] {area}"
     example: "включи лампу в гостиной"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ru/HassTurnOn/name_only.yaml
+++ b/sentences/ru/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<turn_on> {name}"
     example: "включи лампу"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/sk/HassTurnOff/name_area.yaml
+++ b/sentences/sk/HassTurnOff/name_area.yaml
@@ -2,12 +2,7 @@ language: sk
 data:
   - sentences:
       - "(<turn_off>|<turn_off_light>) {name} <area>"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: default
   - sentences:
       - "(<close_door>|<close_curtain>) {name} <area>"

--- a/sentences/sk/HassTurnOff/name_area.yaml
+++ b/sentences/sk/HassTurnOff/name_area.yaml
@@ -2,20 +2,24 @@ language: sk
 data:
   - sentences:
       - "(<turn_off>|<turn_off_light>) {name} <area>"
+    example: "vypni modrú lampu v kuchyni"
     name_domains: "default"
     response: default
   - sentences:
       - "(<close_door>|<close_curtain>) {name} <area>"
+    example: "zatvor garážovú bránu v kuchyni"
     name_domains:
       - "cover"
     response: cover
   - sentences:
       - "<close_valve> [ventil] {name} <area>"
+    example: "zatvor ventil hlavný uzáver vody v kuchyni"
     name_domains:
       - "valve"
     response: valve
   - sentences:
       - "<unlock> {name} <area>"
+    example: "odomkni vstupné dvere v kuchyni"
     name_domains:
       - "lock"
     response: lock

--- a/sentences/sk/HassTurnOff/name_floor.yaml
+++ b/sentences/sk/HassTurnOff/name_floor.yaml
@@ -2,12 +2,7 @@ language: sk
 data:
   - sentences:
       - "(<turn_off>|<turn_off_light>) {name} <floor>"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: default
   - sentences:
       - "(<close_door>|<close_curtain>) {name} <floor>"

--- a/sentences/sk/HassTurnOff/name_floor.yaml
+++ b/sentences/sk/HassTurnOff/name_floor.yaml
@@ -2,15 +2,18 @@ language: sk
 data:
   - sentences:
       - "(<turn_off>|<turn_off_light>) {name} <floor>"
+    example: "vypni modrú lampu na prvom poschodí"
     name_domains: "default"
     response: default
   - sentences:
       - "(<close_door>|<close_curtain>) {name} <floor>"
+    example: "zatvor garážovú bránu na prvom poschodí"
     name_domains:
       - "cover"
     response: cover
   - sentences:
       - "<close_valve> [ventil] {name} <floor>"
+    example: "zatvor ventil hlavný uzáver vody na prvom poschodí"
     name_domains:
       - "valve"
     response: valve

--- a/sentences/sk/HassTurnOff/name_only.yaml
+++ b/sentences/sk/HassTurnOff/name_only.yaml
@@ -3,12 +3,7 @@ data:
   - sentences:
       - "(<turn_off>|<turn_off_light>) {name}"
       - "{name} (<turn_off>|<turn_off_light>)"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: default
   - sentences:
       - "<turn_off> [[stropný] (ventilátor|vetrák)] {name}"

--- a/sentences/sk/HassTurnOff/name_only.yaml
+++ b/sentences/sk/HassTurnOff/name_only.yaml
@@ -3,25 +3,30 @@ data:
   - sentences:
       - "(<turn_off>|<turn_off_light>) {name}"
       - "{name} (<turn_off>|<turn_off_light>)"
+    example: "vypni modrú lampu"
     name_domains: "default"
     response: default
   - sentences:
       - "<turn_off> [[stropný] (ventilátor|vetrák)] {name}"
+    example: "vypni ventilátor Vetrák"
     name_domains:
       - "fan"
     response: default
   - sentences:
       - "(<close_door>|<close_curtain>) {name}"
+    example: "zatvor garážovú bránu"
     name_domains:
       - "cover"
     response: cover
   - sentences:
       - "<close_valve> [ventil] {name}"
+    example: "zatvor ventil hlavný uzáver vody"
     name_domains:
       - "valve"
     response: valve
   - sentences:
       - "<unlock> {name}"
+    example: "odomkni vstupné dvere"
     name_domains:
       - "lock"
     response: lock

--- a/sentences/sk/HassTurnOn/name_area.yaml
+++ b/sentences/sk/HassTurnOn/name_area.yaml
@@ -2,12 +2,7 @@ language: sk
 data:
   - sentences:
       - "(<turn_on>|<turn_on_light>) {name} <area>"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: default
   - sentences:
       - "(<open_door>|<open_curtain>) {name} <area>"

--- a/sentences/sk/HassTurnOn/name_area.yaml
+++ b/sentences/sk/HassTurnOn/name_area.yaml
@@ -2,20 +2,24 @@ language: sk
 data:
   - sentences:
       - "(<turn_on>|<turn_on_light>) {name} <area>"
+    example: "zapni rohovú lampu v kuchyni"
     name_domains: "default"
     response: default
   - sentences:
       - "(<open_door>|<open_curtain>) {name} <area>"
+    example: "otvor garážovú bránu v kuchyni"
     name_domains:
       - "cover"
     response: cover
   - sentences:
       - "<open_valve> [ventil] {name} <area>"
+    example: "otvor ventil hlavný uzáver vody v kuchyni"
     name_domains:
       - "valve"
     response: valve
   - sentences:
       - "<lock> {name} <area>"
+    example: "uzamkni vstupné dvere v kuchyni"
     name_domains:
       - "lock"
     response: lock

--- a/sentences/sk/HassTurnOn/name_floor.yaml
+++ b/sentences/sk/HassTurnOn/name_floor.yaml
@@ -2,12 +2,7 @@ language: sk
 data:
   - sentences:
       - "(<turn_on>|<turn_on_light>) {name} <floor>"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: default
   - sentences:
       - "(<open_door>|<open_curtain>) {name} <floor>"

--- a/sentences/sk/HassTurnOn/name_floor.yaml
+++ b/sentences/sk/HassTurnOn/name_floor.yaml
@@ -2,15 +2,18 @@ language: sk
 data:
   - sentences:
       - "(<turn_on>|<turn_on_light>) {name} <floor>"
+    example: "zapni rohovú lampu na prvom poschodí"
     name_domains: "default"
     response: default
   - sentences:
       - "(<open_door>|<open_curtain>) {name} <floor>"
+    example: "otvor garážovú bránu na prvom poschodí"
     name_domains:
       - "cover"
     response: cover
   - sentences:
       - "<open_valve> [ventil] {name} <floor>"
+    example: "otvor ventil hlavný uzáver vody na prvom poschodí"
     name_domains:
       - "valve"
     response: valve

--- a/sentences/sk/HassTurnOn/name_only.yaml
+++ b/sentences/sk/HassTurnOn/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "(<turn_on>|<turn_on_light>) {name}"
       - "{name} (<turn_on>|<turn_on_light>)"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: default
   # ventilátory s predradeným podstatným menom
   - sentences:

--- a/sentences/sk/HassTurnOn/name_only.yaml
+++ b/sentences/sk/HassTurnOn/name_only.yaml
@@ -4,30 +4,35 @@ data:
   - sentences:
       - "(<turn_on>|<turn_on_light>) {name}"
       - "{name} (<turn_on>|<turn_on_light>)"
+    example: "zapni rohovú lampu"
     name_domains: "default"
     response: default
   # ventilátory s predradeným podstatným menom
   - sentences:
       - "<turn_on> [[stropný] (ventilátor|vetrák)] {name}"
       - "[[stropný] (ventilátor|vetrák)] {name} <turn_on>"
+    example: "zapni ventilátor Vetrák"
     name_domains:
       - "fan"
     response: default
   # cover (otvor/vytiahni)
   - sentences:
       - "(<open_door>|<open_curtain>) {name}"
+    example: "otvor garážovú bránu"
     name_domains:
       - "cover"
     response: cover
   # valve
   - sentences:
       - "<open_valve> [ventil] {name}"
+    example: "otvor ventil hlavný uzáver vody"
     name_domains:
       - "valve"
     response: valve
   # lock
   - sentences:
       - "<lock> {name}"
+    example: "uzamkni vstupné dvere"
     name_domains:
       - "lock"
     response: lock

--- a/sentences/sl/HassTurnOff/name_area.yaml
+++ b/sentences/sl/HassTurnOff/name_area.yaml
@@ -10,12 +10,7 @@ data:
   - sentences:
       - "<izklopi> {name} [v|na] {area}"
     example: "izklopi stropno luč v kuhinji"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/sl/HassTurnOff/name_floor.yaml
+++ b/sentences/sl/HassTurnOff/name_floor.yaml
@@ -10,12 +10,7 @@ data:
   - sentences:
       - "<izklopi> {name} [v|na] {floor} [nadstropju]"
     example: "izklopi stropno luč v pritličju"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/sl/HassTurnOff/name_only.yaml
+++ b/sentences/sl/HassTurnOff/name_only.yaml
@@ -8,12 +8,7 @@ data:
   - sentences:
       - "<izklopi> {name}"
     example: "izklopi stropno luč"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   - sentences:

--- a/sentences/sl/HassTurnOn/name_area.yaml
+++ b/sentences/sl/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<vklopi> {name} [v|na] {area}"
       - "aktiviraj {name} [v|na] {area}"
     example: "vklopi stropno luč v kuhinji"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default_name"
 
   # lights with trailing light word

--- a/sentences/sl/HassTurnOn/name_floor.yaml
+++ b/sentences/sl/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
       - "<vklopi> {name} [v|na] {floor} [nadstropju]"
       - "aktiviraj {name} [v|na] {floor} [nadstropju]"
     example: "vklopi stropno luč v pritličju"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default_name"
 
   - sentences:

--- a/sentences/sl/HassTurnOn/name_only.yaml
+++ b/sentences/sl/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<vklopi> {name}"
       - "aktiviraj {name}"
     example: "vklopi stropno luč"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default_name"
 
   # lights with trailing light word

--- a/sentences/sr-Latn/HassTurnOff/name_area.yaml
+++ b/sentences/sr-Latn/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<deactivate> {name} (u|na) [prostoriji] {area}"
       - "<deactivate> (u|na) [prostoriji] {area} {name}"
     example: "isključi plafonsko svetlo u dnevnoj sobi"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr-Latn/HassTurnOff/name_floor.yaml
+++ b/sentences/sr-Latn/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<deactivate> {name} (na|u) {floor}"
     example: "isključi plafonsko svetlo na prvom spratu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr-Latn/HassTurnOff/name_only.yaml
+++ b/sentences/sr-Latn/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<deactivate> {name}"
       - "{name} [na] isključeno"
     example: "isključi plafonsko svetlo"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr-Latn/HassTurnOn/name_area.yaml
+++ b/sentences/sr-Latn/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<activate> {name} (u|na) [prostoriji] {area}"
       - "<activate> (u|na) [prostoriji] {area} {name}"
     example: "uključi plafonsko svetlo u dnevnoj sobi"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr-Latn/HassTurnOn/name_floor.yaml
+++ b/sentences/sr-Latn/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<activate> {name} (na|u) {floor}"
     example: "uključi plafonsko svetlo na prvom spratu"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr-Latn/HassTurnOn/name_only.yaml
+++ b/sentences/sr-Latn/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<activate> {name}"
       - "{name} [na] uključeno"
     example: "uključi plafonsko svetlo"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr/HassTurnOff/name_area.yaml
+++ b/sentences/sr/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<deactivate> {name} (у|на) [просторији] {area}"
       - "<deactivate> (у|на) [просторији] {area} {name}"
     example: "искључи плафонско светло у дневној соби"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr/HassTurnOff/name_floor.yaml
+++ b/sentences/sr/HassTurnOff/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<deactivate> {name} (на|у) {floor}"
     example: "искључи плафонско светло на првом спрату"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr/HassTurnOff/name_only.yaml
+++ b/sentences/sr/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<deactivate> {name}"
       - "{name} [на] искључено"
     example: "искључи плафонско светло"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr/HassTurnOn/name_area.yaml
+++ b/sentences/sr/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<activate> {name} (у|на) [просторији] {area}"
       - "<activate> (у|на) [просторији] {area} {name}"
     example: "укључи плафонско светло у дневној соби"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr/HassTurnOn/name_floor.yaml
+++ b/sentences/sr/HassTurnOn/name_floor.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "<activate> {name} (на|у) {floor}"
     example: "укључи плафонско светло на првом спрату"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sr/HassTurnOn/name_only.yaml
+++ b/sentences/sr/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<activate> {name}"
       - "{name} [на] укључено"
     example: "укључи плафонско светло"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/sv/HassTurnOff/name_area.yaml
+++ b/sentences/sv/HassTurnOff/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<slå_av> <name> <i_på> <area>"
       - "<slå_av> <area> <name>"
     example: "släck bänkbelysningen i köket"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/sv/HassTurnOff/name_only.yaml
+++ b/sentences/sv/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<slå_av> <name>"
       - "<name> av"
     example: "släck sänglampan"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/sv/HassTurnOn/name_area.yaml
+++ b/sentences/sv/HassTurnOn/name_area.yaml
@@ -12,12 +12,7 @@ data:
       - "<slå_på> <name> <i_på> <area>"
       - "<slå_på> <area> <name>"
     example: "tänd bänkbelysningen i köket"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/sv/HassTurnOn/name_only.yaml
+++ b/sentences/sv/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<slå_på> <name>"
       - "<name> på"
     example: "tänd sänglampan"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light/lamp" word

--- a/sentences/sw/HassTurnOff/name_only.yaml
+++ b/sentences/sw/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<turn_off> {name}"
     example: "zima Taa Ofisini"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/sw/HassTurnOn/name_only.yaml
+++ b/sentences/sw/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "<turn_on> {name}"
     example: "washa Taa Ofisini"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ta/HassTurnOff/name_area.yaml
+++ b/sentences/ta/HassTurnOff/name_area.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{area}[(-இல்|–இல்|இல்)] {name}[(-ஐ|–ஐ|ஐ)] <turn_off>"
     example: "படுக்கையறையில் மேசை லாம்பு ஆஃப் செய்யவும்"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ta/HassTurnOff/name_floor.yaml
+++ b/sentences/ta/HassTurnOff/name_floor.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{floor}[(-இல்|–இல்|இல்)] {name}[(-ஐ|–ஐ|ஐ)] <turn_off>"
     example: "முதல் தளம் மேசை லாம்பு ஆஃப் செய்யவும்"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ta/HassTurnOff/name_only.yaml
+++ b/sentences/ta/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "{name}[(-ஐ|–ஐ|ஐ)] <turn_off>"
       - "{name}[(-ஐ|–ஐ|ஐ)] முடக்கவும்"
     example: "மேசை லாம்பு ஆஃப் செய்யவும்"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/ta/HassTurnOn/name_area.yaml
+++ b/sentences/ta/HassTurnOn/name_area.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{area}[(-இல்|–இல்|இல்)] {name}[(-ஐ|–ஐ|ஐ)] <turn_on>"
     example: "படுக்கையறையில் மேசை லாம்பு ஆன் செய்யவும்"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ta/HassTurnOn/name_floor.yaml
+++ b/sentences/ta/HassTurnOn/name_floor.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{floor}[(-இல்|–இல்|இல்)] {name}[(-ஐ|–ஐ|ஐ)] <turn_on>"
     example: "முதல் தளம் மேசை லாம்பு ஆன் செய்யவும்"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ta/HassTurnOn/name_only.yaml
+++ b/sentences/ta/HassTurnOn/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "{name}[(-ஐ|–ஐ|ஐ)] <turn_on>"
       - "{name}[(-ஐ|–ஐ|ஐ)] இயக்கவும்"
     example: "மேசை லாம்பு ஆன் செய்யவும்"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # lights named with a trailing "light(s)" word

--- a/sentences/te/HassTurnOff/name_only.yaml
+++ b/sentences/te/HassTurnOff/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "[<the>] {name} <turn_off>"
     example: "Bedroom Lamp off చెయ్యి"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/te/HassTurnOn/name_only.yaml
+++ b/sentences/te/HassTurnOn/name_only.yaml
@@ -4,12 +4,7 @@ data:
   - sentences:
       - "[<the>] {name} <turn_on>"
     example: "Bedroom Lamp on చెయ్యి"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/th/HassTurnOff/name_only.yaml
+++ b/sentences/th/HassTurnOff/name_only.yaml
@@ -17,4 +17,5 @@ data:
       - "input_boolean"
       - "cover"
       - "valve"
+      - "climate"
     response: "default"

--- a/sentences/th/HassTurnOff/name_only.yaml
+++ b/sentences/th/HassTurnOff/name_only.yaml
@@ -9,6 +9,7 @@ data:
   - sentences:
       - "ปิด[(ใช้|ใช้งาน)]{name}"
       - "(ปรับ|เปลี่ยน){name}<to>(ปิด|หยุด[ทำงาน]|ไม่ทำงาน)"
+    example: "ปิดไฟห้องน้ำ"
     name_domains:
       - "light"
       - "switch"

--- a/sentences/th/HassTurnOn/name_only.yaml
+++ b/sentences/th/HassTurnOn/name_only.yaml
@@ -16,4 +16,5 @@ data:
       - "input_boolean"
       - "cover"
       - "valve"
+      - "climate"
     response: "default"

--- a/sentences/th/HassTurnOn/name_only.yaml
+++ b/sentences/th/HassTurnOn/name_only.yaml
@@ -8,6 +8,7 @@ data:
   - sentences:
       - "เปิด[(ใช้|ใช้งาน)]{name}"
       - "(ปรับ|เปลี่ยน){name}<to>(เปิด|ทำงาน)"
+    example: "เปิดไฟห้องน้ำ"
     name_domains:
       - "light"
       - "switch"

--- a/sentences/tr/HassTurnOff/name_area.yaml
+++ b/sentences/tr/HassTurnOff/name_area.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "{area}[([(n|ın|in|un|ün|y|t|d|nd|nt)]ı|[(n|ın|in|un|ün|y|t|d|nd|nt)]i|[(n|ın|in|un|ün|y|t|d|nd|nt)]ü|[(n|ın|in|un|ün|y|t|d|nd|nt)]u|[(n|ın|in|un|ün|y|t|d|nd|nt)]e|[(n|ın|in|un|ün|y|t|d|nd|nt)]a)][n][ki] {name}[(ler|leri|lar|ları)][([(n|ın|in|un|ün|y|t|d|nd|nt)]ı|[(n|ın|in|un|ün|y|t|d|nd|nt)]i|[(n|ın|in|un|ün|y|t|d|nd|nt)]ü|[(n|ın|in|un|ün|y|t|d|nd|nt)]u|[(n|ın|in|un|ün|y|t|d|nd|nt)]e|[(n|ın|in|un|ün|y|t|d|nd|nt)]a)][n][ki] <kapat>"
     example: "Oturma Odasındaki Tavan Lambasını kapat"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/tr/HassTurnOff/name_only.yaml
+++ b/sentences/tr/HassTurnOff/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{name}[(ler|leri|lar|ları)][([(n|ın|in|un|ün|y|t|d|nd|nt)]ı|[(n|ın|in|un|ün|y|t|d|nd|nt)]i|[(n|ın|in|un|ün|y|t|d|nd|nt)]ü|[(n|ın|in|un|ün|y|t|d|nd|nt)]u|[(n|ın|in|un|ün|y|t|d|nd|nt)]e|[(n|ın|in|un|ün|y|t|d|nd|nt)]a)][n][ki] <kapat>"
     example: "Yatak Odası Lambasını kapat"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/tr/HassTurnOn/name_area.yaml
+++ b/sentences/tr/HassTurnOn/name_area.yaml
@@ -11,12 +11,7 @@ data:
   - sentences:
       - "{area}[([(n|ın|in|un|ün|y|t|d|nd|nt)]ı|[(n|ın|in|un|ün|y|t|d|nd|nt)]i|[(n|ın|in|un|ün|y|t|d|nd|nt)]ü|[(n|ın|in|un|ün|y|t|d|nd|nt)]u|[(n|ın|in|un|ün|y|t|d|nd|nt)]e|[(n|ın|in|un|ün|y|t|d|nd|nt)]a)][n][ki] {name}[(ler|leri|lar|ları)][([(n|ın|in|un|ün|y|t|d|nd|nt)]ı|[(n|ın|in|un|ün|y|t|d|nd|nt)]i|[(n|ın|in|un|ün|y|t|d|nd|nt)]ü|[(n|ın|in|un|ün|y|t|d|nd|nt)]u|[(n|ın|in|un|ün|y|t|d|nd|nt)]e|[(n|ın|in|un|ün|y|t|d|nd|nt)]a)][n][ki] <ac>"
     example: "Oturma Odasındaki Tavan Lambasını aç"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/tr/HassTurnOn/name_only.yaml
+++ b/sentences/tr/HassTurnOn/name_only.yaml
@@ -9,12 +9,7 @@ data:
   - sentences:
       - "{name}[(ler|leri|lar|ları)][([(n|ın|in|un|ün|y|t|d|nd|nt)]ı|[(n|ın|in|un|ün|y|t|d|nd|nt)]i|[(n|ın|in|un|ün|y|t|d|nd|nt)]ü|[(n|ın|in|un|ün|y|t|d|nd|nt)]u|[(n|ın|in|un|ün|y|t|d|nd|nt)]e|[(n|ın|in|un|ün|y|t|d|nd|nt)]a)][n][ki] <ac>"
     example: "Yatak Odası Lambasını aç"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/uk/HassTurnOff/name_area.yaml
+++ b/sentences/uk/HassTurnOff/name_area.yaml
@@ -7,12 +7,7 @@ data:
       - "<turn_off> [в|у|на] {area} {name}"
       - "<turn_off> {name} [в|у|на] {area}"
     example: "вимкни кондиціонер на кухні"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/uk/HassTurnOff/name_floor.yaml
+++ b/sentences/uk/HassTurnOff/name_floor.yaml
@@ -6,12 +6,7 @@ data:
   - sentences:
       - "<turn_off> {name} [в|у|на] {floor}"
     example: "вимкни кондиціонер на другому поверсі"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/uk/HassTurnOff/name_only.yaml
+++ b/sentences/uk/HassTurnOff/name_only.yaml
@@ -6,12 +6,7 @@ data:
   - sentences:
       - "<turn_off> {name}"
     example: "вимкни кондиціонер"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/uk/HassTurnOn/name_area.yaml
+++ b/sentences/uk/HassTurnOn/name_area.yaml
@@ -9,12 +9,7 @@ data:
       - "активуй [в|у|на] {area} {name}"
       - "активуй {name} [в|у|на] {area}"
     example: "ввімкни настільну лампу на кухні"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/uk/HassTurnOn/name_floor.yaml
+++ b/sentences/uk/HassTurnOn/name_floor.yaml
@@ -7,12 +7,7 @@ data:
       - "<turn_on> {name} [в|у|на] {floor}"
       - "активуй {name} [в|у|на] {floor}"
     example: "ввімкни настільну лампу на другому поверсі"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/uk/HassTurnOn/name_only.yaml
+++ b/sentences/uk/HassTurnOn/name_only.yaml
@@ -7,12 +7,7 @@ data:
       - "<turn_on> {name}"
       - "активуй {name}"
     example: "ввімкни настільну лампу"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ur/HassTurnOff/name_only.yaml
+++ b/sentences/ur/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "{name} [کو] [کے] [کا] <turn_off> [<set>]"
       - "<turn_off> [<set>] {name} [کو] [کے] [کا]"
     example: "bedroom lamp بند کرو"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/ur/HassTurnOn/name_only.yaml
+++ b/sentences/ur/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "{name} [کو] [کے] [کا] <turn_on> [<set>]"
       - "<turn_on> [<set>] {name} [کو] [کے] [کا]"
     example: "ceiling fan کھولو"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/vi/HassTurnOff/name_area.yaml
+++ b/sentences/vi/HassTurnOff/name_area.yaml
@@ -11,12 +11,7 @@ data:
       - "<turn_off> [cái] {name} [<in>] [cái] {area} [đi]"
       - "[chuyển] [cái] {name} [<in>] [cái] {area} [thành] tắt"
     example: "tắt đèn trần trong bếp"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/vi/HassTurnOff/name_only.yaml
+++ b/sentences/vi/HassTurnOff/name_only.yaml
@@ -10,12 +10,7 @@ data:
       - "<turn_off> [cái] {name} [đi]"
       - "[chuyển] [cái] {name} [thành] tắt"
     example: "tắt đèn trần"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/vi/HassTurnOn/name_area.yaml
+++ b/sentences/vi/HassTurnOn/name_area.yaml
@@ -11,12 +11,7 @@ data:
       - "<turn> [cái] {name} [<in>] [cái] {area}"
       - "<turn> [cái] {name} [<in>] [cái] {area} [thành|sang] bật"
     example: "bật đèn trần trong bếp"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/vi/HassTurnOn/name_only.yaml
+++ b/sentences/vi/HassTurnOn/name_only.yaml
@@ -11,12 +11,7 @@ data:
       - "<turn> [cái] {name} [thành|sang] bật"
       - "[cái] {name} bật"
     example: "bật đèn trần"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-CN/HassTurnOff/name_area.yaml
+++ b/sentences/zh-CN/HassTurnOff/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off>{area}[的]{name}[的][(<light>|(开关|电源|插座|通断器))]"
       - "[把|将|让|给]{area}[的]{name}[的][(<light>|(开关|电源|插座|通断器))]<turn_off>"
     example: "关闭客厅吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-CN/HassTurnOff/name_floor.yaml
+++ b/sentences/zh-CN/HassTurnOff/name_floor.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off>{floor}[楼|层][的]{name}[的][(<light>|(开关|电源|插座|通断器))]"
       - "[把|将|让|给]{floor}[楼|层][的]{name}[的][(<light>|(开关|电源|插座|通断器))]<turn_off>"
     example: "关闭一楼吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-CN/HassTurnOff/name_only.yaml
+++ b/sentences/zh-CN/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off>{name}[的][(<light>|(开关|电源|插座|通断器))]"
       - "[把|将|让|给]{name}[的][(<light>|(开关|电源|插座|通断器))]<turn_off>"
     example: "关闭易来吸顶灯"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-CN/HassTurnOn/name_area.yaml
+++ b/sentences/zh-CN/HassTurnOn/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on>{area}[的]{name}[的][(<light>|(开关|电源|插座|通断器))]"
       - "[把|将|让|给]{area}[的]{name}[的][(<light>|(开关|电源|插座|通断器))]<turn_on>"
     example: "打开客厅吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-CN/HassTurnOn/name_floor.yaml
+++ b/sentences/zh-CN/HassTurnOn/name_floor.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on>{floor}[楼|层][的]{name}[的][(<light>|(开关|电源|插座|通断器))]"
       - "[把|将|让|给]{floor}[楼|层][的]{name}[的][(<light>|(开关|电源|插座|通断器))]<turn_on>"
     example: "打开一楼吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-CN/HassTurnOn/name_only.yaml
+++ b/sentences/zh-CN/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on>{name}[的][(<light>|(开关|电源|插座|通断器))]"
       - "[把|将|让|给]{name}[的][(<light>|(开关|电源|插座|通断器))]<turn_on>"
     example: "打开易来吸顶灯"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-HK/HassTurnOff/name_area.yaml
+++ b/sentences/zh-HK/HassTurnOff/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "(關閉|關掉|關|閂){area}[的|嘅]{name}[的|嘅]"
       - "[把|將|請]{area}[的|嘅]{name}[的|嘅](關閉|關掉|關|閂)"
     example: "關閉客廳吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-HK/HassTurnOff/name_only.yaml
+++ b/sentences/zh-HK/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "(關閉|關掉|關|閂){name}[的|嘅]"
       - "[把|將|請]{name}[的|嘅](關閉|關掉|關|閂)"
     example: "關閉吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-HK/HassTurnOn/name_area.yaml
+++ b/sentences/zh-HK/HassTurnOn/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "(打開|開啟|開|着){area}[的|嘅]{name}[的|嘅]"
       - "[把|將|請]{area}[的|嘅]{name}[的|嘅](打開|開啟|開著|着)"
     example: "打開客廳吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-HK/HassTurnOn/name_only.yaml
+++ b/sentences/zh-HK/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "(打開|開啟|開|着){name}[的|嘅]"
       - "[把|將|請]{name}[的|嘅](打開|開啟|開著|着)"
     example: "打開吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-TW/HassTurnOff/name_area.yaml
+++ b/sentences/zh-TW/HassTurnOff/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off>{area}[的]{name}[的][(<light>|<switch>)]"
       - "[把|將]{area}[的]{name}[的][(<light>|<switch>)]<turn_off>"
     example: "關閉客廳吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-TW/HassTurnOff/name_floor.yaml
+++ b/sentences/zh-TW/HassTurnOff/name_floor.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off>{floor}[的]{name}[的][(<light>|<switch>)]"
       - "[把|將]{floor}[的]{name}[的][(<light>|<switch>)]<turn_off>"
     example: "打開二樓的吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-TW/HassTurnOff/name_only.yaml
+++ b/sentences/zh-TW/HassTurnOff/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_off>{name}[的][(<light>|<switch>)]"
       - "[把|將]{name}[的][(<light>|<switch>)]<turn_off>"
     example: "關閉臥室檯燈"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-TW/HassTurnOn/name_area.yaml
+++ b/sentences/zh-TW/HassTurnOn/name_area.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on>{area}[的]{name}[的][(<light>|<switch>)]"
       - "[把|將]{area}[的]{name}[的][(<light>|<switch>)]<turn_on>"
     example: "打開客廳吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-TW/HassTurnOn/name_floor.yaml
+++ b/sentences/zh-TW/HassTurnOn/name_floor.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on>{floor}[的]{name}[的][(<light>|<switch>)]"
       - "[把|將]{floor}[的]{name}[的][(<light>|<switch>)]<turn_on>"
     example: "打開二樓的吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/sentences/zh-TW/HassTurnOn/name_only.yaml
+++ b/sentences/zh-TW/HassTurnOn/name_only.yaml
@@ -5,12 +5,7 @@ data:
       - "<turn_on>{name}[的][(<light>|<switch>)]"
       - "[把|將]{name}[的][(<light>|<switch>)]<turn_on>"
     example: "打開吊扇"
-    name_domains:
-      - "light"
-      - "switch"
-      - "fan"
-      - "media_player"
-      - "input_boolean"
+    name_domains: "default"
     response: "default"
 
   # covers

--- a/tests/en/HassTurnOff/name_area.yaml
+++ b/tests/en/HassTurnOff/name_area.yaml
@@ -11,6 +11,8 @@ entities:
     domain: "light"
   - name: "Play Corner"
     domain: "light"
+  - name: "Thermostat"
+    domain: "climate"
   - name: "Curtain Left"
     domain: "cover"
   - name: "Front Door"
@@ -47,6 +49,19 @@ tests:
       name: "Play Corner"
       area: "Kitchen"
     response: "Turned off the light"
+
+  # climate
+  - sentences:
+      - "turn off the living room thermostat"
+      - "turn off the thermostat in the living room"
+      - "turn the living room thermostat off"
+      - "turn the thermostat in the living room off"
+      - "deactivate the living room thermostat"
+      - "deactivate the thermostat in the living room"
+    slots:
+      name: "Thermostat"
+      area: "Living Room"
+    response: "Turned off the thermostat"
 
   # covers
   - sentences:

--- a/tests/en/HassTurnOff/name_floor.yaml
+++ b/tests/en/HassTurnOff/name_floor.yaml
@@ -11,6 +11,8 @@ entities:
     domain: "light"
   - name: "Play Corner"
     domain: "light"
+  - name: "Thermostat"
+    domain: "climate"
   - name: "Sliding Door"
     domain: "cover"
   - name: "Main Valve"
@@ -38,6 +40,16 @@ tests:
       name: "Play Corner"
       floor: "First Floor"
     response: "Turned off the light"
+
+  # climate
+  - sentences:
+      - "turn off the thermostat on the first floor"
+      - "turn the thermostat on the first floor off"
+      - "deactivate the thermostat on the first floor"
+    slots:
+      name: "Thermostat"
+      floor: "First Floor"
+    response: "Turned off the thermostat"
 
   # covers
   - sentences:

--- a/tests/en/HassTurnOff/name_only.yaml
+++ b/tests/en/HassTurnOff/name_only.yaml
@@ -13,6 +13,8 @@ entities:
     domain: "light"
   - name: "Ceiling Fan"
     domain: "fan"
+  - name: "Thermostat"
+    domain: "climate"
   - name: "Sliding Door"
     domain: "cover"
   - name: "Curtain Left"
@@ -61,6 +63,17 @@ tests:
     slots:
       name: "Ceiling Fan"
     response: "Turned off the fan"
+
+  # climate
+  - sentences:
+      - "turn off thermostat"
+      - "turn off the thermostat"
+      - "turn the thermostat off"
+      - "thermostat off"
+      - "deactivate the thermostat"
+    slots:
+      name: "Thermostat"
+    response: "Turned off the thermostat"
 
   # covers
   - sentences:

--- a/tests/en/HassTurnOn/name_area.yaml
+++ b/tests/en/HassTurnOn/name_area.yaml
@@ -11,6 +11,8 @@ entities:
     domain: "light"
   - name: "Play Corner"
     domain: "light"
+  - name: "Thermostat"
+    domain: "climate"
   - name: "Curtain Left"
     domain: "cover"
   - name: "Front Door"
@@ -49,6 +51,19 @@ tests:
       name: "Play Corner"
       area: "Kitchen"
     response: "Turned on the light"
+
+  # climate
+  - sentences:
+      - "turn on the living room thermostat"
+      - "turn on the thermostat in the living room"
+      - "turn the living room thermostat on"
+      - "turn the thermostat in the living room on"
+      - "activate the living room thermostat"
+      - "activate the thermostat in the living room"
+    slots:
+      name: "Thermostat"
+      area: "Living Room"
+    response: "Turned on the thermostat"
 
   # covers
   - sentences:

--- a/tests/en/HassTurnOn/name_floor.yaml
+++ b/tests/en/HassTurnOn/name_floor.yaml
@@ -11,6 +11,8 @@ entities:
     domain: "light"
   - name: "Play Corner"
     domain: "light"
+  - name: "Thermostat"
+    domain: "climate"
   - name: "Sliding Door"
     domain: "cover"
   - name: "Main Valve"
@@ -39,6 +41,16 @@ tests:
       name: "Play Corner"
       floor: "First Floor"
     response: "Turned on the light"
+
+  # climate
+  - sentences:
+      - "turn on the thermostat on the first floor"
+      - "turn the thermostat on the first floor on"
+      - "activate the thermostat on the first floor"
+    slots:
+      name: "Thermostat"
+      floor: "First Floor"
+    response: "Turned on the thermostat"
 
   # covers
   - sentences:

--- a/tests/en/HassTurnOn/name_only.yaml
+++ b/tests/en/HassTurnOn/name_only.yaml
@@ -11,6 +11,8 @@ entities:
     domain: "light"
   - name: "Ceiling Fan"
     domain: "fan"
+  - name: "Thermostat"
+    domain: "climate"
   - name: "Sliding Door"
     domain: "cover"
   - name: "Curtain Left"
@@ -52,6 +54,17 @@ tests:
     slots:
       name: "Ceiling Fan"
     response: "Turned on the fan"
+
+  # climate
+  - sentences:
+      - "turn on thermostat"
+      - "turn on the thermostat"
+      - "turn the thermostat on"
+      - "thermostat on"
+      - "activate the thermostat"
+    slots:
+      name: "Thermostat"
+    response: "Turned on the thermostat"
 
   # covers
   - sentences:


### PR DESCRIPTION
Fixes #3989.

## The bug

A sentence block's `name_domains` becomes a `requires_context: {domain: [...]}` filter at load time ([`util.py:resolve_domain_context`](https://github.com/OHF-Voice/intents/blob/main/script/intentfest/util.py)), so a climate entity's name cannot match unless the block lists `climate`.

`climate` was already in the `optional`/`complete` allowlist tiers in `intents.yaml`, and #4005 added it to the shared `default` `name_domain_group` — but only **en**, **es** and **ru**'s `name_floor` referenced that group. The other 62 languages hardcoded their own domain list, so "turn on the thermostat" didn't resolve there. That matches the Russian follow-up report on the issue.

Before / after, same grammar files:

```
[en] 'turn on the thermostat'   -> HassTurnOn     (already worked)
[ru] 'включи термостат'         -> None    ->  HassTurnOn
[ru] 'выключи термостат'        -> None    ->  HassTurnOff
```

## The change

Rather than duplicate the domain list into 62 more files, this points the generic on/off-able block at the shared group wherever the two are equivalent — so the diff is mostly a deletion (361 insertions, 1581 deletions):

- **263 blocks** whose literal list matched `default` now use `name_domains: "default"`. Future domain additions become a one-line change in `intents.yaml` instead of a 260-file sweep. This also covers **cy**'s `HassTurnOff`, which spelled out the full list while its `HassTurnOn` already used the group.
- **18 blocks** keep an explicit list because their domain set genuinely differs, and gain `climate`:
  - **cs / de / de-CH** — generic block excludes `light`; they have a separate light block with different verbs
  - **mn** — `light`/`switch` only
  - **th** — same verb also opens covers and valves
- **Speech-to-Phrase blocks are untouched.** Their list is `default` minus `climate`, so collapsing them would have silently widened them.

Also adds the English climate coverage that was missing entirely: a `Thermostat` entity and on/off test groups in all six `tests/en/HassTurn{On,Off}/name_{only,area,floor}.yaml` files, expecting "Turned on/off the thermostat".

## Verification

- `pytest tests/` — **14555 passed**
- `python3 -m script.intentfest validate` — exit 0, output **byte-identical to `main`** (no new warnings)
- `pre-commit run prettier --all-files` — passed; `sr-Latn` confirmed byte-identical to freshly regenerated output
- `climate` now present in `requires_context.domain` for **all 65 languages** × both intents
- Sampled **619 sentences** from the climate-carrying blocks across all 65 languages and recognized each back against the full grammar with a climate entity — all resolved to the correct intent

## Reviewer note

This widens `{name}` matching to climate entities in 62 languages, so a climate entity can now win a name collision against a similarly-named entity in another domain. That's the same tradeoff en/es/cy already carry, and it's what the issue asks for — but it is a behavior change in every language, so it's worth a deliberate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
