### PR TITLE
Give the transliterate pre-commit hook its Python dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,5 +15,10 @@ repos:
         name: Transliterate sr -> sr-Latn
         entry: script/transliterate
         language: python
+        # script.intentfest.__main__ imports .util, which needs yaml + hassil.
+        # Without these the hook's isolated env fails on ModuleNotFoundError.
+        additional_dependencies:
+          - PyYAML==6.0.3
+          - hassil==3.11.0
         pass_filenames: false
         files: ^(sentences|responses|tests|rules|lists)/sr(-Latn)?/


### PR DESCRIPTION
## The problem

The `transliterate` hook runs `python3 -m script.intentfest transliterate` inside pre-commit's isolated `language: python` env. `__main__` imports `.util`, which imports `yaml` and `hassil` — but the hook declared no `additional_dependencies`, so that env had neither and every run died:

```
ModuleNotFoundError: No module named 'yaml'
```

`script/transliterate` sources `./venv` when present, which masks this on machines that have a populated one. Without it, `python3` resolves to the hook venv and the import fails. (The sibling `format` hook survives the same pattern only by accident: `black`/`isort` aren't in the hook venv either, so they fall through `PATH` to the developer's own environment — `python3` *is* in the hook venv, so it doesn't fall through.)

Because the hook only fires on `^(sentences|responses|tests|rules|lists)/sr(-Latn)?/`, this stayed invisible until a change touched Serbian — and then it blocked the commit outright instead of keeping `sr-Latn` in sync. Found while working on #4139.

## The fix

Declare the two imports the entry point actually needs, pinned to match `requirements.txt`:

```yaml
additional_dependencies:
  - PyYAML==6.0.3
  - hassil==3.11.0
```

## Verification

- `pre-commit run transliterate --all-files` → **Passed** (previously `ModuleNotFoundError`)
- Confirmed it still does its job, not merely that it imports: injecting a desync into `sentences/sr-Latn/HassTurnOn/name_only.yaml` makes the hook regenerate the file from `sr` and fail the run so the repair gets staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
