### PR TITLE
Stop English examples leaking into non-English sentence files

### DIFF
--- a/script/intentfest/add_language.py
+++ b/script/intentfest/add_language.py
@@ -54,8 +54,14 @@ def run() -> int:
     # Create sentence files based off English. Sentences live in the
     # per-slot-combination format: sentences/<lang>/<Intent>/<combo>.yaml. Each
     # English combo file is copied with its sentence lists emptied — the
-    # language-independent scaffolding (slots, name/inferred domains, response
-    # keys, and the example hint) is kept for the translator to work from.
+    # language-independent scaffolding (slots, name/inferred domains and
+    # response keys) is kept for the translator to work from.
+    #
+    # `example` is deliberately blanked rather than copied. An English example
+    # left in place looks filled-in, survives untranslated, and only surfaces
+    # later as a `validate_localized_examples` warning; an empty one says plainly
+    # that it still needs writing. Use the matching sentences/en/ file as the
+    # reference for what the group means.
     english_sentences = SENTENCE_DIR / "en"
 
     for intent_dir in sorted(p for p in english_sentences.iterdir() if p.is_dir()):
@@ -67,6 +73,8 @@ def run() -> int:
             combo["language"] = language
             for sentence_info in combo.get("data", []):
                 sentence_info["sentences"] = []
+                if "example" in sentence_info:
+                    sentence_info["example"] = ""
 
             (target_intent_dir / combo_file.name).write_text(yaml_dump(combo))
 

--- a/sentences/ar/HassBroadcast/message_only.yaml
+++ b/sentences/ar/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "ar"

--- a/sentences/ar/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/ar/HassClimateGetTemperature/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - area_only
-# example: what is the temperature in the living room
 # slots: {area}
 
 language: "ar"

--- a/sentences/ar/HassClimateGetTemperature/default.yaml
+++ b/sentences/ar/HassClimateGetTemperature/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - default
-# example: what is the temperature
 # context_area: true
 
 language: "ar"

--- a/sentences/ar/HassGetCurrentDate/default.yaml
+++ b/sentences/ar/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "ar"
 data:

--- a/sentences/ar/HassGetCurrentTime/default.yaml
+++ b/sentences/ar/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "ar"
 data:

--- a/sentences/ar/HassGetState/device_class_state.yaml
+++ b/sentences/ar/HassGetState/device_class_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - device_class_state
-# example: are all the windows closed
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/ar/HassGetState/device_class_state_area.yaml
+++ b/sentences/ar/HassGetState/device_class_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - device_class_state_area
-# example: are all the windows closed in the bedroom
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ar/HassGetState/domain_state_area.yaml
+++ b/sentences/ar/HassGetState/domain_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - domain_state_area
-# example: which lights are on in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ar/HassGetState/name_only.yaml
+++ b/sentences/ar/HassGetState/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_only
-# example: what is the outside temperature
 # slots: {name}
 
 language: "ar"

--- a/sentences/ar/HassGetState/name_state.yaml
+++ b/sentences/ar/HassGetState/name_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state
-# example: is the garage door open
 # slots:
 # - {name}
 # - {state}

--- a/sentences/ar/HassGetState/name_state_area.yaml
+++ b/sentences/ar/HassGetState/name_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state_area
-# example: is the garage door open in the garage
 # slots:
 # - {name}
 # - {state}

--- a/sentences/ar/HassListCompleteItem/name_item.yaml
+++ b/sentences/ar/HassListCompleteItem/name_item.yaml
@@ -1,6 +1,5 @@
 ---
 # HassListCompleteItem - name_item
-# example: check off take out the trash from my chores list
 # slots:
 # - {item}
 # - {name}

--- a/sentences/ar/HassMediaNext/default.yaml
+++ b/sentences/ar/HassMediaNext/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaNext - default
-# example: next track
 # context_area: true
 
 language: "ar"

--- a/sentences/ar/HassNevermind/default.yaml
+++ b/sentences/ar/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "ar"
 data:

--- a/sentences/ar/HassRespond/default.yaml
+++ b/sentences/ar/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "ar"
 data:

--- a/sentences/ar/HassSetPosition/area_device_class.yaml
+++ b/sentences/ar/HassSetPosition/area_device_class.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetPosition - area_device_class
-# example: set the curtains to 50% in the bedroom
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ar/HassSetPosition/device_class.yaml
+++ b/sentences/ar/HassSetPosition/device_class.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetPosition - device_class
-# example: set the curtains to 50%
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/ar/HassSetPosition/name_only.yaml
+++ b/sentences/ar/HassSetPosition/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetPosition - name_only
-# example: set curtain left to 50%
 # slots:
 # - {name}
 # - {position}

--- a/sentences/ar/HassSetVolume/area_only.yaml
+++ b/sentences/ar/HassSetVolume/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolume - area_only
-# example: set living room volume to 90 percent
 # slots:
 # - {area}
 # - {volume_level}

--- a/sentences/ar/HassSetVolume/default.yaml
+++ b/sentences/ar/HassSetVolume/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolume - default
-# example: set volume to 90 percent
 # slots: {volume_level}
 # context_area: true
 

--- a/sentences/ar/HassSetVolume/name_only.yaml
+++ b/sentences/ar/HassSetVolume/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolume - name_only
-# example: set the TV volume to 90 percent
 # slots:
 # - {name}
 # - {volume_level}

--- a/sentences/ar/HassShoppingListAddItem/item_only.yaml
+++ b/sentences/ar/HassShoppingListAddItem/item_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassShoppingListAddItem - item_only
-# example: add apples to my shopping list
 # slots: {item}
 
 language: "ar"

--- a/sentences/ar/HassShoppingListCompleteItem/item_only.yaml
+++ b/sentences/ar/HassShoppingListCompleteItem/item_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassShoppingListCompleteItem - item_only
-# example: check off apples from my shopping list
 # slots: {item}
 
 language: "ar"

--- a/sentences/ar/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/ar/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ar/HassTurnOff/area_domain.yaml
+++ b/sentences/ar/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ar/HassTurnOff/device_class_cover.yaml
+++ b/sentences/ar/HassTurnOff/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - device_class_cover
-# example: close the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/ar/HassTurnOff/domain_all.yaml
+++ b/sentences/ar/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 
 language: "ar"

--- a/sentences/ar/HassTurnOff/domain_only.yaml
+++ b/sentences/ar/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "ar"

--- a/sentences/ar/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/ar/HassTurnOff/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_device_class_cover
-# example: close the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/ar/HassTurnOff/floor_domain.yaml
+++ b/sentences/ar/HassTurnOff/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_domain
-# example: turn off the lights on the first floor
 # slots:
 # - {domain}
 # - {floor}

--- a/sentences/ar/HassTurnOff/name_area.yaml
+++ b/sentences/ar/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/ar/HassTurnOff/name_floor.yaml
+++ b/sentences/ar/HassTurnOff/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_floor
-# example: turn off the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/ar/HassTurnOff/name_only.yaml
+++ b/sentences/ar/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "ar"

--- a/sentences/ar/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/ar/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ar/HassTurnOn/area_domain.yaml
+++ b/sentences/ar/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ar/HassTurnOn/device_class_cover.yaml
+++ b/sentences/ar/HassTurnOn/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - device_class_cover
-# example: open the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/ar/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/ar/HassTurnOn/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_device_class_cover
-# example: open the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/ar/HassTurnOn/floor_domain.yaml
+++ b/sentences/ar/HassTurnOn/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_domain
-# example: turn on the lights on the first floor
 # slots:
 # - {domain}
 # - {floor}

--- a/sentences/ar/HassTurnOn/name_area.yaml
+++ b/sentences/ar/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/ar/HassTurnOn/name_floor.yaml
+++ b/sentences/ar/HassTurnOn/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_floor
-# example: turn on the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/ar/HassTurnOn/name_only.yaml
+++ b/sentences/ar/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "ar"

