### PR TITLE
[ES] Add missing HassIncreaseTimer combinations

### DIFF
--- a/sentences/es/HassIncreaseTimer/area_hours_minutes.yaml
+++ b/sentences/es/HassIncreaseTimer/area_hours_minutes.yaml
@@ -1,0 +1,13 @@
+---
+# HassIncreaseTimer - area_hours_minutes
+# example: añade 1 hora y 5 minutos al temporizador de la cocina
+
+language: "es"
+data:
+  - sentences:
+      - "(<añadir>|<sube>) <nb_hours> hora[s] [y] <nb_minutes> minuto[s] ([a] [mi]|al) <temporizador> <area>"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> <area> en <nb_hours> hora[s] [y] <nb_minutes> minuto[s]"
+      - "(<añadir>|<sube>) <nb_hours> hora[s] y {timer_half:minutes} ([a] [mi]|al) <temporizador> <area>"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> <area> en <nb_hours> hora[s] y {timer_half:minutes}"
+    example: "añade 1 hora y 5 minutos al temporizador de la cocina"
+    response: "default"

--- a/sentences/es/HassIncreaseTimer/area_hours_seconds.yaml
+++ b/sentences/es/HassIncreaseTimer/area_hours_seconds.yaml
@@ -1,0 +1,11 @@
+---
+# HassIncreaseTimer - area_hours_seconds
+# example: añade 1 hora y 30 segundos al temporizador de la cocina
+
+language: "es"
+data:
+  - sentences:
+      - "(<añadir>|<sube>) <nb_hours> hora[s] [y] <nb_seconds> segundo[s] ([a] [mi]|al) <temporizador> <area>"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> <area> en <nb_hours> hora[s] [y] <nb_seconds> segundo[s]"
+    example: "añade 1 hora y 30 segundos al temporizador de la cocina"
+    response: "default"

--- a/sentences/es/HassIncreaseTimer/area_minutes_seconds.yaml
+++ b/sentences/es/HassIncreaseTimer/area_minutes_seconds.yaml
@@ -1,0 +1,13 @@
+---
+# HassIncreaseTimer - area_minutes_seconds
+# example: añade 5 minutos y 30 segundos al temporizador de la cocina
+
+language: "es"
+data:
+  - sentences:
+      - "(<añadir>|<sube>) <nb_minutes> minuto[s] [y] <nb_seconds> segundo[s] ([a] [mi]|al) <temporizador> <area>"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> <area> en <nb_minutes> minuto[s] [y] <nb_seconds> segundo[s]"
+      - "(<añadir>|<sube>) <nb_minutes> minuto[s] y {timer_half:seconds} ([a] [mi]|al) <temporizador> <area>"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> <area> en <nb_minutes> minuto[s] y {timer_half:seconds}"
+    example: "añade 5 minutos y 30 segundos al temporizador de la cocina"
+    response: "default"

--- a/sentences/es/HassIncreaseTimer/hours_seconds.yaml
+++ b/sentences/es/HassIncreaseTimer/hours_seconds.yaml
@@ -1,0 +1,11 @@
+---
+# HassIncreaseTimer - hours_seconds
+# example: añade 1 hora y 30 segundos al temporizador
+
+language: "es"
+data:
+  - sentences:
+      - "(<añadir>|<sube>) <nb_hours> hora[s] [y] <nb_seconds> segundo[s] ([a] [mi]|al) <temporizador>"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> [en] <nb_hours> hora[s] [y] <nb_seconds> segundo[s]"
+    example: "añade 1 hora y 30 segundos al temporizador"
+    response: "default"

