### PR TITLE
[ES] Add missing vacuum location combinations

### DIFF
--- a/rules/es/common.yaml
+++ b/rules/es/common.yaml
@@ -5,6 +5,7 @@ expansion_rules:
   añadir: (añad(a|e|ir|í)|apunt[a|e|ar|á]|pon[ga|er|é]|sum(e|a|ar|á)|agreg(a|ue|ar|á))
   apaga: (apag(a|ue|ar|á)|desconect(a|e|ar|á)|desactiv(a|e|ar|á))
   area: "[[en|de] [el|la]|del] {area}"
+  aspiradora: "([el ]aspirador|[los ]aspiradores|[la ]aspiradora|[las ]aspiradoras)"
   baja: (baj(a|e|ar|á)|redu(ce|zca|cir|cí)|decrement(a|e|ar|á)|disminu(ye|ya|ir|í)|acort(a|e|ar|á))
   porciento: (%|por[ ]cien[to])
   cancela: cancel(a[r]|á|e|ación)

--- a/sentences/es/HassVacuumReturnToBase/area_only.yaml
+++ b/sentences/es/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,13 @@
+---
+# HassVacuumReturnToBase - area_only
+# example: devuelve la aspiradora del salón a la base
+# slots: {area}
+
+language: "es"
+data:
+  - sentences:
+      - "<devuelve> <aspiradora> <area> [a [la] base]"
+      - "(mand(a|e|ar|á)|env(ía|íe|iar|iá)) <aspiradora> <area> [a [la] base]"
+      - "que <aspiradora> <area> (vuelva|regrese|retorne) [a [la] base]"
+    example: "devuelve la aspiradora del salón a la base"
+    response: "default"

--- a/sentences/es/HassVacuumStart/area_only.yaml
+++ b/sentences/es/HassVacuumStart/area_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassVacuumStart - area_only
+# example: inicia la aspiradora del salón
+# slots: {area}
+
+language: "es"
+data:
+  - sentences:
+      - "<ejecuta> <aspiradora> <area>"
+    example: "inicia la aspiradora del salón"
+    response: "default"

--- a/sentences/es/HassVacuumStart/floor_only.yaml
+++ b/sentences/es/HassVacuumStart/floor_only.yaml
@@ -1,0 +1,11 @@
+---
+# HassVacuumStart - floor_only
+# example: inicia la aspiradora de la primera planta
+# slots: {floor}
+
+language: "es"
+data:
+  - sentences:
+      - "<ejecuta> <aspiradora> <floor>"
+    example: "inicia la aspiradora de la primera planta"
+    response: "default"

--- a/tests/es/HassVacuumReturnToBase/area_only.yaml
+++ b/tests/es/HassVacuumReturnToBase/area_only.yaml
@@ -1,0 +1,20 @@
+---
+# HassVacuumReturnToBase - area_only
+
+language: "es"
+areas:
+  - name: Salón
+    floor: Primera planta
+entities:
+  - name: Aspiradora salón
+    domain: vacuum
+    state: cleaning
+    area: Salón
+tests:
+  - sentences:
+      - devuelve la aspiradora del salón a la base
+      - manda el aspirador del salón a la base
+      - que la aspiradora del salón vuelva a la base
+    slots:
+      area: Salón
+    response: Regresando

--- a/tests/es/HassVacuumStart/area_only.yaml
+++ b/tests/es/HassVacuumStart/area_only.yaml
@@ -1,0 +1,20 @@
+---
+# HassVacuumStart - area_only
+
+language: "es"
+areas:
+  - name: Salón
+    floor: Primera planta
+entities:
+  - name: Aspiradora salón
+    domain: vacuum
+    state: idle
+    area: Salón
+tests:
+  - sentences:
+      - enciende la aspiradora del salón
+      - inicia el aspirador en el salón
+      - activa la aspiradora del salón
+    slots:
+      area: Salón
+    response: Limpieza iniciada

--- a/tests/es/HassVacuumStart/floor_only.yaml
+++ b/tests/es/HassVacuumStart/floor_only.yaml
@@ -1,0 +1,22 @@
+---
+# HassVacuumStart - floor_only
+
+language: "es"
+floors:
+  - name: Primera planta
+areas:
+  - name: Salón
+    floor: Primera planta
+entities:
+  - name: Aspiradora salón
+    domain: vacuum
+    state: idle
+    area: Salón
+tests:
+  - sentences:
+      - enciende la aspiradora de la primera planta
+      - inicia el aspirador en la primera planta
+      - activa la aspiradora de la primera planta
+    slots:
+      floor: Primera planta
+    response: Limpieza iniciada


### PR DESCRIPTION
## Summary

Add the three missing Spanish complete-tier vacuum location combinations:

- `HassVacuumStart/area_only`
- `HassVacuumStart/floor_only`
- `HassVacuumReturnToBase/area_only`

Each combination includes sentence templates and localized response tests.

## Implementation notes

- The area and floor slots in `HassVacuumStart` identify where the vacuum is located, whereas the area slot in `HassVacuumCleanArea` identifies the destination to clean. The new Spanish grammar makes this distinction explicit:
  - `inicia la aspiradora del salón` matches `HassVacuumStart`
  - the existing `aspira el salón` continues to match `HassVacuumCleanArea`
- The return-to-base grammar follows the same location-targeting model, for example `devuelve la aspiradora del salón a la base`.
- A shared `<aspiradora>` expansion was added for the masculine/feminine and singular/plural vacuum nouns. The sentence blocks also reuse the existing `<ejecuta>`, `<devuelve>`, `<area>`, and `<floor>` rules.
- pt-BR was used to confirm the complete slot structure. English only implements `floor_only`, and its cleaning-style phrasing would collide conceptually with the existing Spanish `HassVacuumCleanArea` grammar.
- Existing `default` responses are reused.
- No Speech-to-Phrase blocks are added; existing implementations of these location combinations do not opt into the lean grammar.

## Testing

- Before implementation, exactly the three new slot-combination tests failed as unrecognized; the two existing Spanish vacuum tests passed.
- All five focused `HassVacuumStart` and `HassVacuumReturnToBase` tests pass after implementation.
- Full Spanish suite: `603 passed`.
- Cross-intent checker: `1134` sentences checked, `0` over-matches, `0` no-match sentences.
- Spanish validation passes.