--- a/sentences/ar/HassVacuumStart/name_only.yaml
+++ b/sentences/ar/HassVacuumStart/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumStart - name_only
-# example: start rover
 # slots: {name}
 
 language: "ar"

--- a/sentences/ca/HassGetCurrentDate/default.yaml
+++ b/sentences/ca/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "ca"
 data:

--- a/sentences/ca/HassGetCurrentTime/default.yaml
+++ b/sentences/ca/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "ca"
 data:

--- a/sentences/ca/HassRespond/default.yaml
+++ b/sentences/ca/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "ca"
 data:

--- a/sentences/de-CH/HassBroadcast/message_only.yaml
+++ b/sentences/de-CH/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "de-CH"

--- a/sentences/de-CH/HassGetCurrentDate/default.yaml
+++ b/sentences/de-CH/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "de-CH"
 data:

--- a/sentences/de-CH/HassGetCurrentTime/default.yaml
+++ b/sentences/de-CH/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "de-CH"
 data:

--- a/sentences/de-CH/HassNevermind/default.yaml
+++ b/sentences/de-CH/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "de-CH"
 data:

--- a/sentences/de-CH/HassRespond/default.yaml
+++ b/sentences/de-CH/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "de-CH"
 data:

--- a/sentences/de-CH/HassVacuumReturnToBase/name_only.yaml
+++ b/sentences/de-CH/HassVacuumReturnToBase/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumReturnToBase - name_only
-# example: return rover to base
 # slots: {name}
 
 language: "de-CH"

--- a/sentences/de-CH/HassVacuumStart/name_only.yaml
+++ b/sentences/de-CH/HassVacuumStart/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumStart - name_only
-# example: start rover
 # slots: {name}
 
 language: "de-CH"

--- a/sentences/de/HassBroadcast/message_only.yaml
+++ b/sentences/de/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "de"

--- a/sentences/de/HassGetCurrentDate/default.yaml
+++ b/sentences/de/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "de"
 data:

--- a/sentences/de/HassGetCurrentTime/default.yaml
+++ b/sentences/de/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "de"
 data:

--- a/sentences/de/HassNevermind/default.yaml
+++ b/sentences/de/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "de"
 data:

--- a/sentences/fr/HassMediaPause/default.yaml
+++ b/sentences/fr/HassMediaPause/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPause - default
-# example: pause
 # context_area: true
 
 language: fr

--- a/sentences/gl/HassGetCurrentDate/default.yaml
+++ b/sentences/gl/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "gl"
 data:

--- a/sentences/gl/HassGetCurrentTime/default.yaml
+++ b/sentences/gl/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "gl"
 data:

--- a/sentences/gl/HassMediaUnpause/default.yaml
+++ b/sentences/gl/HassMediaUnpause/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaUnpause - default
-# example: resume
 # context_area: true
 
 language: "gl"

--- a/sentences/gl/HassNevermind/default.yaml
+++ b/sentences/gl/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "gl"
 data:

--- a/sentences/he/HassClimateGetTemperature/area_only.yaml
+++ b/sentences/he/HassClimateGetTemperature/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - area_only
-# example: what is the temperature in the living room
 # slots: {area}
 
 language: "he"

--- a/sentences/he/HassClimateGetTemperature/default.yaml
+++ b/sentences/he/HassClimateGetTemperature/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - default
-# example: what is the temperature
 
 language: "he"
 data:

--- a/sentences/he/HassClimateSetTemperature/area_temperature.yaml
+++ b/sentences/he/HassClimateSetTemperature/area_temperature.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateSetTemperature - area_temperature
-# example: set the bedroom temperature to 20 degrees
 # slots:
 # - {area}
 # - {temperature}

--- a/sentences/he/HassClimateSetTemperature/temperature_only.yaml
+++ b/sentences/he/HassClimateSetTemperature/temperature_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateSetTemperature - temperature_only
-# example: set temperature to 20 degrees
 # slots: {temperature}
 
 language: "he"

--- a/sentences/he/HassGetCurrentDate/default.yaml
+++ b/sentences/he/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "he"
 data:

--- a/sentences/he/HassGetCurrentTime/default.yaml
+++ b/sentences/he/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "he"
 data:

--- a/sentences/he/HassGetState/device_class_state.yaml
+++ b/sentences/he/HassGetState/device_class_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - device_class_state
-# example: are all the windows closed
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/he/HassGetState/domain_state.yaml
+++ b/sentences/he/HassGetState/domain_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - domain_state
-# example: are all the lights off
 # slots:
 # - {domain}
 # - {state}

--- a/sentences/he/HassGetState/name_only.yaml
+++ b/sentences/he/HassGetState/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_only
-# example: what is the outside temperature
 # slots: {name}
 
 language: "he"

--- a/sentences/he/HassGetState/name_state.yaml
+++ b/sentences/he/HassGetState/name_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state
-# example: is the garage door open
 # slots:
 # - {name}
 # - {state}

--- a/sentences/he/HassGetState/name_state_area.yaml
+++ b/sentences/he/HassGetState/name_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state_area
-# example: is the garage door open in the garage
 # slots:
 # - {name}
 # - {state}

--- a/sentences/he/HassLightSet/name_brightness.yaml
+++ b/sentences/he/HassLightSet/name_brightness.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLightSet - name_brightness
-# example: set the bedroom lamp brightness to 50%
 # slots:
 # - {name}
 # - {brightness}

--- a/sentences/he/HassNevermind/default.yaml
+++ b/sentences/he/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "he"
 data:

--- a/sentences/he/HassRespond/default.yaml
+++ b/sentences/he/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "he"
 data:

--- a/sentences/he/HassTimerStatus/area_only.yaml
+++ b/sentences/he/HassTimerStatus/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTimerStatus - area_only
-# example: status of timer in the kitchen
 
 language: "he"
 data:

--- a/sentences/he/HassTimerStatus/default.yaml
+++ b/sentences/he/HassTimerStatus/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTimerStatus - default
-# example: timer status
 
 language: "he"
 data:

--- a/sentences/he/HassTimerStatus/name_only.yaml
+++ b/sentences/he/HassTimerStatus/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTimerStatus - name_only
-# example: pizza timer status
 
 language: "he"
 data:

--- a/sentences/he/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/he/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/he/HassTurnOff/area_domain.yaml
+++ b/sentences/he/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/he/HassTurnOff/domain_only.yaml
+++ b/sentences/he/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "he"

--- a/sentences/he/HassTurnOff/name_only.yaml
+++ b/sentences/he/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "he"

--- a/sentences/he/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/he/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/he/HassTurnOn/area_domain.yaml
+++ b/sentences/he/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/he/HassTurnOn/name_only.yaml
+++ b/sentences/he/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "he"

--- a/sentences/hu/HassGetCurrentDate/default.yaml
+++ b/sentences/hu/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "hu"
 data:

--- a/sentences/hu/HassGetCurrentTime/default.yaml
+++ b/sentences/hu/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "hu"
 data:

--- a/sentences/hy/HassBroadcast/message_only.yaml
+++ b/sentences/hy/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "hy"

--- a/sentences/hy/HassGetState/device_class_state.yaml
+++ b/sentences/hy/HassGetState/device_class_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - device_class_state
-# example: are all the windows closed
 # slots: {domain}, {device_class}, {state}
 
 language: hy

--- a/sentences/hy/HassGetState/device_class_state_area.yaml
+++ b/sentences/hy/HassGetState/device_class_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - device_class_state_area
-# example: are all the windows closed in the bedroom
 # slots: {area}, {domain}, {device_class}, {state}
 
 language: hy

--- a/sentences/hy/HassGetState/device_class_state_floor.yaml
+++ b/sentences/hy/HassGetState/device_class_state_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - device_class_state_floor
-# example: are all the windows closed on the second floor
 # slots: {floor}, {domain}, {device_class}, {state}
 
 language: hy

