### PR TITLE
[ES] Add HassClimateGetTemperature floor combination

### DIFF
--- a/sentences/es/HassClimateGetTemperature/floor_only.yaml
+++ b/sentences/es/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,15 @@
+---
+# HassClimateGetTemperature - floor_only
+# example: ¿qué temperatura hace en la primera planta?
+# slots: {floor}
+
+language: "es"
+data:
+  - sentences:
+      - "<cual_es> <temp> [ahora [mismo]|actual[mente]|en este momento] <floor>"
+      - "<cual_es> <temp> <floor> [ahora [mismo]|actual[mente]|en este momento]"
+      - "[a] (cuánta|cuánto|cuántos|qué) <temp> (hace|hacen|hay|está|están|estamos) [ahora [mismo]|actual[mente]|en este momento] <floor>"
+      - "[a] (cuánta|cuánto|cuántos|qué) <temp> (hace|hacen|hay|está|están|estamos) <floor> [ahora [mismo]|actual[mente]|en este momento]"
+      - "hace (frío|calor) <floor>"
+    example: "¿qué temperatura hace en la primera planta?"
+    response: "default"

--- a/tests/es/HassClimateGetTemperature/floor_only.yaml
+++ b/tests/es/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,32 @@
+---
+# HassClimateGetTemperature - floor_only
+
+language: "es"
+floors:
+  - name: Primera planta
+areas:
+  - name: Salón
+    floor: Primera planta
+entities:
+  - name: Termostato salón
+    domain: climate
+    state: heat
+    area: Salón
+    attributes:
+      unit_of_measurement: °C
+      current_temperature: 22
+tests:
+  - sentences:
+      - ¿cuál es la temperatura actual de la primera planta?
+      - ¿cuál es la temperatura de la primera planta ahora mismo?
+      - ¿qué temperatura hace en la primera planta?
+      - ¿qué temperatura hay en la primera planta en este momento?
+      - ¿cuánto calor hace en la primera planta?
+      - ¿cuántos grados hace en la primera planta?
+      - ¿a qué temperatura está la primera planta?
+      - ¿a cuántos grados estamos en la primera planta?
+      - ¿a qué temperatura están ahora en la primera planta?
+      - hace calor en la primera planta
+    slots:
+      floor: Primera planta
+    response: "22 grados"


### PR DESCRIPTION
## Summary

- Add the missing Spanish `HassClimateGetTemperature/floor_only` sentence block.
- Add coverage for temperature queries targeting a floor and verify the localized response.

## Implementation notes

- English does not currently implement this slot combination, so `intents.yaml` was treated as the source of truth, pt-BR was used as a structural cross-language reference, and the existing Spanish `area_only` grammar was used as the language reference.
- The sentences reuse the established Spanish `<floor>`, `<cual_es>`, and `<temp>` expansion rules. This avoids duplicating the accepted `planta`/`piso` forms and floor-name ordering.
- Optional current-time expressions remain inline to match the existing Spanish climate query files; there is no established shared expansion rule for them.
- The existing `default` climate temperature response is reused.
- This adds regular Assist grammar only. No `speech_to_phrase` block is added because existing `floor_only` implementations do not opt this combination into the lean Speech-to-Phrase grammar.

## Testing

- Confirmed the new test failed before implementation because the floor sentence was not recognized.
- Focused slot-combination test passes.
- Full Spanish suite: `603 passed`.
- Cross-intent checker: `1104` sentences checked, `0` over-matches, `0` no-match sentences.
- Spanish validation passes.