### PR TITLE
[ml] Add floor-based light turn-off commands

### DIFF
--- a/responses/ml/HassTurnOff.yaml
+++ b/responses/ml/HassTurnOff.yaml
@@ -4,6 +4,7 @@ responses:
     HassTurnOff:
       default: "{{ slots.name }} നിറുത്തി"
       lights_area: "ലൈറ്റുകൾ ഓഫാക്കി"
+      lights_floor: "{{ slots.floor }} നിലയിലെ വിളക്കുകൾ അണച്ചു"
       fans_area: "പങ്കകൾ നിറുത്തി"
       cover: "{{ slots.name }} അടച്ചു"
       cover_device_class: "{{ slots.device_class }} അടച്ചു"

--- a/sentences/ml/HassTurnOff/floor_domain.yaml
+++ b/sentences/ml/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,24 @@
+---
+# HassTurnOff - floor_domain
+# example: ഒന്നാം നിലയിലെ വിളക്കുകൾ അണയ്ക്കുക
+# slots:
+# - {floor}
+# - {domain}
+
+language: "ml"
+
+data:
+  # lights
+  - sentences:
+      - "{floor} നില (ഇരുട്ടാകുക|അന്ധകാരമാക്കുക)"
+      - "{floor} നില[<in>] വിളക്കുകൾ <turn_off>"
+
+    example: "ഒന്നാം നിലയിലെ വിളക്കുകൾ അണയ്ക്കുക"
+    inferred_domain: "light"
+    response: "lights_floor"
+  # Speech-to-Phrase: lean subset of the block above.
+  - sentences:
+      - "{floor} നില[<in>] വിളക്കുകൾ <turn_off>"
+    inferred_domain: "light"
+    response: "lights_floor"
+    speech_to_phrase: true

--- a/sentences/ml/HassTurnOff/floor_domain.yaml
+++ b/sentences/ml/HassTurnOff/floor_domain.yaml
@@ -19,6 +19,8 @@ data:
   # Speech-to-Phrase: lean subset of the block above.
   - sentences:
       - "{floor} നില[<in>] വിളക്കുകൾ <turn_off>"
+
+    example: "ഒന്നാം നിലയിലെ വിളക്കുകൾ അണയ്ക്കുക"
     inferred_domain: "light"
     response: "lights_floor"
     speech_to_phrase: true

--- a/tests/ml/HassTurnOff/floor_domain.yaml
+++ b/tests/ml/HassTurnOff/floor_domain.yaml
@@ -1,0 +1,22 @@
+# HassTurnOff - floor_domain
+language: ml
+
+floors:
+  - name: "ഒന്നാം"
+  - name: "രണ്ടാം"
+
+tests:
+  - sentences:
+      - "ഒന്നാം നില ഇരുട്ടാകുക"
+      - "ഒന്നാം നിലയിലെ വിളക്കുകൾ അണക്കുക"
+    slots:
+      floor: "ഒന്നാം"
+      domain: light
+    response: "ഒന്നാം നിലയിലെ വിളക്കുകൾ അണച്ചു"
+
+  - sentences:
+      - "രണ്ടാം നിലയിലെ വിളക്കുകൾ അണക്കുക"
+    slots:
+      floor: "രണ്ടാം"
+      domain: light
+    response: "രണ്ടാം നിലയിലെ വിളക്കുകൾ അണച്ചു"


### PR DESCRIPTION
* Add Malayalam sentences for turning off lights by floor
* Support commands such as “ഒന്നാം നില ഇരുട്ടാകുക” and “ഒന്നാം നിലയിലെ വിളക്കുകൾ അണക്കുക”
* Add a `lights_floor` response that includes the recognized floor name
* Add a Malayalam Speech-to-Phrase subset for floor-based light commands
* Add tests for floor-name extraction, light-domain inference, and rendered responses