--- a/sentences/hy/HassGetState/domain_state.yaml
+++ b/sentences/hy/HassGetState/domain_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - domain_state
-# example: are all the lights off
 # slots: {domain}, {state}
 
 language: hy

--- a/sentences/hy/HassGetState/domain_state_area.yaml
+++ b/sentences/hy/HassGetState/domain_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - domain_state_area
-# example: which lights are on in the kitchen
 # slots: {area}, {domain}, {state}
 
 language: hy

--- a/sentences/hy/HassGetState/domain_state_floor.yaml
+++ b/sentences/hy/HassGetState/domain_state_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - domain_state_floor
-# example: are all the lights off on the first floor
 # slots: {floor}, {domain}, {state}
 
 language: hy

--- a/sentences/hy/HassGetState/name_only.yaml
+++ b/sentences/hy/HassGetState/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_only
-# example: what is the outside temperature
 # slots: {name}
 
 language: hy

--- a/sentences/hy/HassGetState/name_state.yaml
+++ b/sentences/hy/HassGetState/name_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state
-# example: is the garage door open
 # slots: {name}, {state}
 
 language: hy

--- a/sentences/hy/HassGetState/name_state_area.yaml
+++ b/sentences/hy/HassGetState/name_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state_area
-# example: is the garage door open in the garage
 # slots: {name}, {state}, {area}
 
 language: hy

--- a/sentences/hy/HassGetState/name_state_floor.yaml
+++ b/sentences/hy/HassGetState/name_state_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state_floor
-# example: is the bedroom window open on the second floor
 # slots: {name}, {state}, {floor}
 
 language: hy

--- a/sentences/hy/HassGetState/name_where.yaml
+++ b/sentences/hy/HassGetState/name_where.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_where
-# example: where is jane
 # slots: {name}
 
 language: hy

--- a/sentences/hy/HassGetState/name_zone.yaml
+++ b/sentences/hy/HassGetState/name_zone.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_zone
-# example: is jane home
 # slots: {name}, {state}
 
 language: hy

--- a/sentences/hy/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/hy/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots: {area}, {domain}, {device_class}
 
 language: hy

--- a/sentences/hy/HassTurnOff/area_domain.yaml
+++ b/sentences/hy/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots: {area}, {domain}
 
 language: hy

--- a/sentences/hy/HassTurnOff/device_class_cover.yaml
+++ b/sentences/hy/HassTurnOff/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - device_class_cover
-# example: close the windows in here
 # slots: {domain}, {device_class}
 # context_area: true
 

--- a/sentences/hy/HassTurnOff/domain_all.yaml
+++ b/sentences/hy/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 # context_area: false
 

--- a/sentences/hy/HassTurnOff/domain_only.yaml
+++ b/sentences/hy/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: hy

--- a/sentences/hy/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/hy/HassTurnOff/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_device_class_cover
-# example: close the curtains on the first floor
 # slots: {floor}, {domain}, {device_class}
 
 language: hy

--- a/sentences/hy/HassTurnOff/floor_domain.yaml
+++ b/sentences/hy/HassTurnOff/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_domain
-# example: turn off the lights on the first floor
 # slots: {floor}, {domain}
 
 language: hy

--- a/sentences/hy/HassTurnOff/name_area.yaml
+++ b/sentences/hy/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots: {name}, {area}
 
 language: hy

--- a/sentences/hy/HassTurnOff/name_floor.yaml
+++ b/sentences/hy/HassTurnOff/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_floor
-# example: turn off the overhead light on the first floor
 # slots: {name}, {floor}
 
 language: hy

--- a/sentences/hy/HassTurnOff/name_only.yaml
+++ b/sentences/hy/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: hy

--- a/sentences/hy/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/hy/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots: {area}, {domain}, {device_class}
 
 language: hy

--- a/sentences/hy/HassTurnOn/area_domain.yaml
+++ b/sentences/hy/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots: {area}, {domain}
 
 language: hy

--- a/sentences/hy/HassTurnOn/device_class_cover.yaml
+++ b/sentences/hy/HassTurnOn/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - device_class_cover
-# example: open the windows in here
 # slots: {domain}, {device_class}
 # context_area: true
 

--- a/sentences/hy/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/hy/HassTurnOn/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_device_class_cover
-# example: open the curtains on the first floor
 # slots: {floor}, {domain}, {device_class}
 
 language: hy

--- a/sentences/hy/HassTurnOn/floor_domain.yaml
+++ b/sentences/hy/HassTurnOn/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_domain
-# example: turn on the lights on the first floor
 # slots: {floor}, {domain}
 
 language: hy

--- a/sentences/hy/HassTurnOn/name_area.yaml
+++ b/sentences/hy/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots: {name}, {area}
 
 language: hy

--- a/sentences/hy/HassTurnOn/name_floor.yaml
+++ b/sentences/hy/HassTurnOn/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_floor
-# example: turn on the overhead light on the first floor
 # slots: {name}, {floor}
 
 language: hy

--- a/sentences/hy/HassTurnOn/name_only.yaml
+++ b/sentences/hy/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: hy

--- a/sentences/hy/HassTurnOn/name_scene.yaml
+++ b/sentences/hy/HassTurnOn/name_scene.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_scene
-# example: activate mood lighting scene
 # slots: {name}
 
 language: hy

--- a/sentences/hy/HassTurnOn/name_script.yaml
+++ b/sentences/hy/HassTurnOn/name_script.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_script
-# example: run party time script
 # slots: {name}
 
 language: hy

--- a/sentences/it/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/it/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/it/HassTurnOff/area_domain.yaml
+++ b/sentences/it/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/it/HassTurnOff/device_class_cover.yaml
+++ b/sentences/it/HassTurnOff/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - device_class_cover
-# example: close the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/it/HassTurnOff/domain_all.yaml
+++ b/sentences/it/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 # context_area: false
 

--- a/sentences/it/HassTurnOff/domain_only.yaml
+++ b/sentences/it/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "it"

--- a/sentences/it/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/it/HassTurnOff/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_device_class_cover
-# example: close the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/it/HassTurnOff/floor_domain.yaml
+++ b/sentences/it/HassTurnOff/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_domain
-# example: turn off the lights on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/it/HassTurnOff/name_area.yaml
+++ b/sentences/it/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/it/HassTurnOff/name_floor.yaml
+++ b/sentences/it/HassTurnOff/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_floor
-# example: turn off the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/it/HassTurnOff/name_only.yaml
+++ b/sentences/it/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "it"

--- a/sentences/it/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/it/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/it/HassTurnOn/area_domain.yaml
+++ b/sentences/it/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots: {area}, {domain}
 
 language: "it"

--- a/sentences/it/HassTurnOn/device_class_cover.yaml
+++ b/sentences/it/HassTurnOn/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - device_class_cover
-# example: open the windows in here
 # slots: {device_class}, {domain}; context_area: true
 
 language: "it"

--- a/sentences/it/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/it/HassTurnOn/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_device_class_cover
-# example: open the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/it/HassTurnOn/floor_domain.yaml
+++ b/sentences/it/HassTurnOn/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_domain
-# example: turn on the lights on the first floor
 # slots: {domain}, {floor}
 
 language: "it"

--- a/sentences/it/HassTurnOn/name_area.yaml
+++ b/sentences/it/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/it/HassTurnOn/name_floor.yaml
+++ b/sentences/it/HassTurnOn/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_floor
-# example: turn on the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/it/HassTurnOn/name_only.yaml
+++ b/sentences/it/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "it"

--- a/sentences/it/HassTurnOn/name_scene.yaml
+++ b/sentences/it/HassTurnOn/name_scene.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_scene
-# example: activate mood lighting scene
 # slots: {name}
 
 language: "it"

--- a/sentences/it/HassTurnOn/name_script.yaml
+++ b/sentences/it/HassTurnOn/name_script.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_script
-# example: run party time script
 # slots: {name}
 
 language: "it"