--- a/sentences/es/HassIncreaseTimer/name_hours_minutes.yaml
+++ b/sentences/es/HassIncreaseTimer/name_hours_minutes.yaml
@@ -1,0 +1,15 @@
+---
+# HassIncreaseTimer - name_hours_minutes
+# example: añade 1 hora y 5 minutos al temporizador pizza
+
+language: "es"
+data:
+  - sentences:
+      - "(<añadir>|<sube>) <nb_hours> hora[s] [y] <nb_minutes> minuto[s] ([a] [mi]|al) <temporizador> [para|de|con nombre|llamad(o|a)|denominad(o|a)] {timer_name:name}"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> (para|de|con nombre|llamad(o|a)|denominad(o|a)) {timer_name:name} en <nb_hours> hora[s] [y] <nb_minutes> minuto[s]"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> {timer_name:name} en <nb_hours> hora[s] [y] <nb_minutes> minuto[s]"
+      - "(<añadir>|<sube>) <nb_hours> hora[s] y {timer_half:minutes} ([a] [mi]|al) <temporizador> [para|de|con nombre|llamad(o|a)|denominad(o|a)] {timer_name:name}"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> (para|de|con nombre|llamad(o|a)|denominad(o|a)) {timer_name:name} en <nb_hours> hora[s] y {timer_half:minutes}"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> {timer_name:name} en <nb_hours> hora[s] y {timer_half:minutes}"
+    example: "añade 1 hora y 5 minutos al temporizador pizza"
+    response: "default"

--- a/sentences/es/HassIncreaseTimer/name_hours_seconds.yaml
+++ b/sentences/es/HassIncreaseTimer/name_hours_seconds.yaml
@@ -1,0 +1,12 @@
+---
+# HassIncreaseTimer - name_hours_seconds
+# example: añade 1 hora y 30 segundos al temporizador pizza
+
+language: "es"
+data:
+  - sentences:
+      - "(<añadir>|<sube>) <nb_hours> hora[s] [y] <nb_seconds> segundo[s] ([a] [mi]|al) <temporizador> [para|de|con nombre|llamad(o|a)|denominad(o|a)] {timer_name:name}"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> (para|de|con nombre|llamad(o|a)|denominad(o|a)) {timer_name:name} en <nb_hours> hora[s] [y] <nb_seconds> segundo[s]"
+      - "(<añadir>|<sube>) [[a] [mi]|al] <temporizador> {timer_name:name} en <nb_hours> hora[s] [y] <nb_seconds> segundo[s]"
+    example: "añade 1 hora y 30 segundos al temporizador pizza"
+    response: "default"

--- a/tests/es/HassIncreaseTimer/area_hours_minutes.yaml
+++ b/tests/es/HassIncreaseTimer/area_hours_minutes.yaml
@@ -1,0 +1,32 @@
+---
+# HassIncreaseTimer - area_hours_minutes
+
+language: "es"
+areas:
+  - name: Cocina
+    floor: Planta baja
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    area: Cocina
+    start_minutes: 5
+tests:
+  - sentences:
+      - añade 1 hora y 5 minutos al temporizador de la cocina
+      - aumentar temporizador de la cocina en 1 hora y 5 minutos
+    slots:
+      hours: 1
+      minutes: 5
+      area: Cocina
+    response: Temporizador actualizado
+  - sentences:
+      - añade 1 hora y media al temporizador de la cocina
+      - aumentar temporizador de la cocina en 1 hora y media
+    slots:
+      hours: 1
+      minutes: 30
+      area: Cocina
+    response: Temporizador actualizado

--- a/tests/es/HassIncreaseTimer/area_hours_seconds.yaml
+++ b/tests/es/HassIncreaseTimer/area_hours_seconds.yaml
@@ -1,0 +1,24 @@
+---
+# HassIncreaseTimer - area_hours_seconds
+
+language: "es"
+areas:
+  - name: Cocina
+    floor: Planta baja
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    area: Cocina
+    start_minutes: 5
+tests:
+  - sentences:
+      - añade 1 hora y 30 segundos al temporizador de la cocina
+      - aumentar temporizador de la cocina en 1 hora y 30 segundos
+    slots:
+      hours: 1
+      seconds: 30
+      area: Cocina
+    response: Temporizador actualizado

--- a/tests/es/HassIncreaseTimer/area_minutes_seconds.yaml
+++ b/tests/es/HassIncreaseTimer/area_minutes_seconds.yaml
@@ -1,0 +1,32 @@
+---
+# HassIncreaseTimer - area_minutes_seconds
+
+language: "es"
+areas:
+  - name: Cocina
+    floor: Planta baja
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    area: Cocina
+    start_minutes: 5
+tests:
+  - sentences:
+      - añade 5 minutos y 30 segundos al temporizador de la cocina
+      - aumentar temporizador de la cocina en 5 minutos y 30 segundos
+    slots:
+      minutes: 5
+      seconds: 30
+      area: Cocina
+    response: Temporizador actualizado
+  - sentences:
+      - añade 5 minutos y medio al temporizador de la cocina
+      - aumentar temporizador de la cocina en 5 minutos y medio
+    slots:
+      minutes: 5
+      seconds: 30
+      area: Cocina
+    response: Temporizador actualizado