--- a/sentences/kw/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/kw/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/kw/HassTurnOff/area_domain.yaml
+++ b/sentences/kw/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/kw/HassTurnOff/device_class_cover.yaml
+++ b/sentences/kw/HassTurnOff/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - device_class_cover
-# example: close the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/kw/HassTurnOff/domain_all.yaml
+++ b/sentences/kw/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 # context_area: false
 

--- a/sentences/kw/HassTurnOff/domain_only.yaml
+++ b/sentences/kw/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "kw"

--- a/sentences/kw/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/kw/HassTurnOff/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_device_class_cover
-# example: close the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/kw/HassTurnOff/floor_domain.yaml
+++ b/sentences/kw/HassTurnOff/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_domain
-# example: turn off the lights on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/kw/HassTurnOff/name_area.yaml
+++ b/sentences/kw/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/kw/HassTurnOff/name_floor.yaml
+++ b/sentences/kw/HassTurnOff/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_floor
-# example: turn off the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/kw/HassTurnOff/name_only.yaml
+++ b/sentences/kw/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "kw"

--- a/sentences/kw/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/kw/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/kw/HassTurnOn/area_domain.yaml
+++ b/sentences/kw/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/kw/HassTurnOn/device_class_cover.yaml
+++ b/sentences/kw/HassTurnOn/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - device_class_cover
-# example: open the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/kw/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/kw/HassTurnOn/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_device_class_cover
-# example: open the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/kw/HassTurnOn/floor_domain.yaml
+++ b/sentences/kw/HassTurnOn/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_domain
-# example: turn on the lights on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/kw/HassTurnOn/name_area.yaml
+++ b/sentences/kw/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/kw/HassTurnOn/name_floor.yaml
+++ b/sentences/kw/HassTurnOn/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_floor
-# example: turn on the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/kw/HassTurnOn/name_only.yaml
+++ b/sentences/kw/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "kw"

--- a/sentences/kw/HassTurnOn/name_scene.yaml
+++ b/sentences/kw/HassTurnOn/name_scene.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_scene
-# example: activate mood lighting scene
 # slots: {name}
 
 language: "kw"

--- a/sentences/kw/HassTurnOn/name_script.yaml
+++ b/sentences/kw/HassTurnOn/name_script.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_script
-# example: run party time script
 # slots: {name}
 
 language: "kw"

--- a/sentences/ne/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/ne/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ne/HassTurnOff/area_domain.yaml
+++ b/sentences/ne/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ne/HassTurnOff/device_class_cover.yaml
+++ b/sentences/ne/HassTurnOff/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - device_class_cover
-# example: close the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/ne/HassTurnOff/domain_all.yaml
+++ b/sentences/ne/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 # context_area: false
 

--- a/sentences/ne/HassTurnOff/domain_only.yaml
+++ b/sentences/ne/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "ne"

--- a/sentences/ne/HassTurnOff/name_area.yaml
+++ b/sentences/ne/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/ne/HassTurnOff/name_floor.yaml
+++ b/sentences/ne/HassTurnOff/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_floor
-# example: turn off the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/ne/HassTurnOff/name_only.yaml
+++ b/sentences/ne/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "ne"

--- a/sentences/ne/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/ne/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/ne/HassTurnOn/area_domain.yaml
+++ b/sentences/ne/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots:
 # - {area}
 

--- a/sentences/ne/HassTurnOn/device_class_cover.yaml
+++ b/sentences/ne/HassTurnOn/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - device_class_cover
-# example: open the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/ne/HassTurnOn/name_area.yaml
+++ b/sentences/ne/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/ne/HassTurnOn/name_floor.yaml
+++ b/sentences/ne/HassTurnOn/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_floor
-# example: turn on the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/ne/HassTurnOn/name_only.yaml
+++ b/sentences/ne/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "ne"

--- a/sentences/ne/HassTurnOn/name_scene.yaml
+++ b/sentences/ne/HassTurnOn/name_scene.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_scene
-# example: activate mood lighting scene
 # slots: {name}
 
 language: "ne"

--- a/sentences/ne/HassTurnOn/name_script.yaml
+++ b/sentences/ne/HassTurnOn/name_script.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_script
-# example: run party time script
 # slots: {name}
 
 language: "ne"

--- a/sentences/nl/HassLawnMowerDock/default.yaml
+++ b/sentences/nl/HassLawnMowerDock/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerDock - default
-# example: stop mowing
 
 language: "nl"
 data:

--- a/sentences/nl/HassLawnMowerDock/name_only.yaml
+++ b/sentences/nl/HassLawnMowerDock/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerDock - name_only
-# example: return clippy to base
 # slots: {name}
 
 language: "nl"

--- a/sentences/nl/HassLawnMowerStartMowing/default.yaml
+++ b/sentences/nl/HassLawnMowerStartMowing/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerStartMowing - default
-# example: start mowing
 
 language: "nl"
 data:

--- a/sentences/nl/HassLawnMowerStartMowing/name_only.yaml
+++ b/sentences/nl/HassLawnMowerStartMowing/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerStartMowing - name_only
-# example: start clippy
 # slots: {name}
 
 language: "nl"

--- a/sentences/nl/HassListCompleteItem/name_item.yaml
+++ b/sentences/nl/HassListCompleteItem/name_item.yaml
@@ -1,6 +1,5 @@
 ---
 # HassListCompleteItem - name_item
-# example: check off take out the trash from my chores list
 # slots: {item}, {name}
 
 language: "nl"

--- a/sentences/nl/HassNevermind/default.yaml
+++ b/sentences/nl/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "nl"
 data:

--- a/sentences/nl/HassShoppingListAddItem/item_only.yaml
+++ b/sentences/nl/HassShoppingListAddItem/item_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassShoppingListAddItem - item_only
-# example: add apples to my shopping list
 # slots: {item}
 
 language: "nl"

--- a/sentences/nl/HassVacuumReturnToBase/name_only.yaml
+++ b/sentences/nl/HassVacuumReturnToBase/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumReturnToBase - name_only
-# example: return rover to base
 # slots: {name}
 
 language: "nl"

--- a/sentences/nl/HassVacuumStart/name_only.yaml
+++ b/sentences/nl/HassVacuumStart/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumStart - name_only
-# example: start rover
 # slots: {name}
 
 language: "nl"

--- a/sentences/pa/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/pa/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/pa/HassTurnOff/area_domain.yaml
+++ b/sentences/pa/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/pa/HassTurnOff/domain_all.yaml
+++ b/sentences/pa/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 # context_area: false
 

--- a/sentences/pa/HassTurnOff/domain_only.yaml
+++ b/sentences/pa/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "pa"

--- a/sentences/pa/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/pa/HassTurnOff/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_device_class_cover
-# example: close the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/pa/HassTurnOff/floor_domain.yaml
+++ b/sentences/pa/HassTurnOff/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_domain
-# example: turn off the lights on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/pa/HassTurnOff/name_area.yaml
+++ b/sentences/pa/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/pa/HassTurnOff/name_floor.yaml
+++ b/sentences/pa/HassTurnOff/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_floor
-# example: turn off the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/pa/HassTurnOff/name_only.yaml
+++ b/sentences/pa/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "pa"

--- a/sentences/pa/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/pa/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/pa/HassTurnOn/area_domain.yaml
+++ b/sentences/pa/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/pa/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/pa/HassTurnOn/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_device_class_cover
-# example: open the curtains on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/pa/HassTurnOn/floor_domain.yaml
+++ b/sentences/pa/HassTurnOn/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_domain
-# example: turn on the lights on the first floor
 # slots:
 # - {floor}
 # - {domain}

--- a/sentences/pa/HassTurnOn/name_area.yaml
+++ b/sentences/pa/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/pa/HassTurnOn/name_floor.yaml
+++ b/sentences/pa/HassTurnOn/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_floor
-# example: turn on the overhead light on the first floor
 # slots:
 # - {name}
 # - {floor}

--- a/sentences/pa/HassTurnOn/name_only.yaml
+++ b/sentences/pa/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "pa"

--- a/sentences/pa/HassTurnOn/name_scene.yaml
+++ b/sentences/pa/HassTurnOn/name_scene.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_scene
-# example: activate mood lighting scene
 # slots: {name}
 
 language: "pa"

--- a/sentences/pa/HassTurnOn/name_script.yaml
+++ b/sentences/pa/HassTurnOn/name_script.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_script
-# example: run party time script
 # slots: {name}
 
 language: "pa"

--- a/sentences/pl/HassBroadcast/message_only.yaml
+++ b/sentences/pl/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "pl"

--- a/sentences/pl/HassGetCurrentDate/default.yaml
+++ b/sentences/pl/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "pl"
 data:

--- a/sentences/pl/HassGetCurrentTime/default.yaml
+++ b/sentences/pl/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "pl"
 data:

--- a/sentences/pl/HassNevermind/default.yaml
+++ b/sentences/pl/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "pl"
 data:

--- a/sentences/pl/HassRespond/default.yaml
+++ b/sentences/pl/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "pl"
 data:

--- a/sentences/pt-BR/HassVacuumCleanArea/area_only.yaml
+++ b/sentences/pt-BR/HassVacuumCleanArea/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumCleanArea - area_only
-# example: vacuum the kitchen
 # slots: {area}
 
 language: "pt-BR"

--- a/sentences/pt-BR/HassVacuumCleanArea/name_area.yaml
+++ b/sentences/pt-BR/HassVacuumCleanArea/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumCleanArea - name_area
-# example: vacuum the kitchen with rover
 # slots: {area}, {name}
 
 language: "pt-BR"

--- a/sentences/ro/HassBroadcast/message_only.yaml
+++ b/sentences/ro/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "ro"

--- a/sentences/ro/HassClimateGetTemperature/default.yaml
+++ b/sentences/ro/HassClimateGetTemperature/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - default
-# example: what is the temperature
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassClimateSetTemperature/area_temperature.yaml
+++ b/sentences/ro/HassClimateSetTemperature/area_temperature.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateSetTemperature - area_temperature
-# example: set the bedroom temperature to 20 degrees
 # slots: {area}, {temperature}
 
 language: "ro"

--- a/sentences/ro/HassClimateSetTemperature/floor_temperature.yaml
+++ b/sentences/ro/HassClimateSetTemperature/floor_temperature.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateSetTemperature - floor_temperature
-# example: set the first floor temperature to 20 degrees
 # slots: {floor}, {temperature}
 
 language: "ro"

--- a/sentences/ro/HassClimateSetTemperature/name_temperature.yaml
+++ b/sentences/ro/HassClimateSetTemperature/name_temperature.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateSetTemperature - name_temperature
-# example: set the office thermostat to 20 degrees
 # slots: <name>, {temperature}
 
 language: "ro"

--- a/sentences/ro/HassClimateSetTemperature/temperature_only.yaml
+++ b/sentences/ro/HassClimateSetTemperature/temperature_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateSetTemperature - temperature_only
-# example: set temperature to 20 degrees
 # slots: {temperature}
 # context_area: true
 

--- a/sentences/ro/HassFanSetSpeed/area_only.yaml
+++ b/sentences/ro/HassFanSetSpeed/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassFanSetSpeed - area_only
-# example: set kitchen fans to 50%
 # slots: {area}, {percentage}
 
 language: "ro"

--- a/sentences/ro/HassFanSetSpeed/default.yaml
+++ b/sentences/ro/HassFanSetSpeed/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassFanSetSpeed - default
-# example: set fans to 50%
 # slots: {percentage}
 # context_area: true
 

--- a/sentences/ro/HassFanSetSpeed/floor_only.yaml
+++ b/sentences/ro/HassFanSetSpeed/floor_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassFanSetSpeed - floor_only
-# example: set first floor fans to 50%
 # slots: {floor}, {percentage}
 
 language: "ro"

--- a/sentences/ro/HassFanSetSpeed/name_only.yaml
+++ b/sentences/ro/HassFanSetSpeed/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassFanSetSpeed - name_only
-# example: set ceiling fan to 50%
 # slots: <name>, {percentage}
 
 language: "ro"

--- a/sentences/ro/HassGetCurrentDate/default.yaml
+++ b/sentences/ro/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "ro"
 data:

--- a/sentences/ro/HassGetCurrentTime/default.yaml
+++ b/sentences/ro/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "ro"
 data:

--- a/sentences/ro/HassGetState/name_only.yaml
+++ b/sentences/ro/HassGetState/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_only
-# example: what is the outside temperature
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassGetState/name_state.yaml
+++ b/sentences/ro/HassGetState/name_state.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state
-# example: is the garage door open
 # slots: <name>, {state}
 
 language: "ro"

--- a/sentences/ro/HassGetState/name_state_area.yaml
+++ b/sentences/ro/HassGetState/name_state_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state_area
-# example: is the garage door open in the garage
 # slots: <name>, {state}, {area}
 
 language: "ro"

--- a/sentences/ro/HassGetState/name_state_floor.yaml
+++ b/sentences/ro/HassGetState/name_state_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_state_floor
-# example: is the bedroom window open on the second floor
 # slots: <name>, {state}, {floor}
 
 language: "ro"

--- a/sentences/ro/HassGetState/name_where.yaml
+++ b/sentences/ro/HassGetState/name_where.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_where
-# example: where is jane
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassGetState/name_zone.yaml
+++ b/sentences/ro/HassGetState/name_zone.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetState - name_zone
-# example: is jane home
 # slots: <name>, {state}
 
 language: "ro"

--- a/sentences/ro/HassLawnMowerDock/default.yaml
+++ b/sentences/ro/HassLawnMowerDock/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerDock - default
-# example: stop mowing
 
 language: "ro"
 data:

--- a/sentences/ro/HassLawnMowerDock/name_only.yaml
+++ b/sentences/ro/HassLawnMowerDock/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerDock - name_only
-# example: return clippy to base
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassLawnMowerStartMowing/default.yaml
+++ b/sentences/ro/HassLawnMowerStartMowing/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerStartMowing - default
-# example: start mowing
 
 language: "ro"
 data:

--- a/sentences/ro/HassLawnMowerStartMowing/name_only.yaml
+++ b/sentences/ro/HassLawnMowerStartMowing/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLawnMowerStartMowing - name_only
-# example: start clippy
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassLightSet/color_only.yaml
+++ b/sentences/ro/HassLightSet/color_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassLightSet - color_only
-# example: make the lights red
 # slots: {color}
 # context_area: true
 

--- a/sentences/ro/HassMediaNext/area_only.yaml
+++ b/sentences/ro/HassMediaNext/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaNext - area_only
-# example: next track in the living room
 # slots: {area}
 
 language: "ro"

--- a/sentences/ro/HassMediaNext/default.yaml
+++ b/sentences/ro/HassMediaNext/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaNext - default
-# example: next track
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassMediaNext/name_only.yaml
+++ b/sentences/ro/HassMediaNext/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaNext - name_only
-# example: next track on the TV
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassMediaPause/default.yaml
+++ b/sentences/ro/HassMediaPause/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPause - default
-# example: pause
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassMediaPlayerMute/default.yaml
+++ b/sentences/ro/HassMediaPlayerMute/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPlayerMute - default
-# example: mute
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassMediaPlayerMute/name_only.yaml
+++ b/sentences/ro/HassMediaPlayerMute/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPlayerMute - name_only
-# example: mute the TV
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassMediaPlayerUnmute/default.yaml
+++ b/sentences/ro/HassMediaPlayerUnmute/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPlayerUnmute - default
-# example: unmute
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassMediaPlayerUnmute/name_only.yaml
+++ b/sentences/ro/HassMediaPlayerUnmute/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPlayerUnmute - name_only
-# example: unmute the TV
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassMediaPrevious/area_only.yaml
+++ b/sentences/ro/HassMediaPrevious/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPrevious - area_only
-# example: previous track in the living room
 # slots: {area}
 
 language: "ro"