--- a/tests/es/HassIncreaseTimer/hours_seconds.yaml
+++ b/tests/es/HassIncreaseTimer/hours_seconds.yaml
@@ -1,0 +1,19 @@
+---
+# HassIncreaseTimer - hours_seconds
+
+language: "es"
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    start_minutes: 5
+tests:
+  - sentences:
+      - añade 1 hora y 30 segundos al temporizador
+      - aumentar el temporizador en 1 hora y 30 segundos
+    slots:
+      hours: 1
+      seconds: 30
+    response: Temporizador actualizado

--- a/tests/es/HassIncreaseTimer/name_hours_minutes.yaml
+++ b/tests/es/HassIncreaseTimer/name_hours_minutes.yaml
@@ -1,0 +1,31 @@
+---
+# HassIncreaseTimer - name_hours_minutes
+
+language: "es"
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    name: pizza
+    start_minutes: 5
+tests:
+  - sentences:
+      - añade 1 hora y 5 minutos al temporizador pizza
+      - aumentar temporizador llamado pizza en 1 hora y 5 minutos
+      - aumentar temporizador pizza en 1 hora y 5 minutos
+    slots:
+      hours: 1
+      minutes: 5
+      name: pizza
+    response: Temporizador actualizado
+  - sentences:
+      - añade 1 hora y media al temporizador pizza
+      - aumentar temporizador llamado pizza en 1 hora y media
+      - aumentar temporizador pizza en 1 hora y media
+    slots:
+      hours: 1
+      minutes: 30
+      name: pizza
+    response: Temporizador actualizado

--- a/tests/es/HassIncreaseTimer/name_hours_seconds.yaml
+++ b/tests/es/HassIncreaseTimer/name_hours_seconds.yaml
@@ -1,0 +1,22 @@
+---
+# HassIncreaseTimer - name_hours_seconds
+
+language: "es"
+timers:
+  - is_active: true
+    total_seconds_left: 300
+    rounded_hours_left: 0
+    rounded_minutes_left: 5
+    rounded_seconds_left: 0
+    name: pizza
+    start_minutes: 5
+tests:
+  - sentences:
+      - añade 1 hora y 30 segundos al temporizador pizza
+      - aumentar temporizador llamado pizza en 1 hora y 30 segundos
+      - aumentar temporizador pizza en 1 hora y 30 segundos
+    slots:
+      hours: 1
+      seconds: 30
+      name: pizza
+    response: Temporizador actualizado


### PR DESCRIPTION
## Summary

Add the six missing Spanish `HassIncreaseTimer` complete-tier slot combinations:

- `hours_seconds`
- `name_hours_minutes`
- `name_hours_seconds`
- `area_minutes_seconds`
- `area_hours_minutes`
- `area_hours_seconds`

Each combination includes sentence templates and response-rendering tests.

## Implementation notes

- The corresponding Spanish `HassDecreaseTimer` combinations already implement the same slot layouts. These new files deliberately mirror their sentence ordering, timer targeting, and half-unit variants, replacing the decrease verbs and connectors with the established increase forms. This should make the change straightforward to review side by side.
- English does not currently implement these six combinations. `intents.yaml` was therefore treated as the semantic source of truth, while pt-BR was used to confirm the complete slot structure.
- The templates reuse the existing Spanish `<añadir>`, `<sube>`, `<temporizador>`, `<area>`, and numeric-unit expansion rules, as well as the `timer_half` and `timer_name` lists.
- The hours/minutes and minutes/seconds combinations preserve the existing Spanish half-unit forms, such as `una hora y media` and `cinco minutos y medio`.
- No Speech-to-Phrase blocks are added, matching the existing multi-unit Spanish timer combinations.

## Testing

- Before implementation, the six new slot-combination tests failed as unrecognized; the other 20 `HassIncreaseTimer` combinations passed.
- All 26 Spanish `HassIncreaseTimer` combination tests pass after implementation.
- Full Spanish suite: `603 passed`.
- Cross-intent checker: `1115` sentences checked, `0` over-matches, `0` no-match sentences.
- Spanish validation passes.