--- a/sentences/ro/HassMediaPrevious/default.yaml
+++ b/sentences/ro/HassMediaPrevious/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPrevious - default
-# example: previous track
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassMediaPrevious/name_only.yaml
+++ b/sentences/ro/HassMediaPrevious/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPrevious - name_only
-# example: previous track on the TV
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassMediaSearchAndPlay/area_media_class.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/area_media_class.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - area_media_class
-# example: play the song Bohemian Rhapsody in the kitchen
 # slots: {area}, {search_query}, {media_class}
 
 language: "ro"

--- a/sentences/ro/HassMediaSearchAndPlay/area_only.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - area_only
-# example: play The Office in the kitchen
 # slots: {area}, {search_query}
 
 language: "ro"

--- a/sentences/ro/HassMediaSearchAndPlay/default.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - default
-# example: play The Office
 # slots: {search_query}
 # context_area: true
 

--- a/sentences/ro/HassMediaSearchAndPlay/media_class_only.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/media_class_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - media_class_only
-# example: play the track Bohemian Rhapsody
 # slots: {search_query}, {media_class}
 # context_area: true
 

--- a/sentences/ro/HassMediaSearchAndPlay/name_area.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - name_area
-# example: play The Office on the TV in the kitchen
 # slots: <name>, {area}, {search_query}
 
 language: "ro"

--- a/sentences/ro/HassMediaSearchAndPlay/name_area_media_class.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/name_area_media_class.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - name_area_media_class
-# example: play the artist Queen on the TV in the kitchen
 # slots: <name>, {area}, {search_query}, {media_class}
 
 language: "ro"

--- a/sentences/ro/HassMediaSearchAndPlay/name_media_class.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/name_media_class.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - name_media_class
-# example: play the track Bohemian Rhapsody on the TV
 # slots: <name>, {search_query}, {media_class}
 
 language: "ro"

--- a/sentences/ro/HassMediaSearchAndPlay/name_only.yaml
+++ b/sentences/ro/HassMediaSearchAndPlay/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaSearchAndPlay - name_only
-# example: play The Office on the TV
 # slots: <name>, {search_query}
 
 language: "ro"

--- a/sentences/ro/HassMediaUnpause/default.yaml
+++ b/sentences/ro/HassMediaUnpause/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaUnpause - default
-# example: resume
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassNevermind/default.yaml
+++ b/sentences/ro/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "ro"
 data:

--- a/sentences/ro/HassRespond/default.yaml
+++ b/sentences/ro/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "ro"
 data:

--- a/sentences/ro/HassSetPosition/area_device_class.yaml
+++ b/sentences/ro/HassSetPosition/area_device_class.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetPosition - area_device_class
-# example: set the curtains to 50% in the bedroom
 # slots: {area}, {domain}, {device_class}, {position}
 
 language: "ro"

--- a/sentences/ro/HassSetPosition/device_class.yaml
+++ b/sentences/ro/HassSetPosition/device_class.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetPosition - device_class
-# example: set the curtains to 50%
 # slots: {domain}, {device_class}, {position}
 # context_area: true
 

--- a/sentences/ro/HassSetVolume/area_only.yaml
+++ b/sentences/ro/HassSetVolume/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolume - area_only
-# example: set living room volume to 90 percent
 # slots: {area}, {volume_level}
 
 language: "ro"

--- a/sentences/ro/HassSetVolume/default.yaml
+++ b/sentences/ro/HassSetVolume/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolume - default
-# example: set volume to 90 percent
 # slots: {volume_level}
 # context_area: true
 

--- a/sentences/ro/HassSetVolume/name_only.yaml
+++ b/sentences/ro/HassSetVolume/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolume - name_only
-# example: set the TV volume to 90 percent
 # slots: <name>, {volume_level}
 
 language: "ro"

--- a/sentences/ro/HassSetVolumeRelative/default.yaml
+++ b/sentences/ro/HassSetVolumeRelative/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolumeRelative - default
-# example: increase volume
 # slots: {volume_step}
 # context_area: true
 

--- a/sentences/ro/HassSetVolumeRelative/floor_only.yaml
+++ b/sentences/ro/HassSetVolumeRelative/floor_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolumeRelative - floor_only
-# example: increase volume on the first floor
 # slots: {volume_step}, {floor}
 
 language: "ro"

--- a/sentences/ro/HassSetVolumeRelative/name_only.yaml
+++ b/sentences/ro/HassSetVolumeRelative/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassSetVolumeRelative - name_only
-# example: decrease TV volume
 # slots: {volume_step}, <name>
 
 language: "ro"

--- a/sentences/ro/HassShoppingListAddItem/item_only.yaml
+++ b/sentences/ro/HassShoppingListAddItem/item_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassShoppingListAddItem - item_only
-# example: add apples to my shopping list
 # slots: {item}
 
 language: "ro"

--- a/sentences/ro/HassShoppingListCompleteItem/item_only.yaml
+++ b/sentences/ro/HassShoppingListCompleteItem/item_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassShoppingListCompleteItem - item_only
-# example: check off apples from my shopping list
 # slots: {item}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/ro/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots: {area}, {domain}, {device_class}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/area_domain.yaml
+++ b/sentences/ro/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots: {area}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/domain_all.yaml
+++ b/sentences/ro/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/domain_only.yaml
+++ b/sentences/ro/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/floor_device_class_cover.yaml
+++ b/sentences/ro/HassTurnOff/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_device_class_cover
-# example: close the curtains on the first floor
 # slots: {floor}, {domain}, {device_class}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/floor_domain.yaml
+++ b/sentences/ro/HassTurnOff/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - floor_domain
-# example: turn off the lights on the first floor
 # slots: {floor}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/name_area.yaml
+++ b/sentences/ro/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots: <name>, {area}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/name_floor.yaml
+++ b/sentences/ro/HassTurnOff/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_floor
-# example: turn off the overhead light on the first floor
 # slots: <name>, {floor}
 
 language: "ro"

--- a/sentences/ro/HassTurnOff/name_only.yaml
+++ b/sentences/ro/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/ro/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots: {area}, {domain}, {device_class}
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/area_domain.yaml
+++ b/sentences/ro/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots: {area}
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/floor_device_class_cover.yaml
+++ b/sentences/ro/HassTurnOn/floor_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_device_class_cover
-# example: open the curtains on the first floor
 # slots: {floor}, {domain}, {device_class}
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/floor_domain.yaml
+++ b/sentences/ro/HassTurnOn/floor_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - floor_domain
-# example: turn on the lights on the first floor
 # slots: {floor}
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/name_area.yaml
+++ b/sentences/ro/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots: <name>, {area}
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/name_floor.yaml
+++ b/sentences/ro/HassTurnOn/name_floor.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_floor
-# example: turn on the overhead light on the first floor
 # slots: <name>, {floor}
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/name_only.yaml
+++ b/sentences/ro/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassTurnOn/name_script.yaml
+++ b/sentences/ro/HassTurnOn/name_script.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_script
-# example: run party time script
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassVacuumCleanArea/area_only.yaml
+++ b/sentences/ro/HassVacuumCleanArea/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumCleanArea - area_only
-# example: vacuum the kitchen
 # slots: {area}
 
 language: "ro"

--- a/sentences/ro/HassVacuumCleanArea/context_area.yaml
+++ b/sentences/ro/HassVacuumCleanArea/context_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumCleanArea - context_area
-# example: vacuum in here
 # context_area: true
 
 language: "ro"

--- a/sentences/ro/HassVacuumCleanArea/name_area.yaml
+++ b/sentences/ro/HassVacuumCleanArea/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumCleanArea - name_area
-# example: vacuum the kitchen with rover
 # slots: {area}, <name>
 
 language: "ro"

--- a/sentences/ro/HassVacuumReturnToBase/name_only.yaml
+++ b/sentences/ro/HassVacuumReturnToBase/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumReturnToBase - name_only
-# example: return rover to base
 # slots: <name>
 
 language: "ro"

--- a/sentences/ro/HassVacuumStart/name_only.yaml
+++ b/sentences/ro/HassVacuumStart/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumStart - name_only
-# example: start rover
 # slots: <name>
 
 language: "ro"

--- a/sentences/sk/HassClimateGetTemperature/default.yaml
+++ b/sentences/sk/HassClimateGetTemperature/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - default
-# example: what is the temperature
 # context_area: true
 
 language: "sk"

--- a/sentences/sl/HassBroadcast/message_only.yaml
+++ b/sentences/sl/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "sl"

--- a/sentences/sl/HassGetCurrentDate/default.yaml
+++ b/sentences/sl/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "sl"
 data:

--- a/sentences/sl/HassGetCurrentTime/default.yaml
+++ b/sentences/sl/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "sl"
 data:

--- a/sentences/sl/HassMediaPrevious/default.yaml
+++ b/sentences/sl/HassMediaPrevious/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassMediaPrevious - default
-# example: previous track
 # context_area: true
 
 language: "sl"

--- a/sentences/sl/HassNevermind/default.yaml
+++ b/sentences/sl/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "sl"
 data:

--- a/sentences/sl/HassRespond/default.yaml
+++ b/sentences/sl/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "sl"
 data:

--- a/sentences/sl/HassVacuumReturnToBase/name_only.yaml
+++ b/sentences/sl/HassVacuumReturnToBase/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumReturnToBase - name_only
-# example: return rover to base
 # slots: {name}
 
 language: "sl"

--- a/sentences/sl/HassVacuumStart/name_only.yaml
+++ b/sentences/sl/HassVacuumStart/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumStart - name_only
-# example: start rover
 # slots: {name}
 
 language: "sl"

--- a/sentences/sv/HassBroadcast/message_only.yaml
+++ b/sentences/sv/HassBroadcast/message_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassBroadcast - message_only
-# example: broadcast that dinner is ready
 # slots: {message}
 
 language: "sv"

--- a/sentences/sv/HassGetCurrentDate/default.yaml
+++ b/sentences/sv/HassGetCurrentDate/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentDate - default
-# example: what is the date
 
 language: "sv"
 data:

--- a/sentences/sv/HassGetCurrentTime/default.yaml
+++ b/sentences/sv/HassGetCurrentTime/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassGetCurrentTime - default
-# example: what time is it
 
 language: "sv"
 data:

--- a/sentences/sv/HassRespond/default.yaml
+++ b/sentences/sv/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "sv"
 data:

--- a/sentences/sv/HassVacuumReturnToBase/name_only.yaml
+++ b/sentences/sv/HassVacuumReturnToBase/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumReturnToBase - name_only
-# example: return rover to base
 # slots: {name}
 
 language: "sv"

--- a/sentences/sv/HassVacuumStart/name_only.yaml
+++ b/sentences/sv/HassVacuumStart/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumStart - name_only
-# example: start rover
 # slots: {name}
 
 language: "sv"

--- a/sentences/th/HassClimateGetTemperature/default.yaml
+++ b/sentences/th/HassClimateGetTemperature/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - default
-# example: what is the temperature
 # context_area: true
 
 language: "th"

--- a/sentences/th/HassRespond/default.yaml
+++ b/sentences/th/HassRespond/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassRespond - default
-# example: hello
 
 language: "th"
 data:

--- a/sentences/th/HassTurnOff/area_domain.yaml
+++ b/sentences/th/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots: {area}
 
 language: "th"

--- a/sentences/th/HassTurnOff/domain_only.yaml
+++ b/sentences/th/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "th"

--- a/sentences/th/HassTurnOff/name_only.yaml
+++ b/sentences/th/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "th"

--- a/sentences/th/HassTurnOn/area_domain.yaml
+++ b/sentences/th/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots: {area}
 
 language: "th"

--- a/sentences/th/HassTurnOn/name_only.yaml
+++ b/sentences/th/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "th"

--- a/sentences/tr/HassClimateGetTemperature/default.yaml
+++ b/sentences/tr/HassClimateGetTemperature/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassClimateGetTemperature - default
-# example: what is the temperature
 # context_area: true
 
 language: "tr"

--- a/sentences/tr/HassNevermind/default.yaml
+++ b/sentences/tr/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "tr"
 data:

--- a/sentences/tr/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/tr/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/tr/HassTurnOff/area_domain.yaml
+++ b/sentences/tr/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/tr/HassTurnOff/device_class_cover.yaml
+++ b/sentences/tr/HassTurnOff/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - device_class_cover
-# example: close the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/tr/HassTurnOff/domain_all.yaml
+++ b/sentences/tr/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}
 # context_area: false
 

--- a/sentences/tr/HassTurnOff/domain_only.yaml
+++ b/sentences/tr/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # context_area: true
 
 language: "tr"

--- a/sentences/tr/HassTurnOff/name_area.yaml
+++ b/sentences/tr/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/tr/HassTurnOff/name_only.yaml
+++ b/sentences/tr/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "tr"

--- a/sentences/tr/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/tr/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/tr/HassTurnOn/area_domain.yaml
+++ b/sentences/tr/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots:
 # - {area}
 # - {domain}

--- a/sentences/tr/HassTurnOn/device_class_cover.yaml
+++ b/sentences/tr/HassTurnOn/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - device_class_cover
-# example: open the windows in here
 # slots:
 # - {domain}
 # - {device_class}

--- a/sentences/tr/HassTurnOn/name_area.yaml
+++ b/sentences/tr/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots:
 # - {name}
 # - {area}

--- a/sentences/tr/HassTurnOn/name_only.yaml
+++ b/sentences/tr/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "tr"

--- a/sentences/uk/HassStartTimer/command_hours.yaml
+++ b/sentences/uk/HassStartTimer/command_hours.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - command_hours
-# example: 1 hour
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/command_hours_minutes.yaml
+++ b/sentences/uk/HassStartTimer/command_hours_minutes.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - command_hours_minutes
-# example: 1 hour 5 minutes
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/command_hours_minutes_seconds.yaml
+++ b/sentences/uk/HassStartTimer/command_hours_minutes_seconds.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - command_hours_minutes_seconds
-# example: 1 hour 5 minutes 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/command_hours_seconds.yaml
+++ b/sentences/uk/HassStartTimer/command_hours_seconds.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - command_hours_seconds
-# example: 1 hour 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/command_minutes.yaml
+++ b/sentences/uk/HassStartTimer/command_minutes.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - command_minutes
-# example: 5 minutes
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/command_minutes_seconds.yaml
+++ b/sentences/uk/HassStartTimer/command_minutes_seconds.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - command_minutes_seconds
-# example: 5 minutes 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/command_seconds.yaml
+++ b/sentences/uk/HassStartTimer/command_seconds.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - command_seconds
-# example: 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/hours_minutes.yaml
+++ b/sentences/uk/HassStartTimer/hours_minutes.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - hours_minutes
-# example: 1 hour 5 minutes
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/hours_minutes_seconds.yaml
+++ b/sentences/uk/HassStartTimer/hours_minutes_seconds.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - hours_minutes_seconds
-# example: 1 hour 5 minutes 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/hours_only.yaml
+++ b/sentences/uk/HassStartTimer/hours_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - hours_only
-# example: 1 hour
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/hours_seconds.yaml
+++ b/sentences/uk/HassStartTimer/hours_seconds.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - hours_seconds
-# example: 1 hour 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/minutes_only.yaml
+++ b/sentences/uk/HassStartTimer/minutes_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - minutes_only
-# example: 5 minutes
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/minutes_seconds.yaml
+++ b/sentences/uk/HassStartTimer/minutes_seconds.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - minutes_seconds
-# example: 5 minutes 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassStartTimer/seconds_only.yaml
+++ b/sentences/uk/HassStartTimer/seconds_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassStartTimer - seconds_only
-# example: 30 seconds
 
 language: "uk"
 data:

--- a/sentences/uk/HassTimerStatus/area_only.yaml
+++ b/sentences/uk/HassTimerStatus/area_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTimerStatus - area_only
-# example: status of timer in the kitchen
 
 language: "uk"
 data:

--- a/sentences/uk/HassTimerStatus/default.yaml
+++ b/sentences/uk/HassTimerStatus/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTimerStatus - default
-# example: timer status
 
 language: "uk"
 data:

--- a/sentences/uk/HassTimerStatus/name_only.yaml
+++ b/sentences/uk/HassTimerStatus/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTimerStatus - name_only
-# example: pizza timer status
 
 language: "uk"
 data:

--- a/sentences/vi/HassNevermind/default.yaml
+++ b/sentences/vi/HassNevermind/default.yaml
@@ -1,6 +1,5 @@
 ---
 # HassNevermind - default
-# example: nevermind
 
 language: "vi"
 data:

--- a/sentences/vi/HassShoppingListAddItem/item_only.yaml
+++ b/sentences/vi/HassShoppingListAddItem/item_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassShoppingListAddItem - item_only
-# example: add apples to my shopping list
 # slots: {item}
 
 language: "vi"

--- a/sentences/vi/HassTurnOff/area_device_class_cover.yaml
+++ b/sentences/vi/HassTurnOff/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_device_class_cover
-# example: close the curtains in the living room
 # slots: {area}, {device_class}, {domain}
 
 language: "vi"

--- a/sentences/vi/HassTurnOff/area_domain.yaml
+++ b/sentences/vi/HassTurnOff/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - area_domain
-# example: turn off the lights in the kitchen
 # slots: {area}, {domain}
 
 language: "vi"

--- a/sentences/vi/HassTurnOff/device_class_cover.yaml
+++ b/sentences/vi/HassTurnOff/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - device_class_cover
-# example: close the windows in here
 # slots: {device_class}, {domain}; context_area: true
 
 language: "vi"

--- a/sentences/vi/HassTurnOff/domain_all.yaml
+++ b/sentences/vi/HassTurnOff/domain_all.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_all
-# example: turn off all the lights in the house
 # slots: {domain}; context_area: false
 
 language: "vi"

--- a/sentences/vi/HassTurnOff/domain_only.yaml
+++ b/sentences/vi/HassTurnOff/domain_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - domain_only
-# example: turn off the lights in here
 # slots: {domain}; context_area: true
 
 language: "vi"

--- a/sentences/vi/HassTurnOff/name_area.yaml
+++ b/sentences/vi/HassTurnOff/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_area
-# example: turn off the overhead light in the kitchen
 # slots: {name}, {area}
 
 language: "vi"

--- a/sentences/vi/HassTurnOff/name_only.yaml
+++ b/sentences/vi/HassTurnOff/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOff - name_only
-# example: turn off the overhead light
 # slots: {name}
 
 language: "vi"

--- a/sentences/vi/HassTurnOn/area_device_class_cover.yaml
+++ b/sentences/vi/HassTurnOn/area_device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_device_class_cover
-# example: open the curtains in the living room
 # slots: {area}, {device_class}, {domain}
 
 language: "vi"

--- a/sentences/vi/HassTurnOn/area_domain.yaml
+++ b/sentences/vi/HassTurnOn/area_domain.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - area_domain
-# example: turn on the lights in the kitchen
 # slots: {area}, {domain}
 
 language: "vi"

--- a/sentences/vi/HassTurnOn/device_class_cover.yaml
+++ b/sentences/vi/HassTurnOn/device_class_cover.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - device_class_cover
-# example: open the windows in here
 # slots: {device_class}, {domain}; context_area: true
 
 language: "vi"

--- a/sentences/vi/HassTurnOn/name_area.yaml
+++ b/sentences/vi/HassTurnOn/name_area.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_area
-# example: turn on the overhead light in the kitchen
 # slots: {name}, {area}
 
 language: "vi"

--- a/sentences/vi/HassTurnOn/name_only.yaml
+++ b/sentences/vi/HassTurnOn/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: {name}
 
 language: "vi"

--- a/sentences/vi/HassTurnOn/name_scene.yaml
+++ b/sentences/vi/HassTurnOn/name_scene.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_scene
-# example: activate mood lighting scene
 # slots: {name}
 
 language: "vi"

--- a/sentences/vi/HassTurnOn/name_script.yaml
+++ b/sentences/vi/HassTurnOn/name_script.yaml
@@ -1,6 +1,5 @@
 ---
 # HassTurnOn - name_script
-# example: run party time script
 # slots: {name}
 
 language: "vi"

--- a/sentences/vi/HassVacuumReturnToBase/name_only.yaml
+++ b/sentences/vi/HassVacuumReturnToBase/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumReturnToBase - name_only
-# example: return rover to base
 # slots: {name}
 
 language: "vi"

--- a/sentences/vi/HassVacuumStart/name_only.yaml
+++ b/sentences/vi/HassVacuumStart/name_only.yaml
@@ -1,6 +1,5 @@
 ---
 # HassVacuumStart - name_only
-# example: start rover
 # slots: {name}
 
 language: "vi"


### PR DESCRIPTION
Two related changes: fix the generator that seeds English examples into new languages, and remove the historical residue. Split into two commits so they can be reviewed (or landed) separately.

## 1. `add_language` no longer seeds English examples

`add_language` copies each English combo file and empties its sentence lists, but kept the English `example:` value. A new language therefore starts with examples that *look* filled in, read as English, and survive untranslated — surfacing much later as `validate_localized_examples` warnings. That's the origin of the 9 "example is identical to the English example" warnings on `main` (nl, sk, th).

Now blanked. An empty example says plainly it still needs writing, and the matching `sentences/en/` file remains the reference for what the group means.

Verified by scaffolding a throwaway language: 42 intent directories, every `example:` emitted empty, no English text leaked.

## 2. Removing 358 stale English header comments

358 non-English sentence files carry a `# example:` header comment still byte-identical to the English one — English prose at the top of a Slovak or Romanian file, describing a sentence that isn't in it:

```diff
 ---
 # HassTurnOn - name_only
-# example: turn on the overhead light
 # slots: <name>

 language: "ro"
```

Nothing parses these comments and every group carries a validated `example:` key a few lines below, so nothing is lost.

**Only the untranslated leftovers go:**

| | count | action |
|---|---|---|
| header identical to English | 358 | removed |
| header localized | 1788 | **left untouched** |
| no English counterpart to compare | 328 | left untouched |

Header comments are already absent from 4440 of the 6914 non-English combo files, so this doesn't introduce an inconsistency. Removals span 24 languages, led by ro (77), ar (42), hy (33), he (24), it (20), kw (20).

Worth noting these comments are *not* the source of problem #1 — `add_language` round-trips through `yaml_dump`, which strips comments, so the generator never propagated them. They're older residue.

## Verification

- `intentfest validate` output is **byte-identical to main** — confirming the comments are inert
- `pytest tests/` — **14555 passed**
- prettier clean; `black`/`isort`/`flake8`/`pylint` clean on the changed script (the one `mypy` note about `hassil` stubs reproduces identically on `main`)

## Related

- #4141 fills the 300 missing `example:` values these warnings are about
- #4139 fixed the 30 in its own path
- The 9 identical-to-English examples that already exist still need a native speaker; this PR stops *new* ones appearing but doesn't translate the existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
