### PR TITLE
[it] Add mi forms to named turn on/off sentences

### DIFF
--- a/sentences/it/HassTurnOff/name_only.yaml
+++ b/sentences/it/HassTurnOff/name_only.yaml
@@ -8,6 +8,7 @@ data:
   # off-able domains
   - sentences:
       - "<turn_off> [<the>] {name}"
+      - "mi <turn_off> [<the>] {name}"
       - "[<the>] {name} <turn_off>"
     example: "spegni la luce a soffitto"
     name_domains: "default"
@@ -16,6 +17,8 @@ data:
   # lights named with a trailing "light(s)/lamp(s)" word
   - sentences:
       - "<turn_off> [<the>] {name} <light>"
+      - "mi <turn_off> [<the>] {name} <light>"
+      - "mi <turn_off> [<the>] <light> [<of>][<the>]{name}"
       - "[<the>] {name} <light> <turn_off>"
     example: "spegni le luci dell'angolo gioco"
     name_domains:

--- a/sentences/it/HassTurnOn/name_only.yaml
+++ b/sentences/it/HassTurnOn/name_only.yaml
@@ -8,6 +8,7 @@ data:
   # on-able domains
   - sentences:
       - "<turn_on> [<the>] {name}"
+      - "mi <turn_on> [<the>] {name}"
       - "[<the>] {name}"
     example: "accendi la luce centrale"
     name_domains: "default"
@@ -16,6 +17,7 @@ data:
   # lights named with a "light(s)/lamp(s)" word
   - sentences:
       - "<turn_on> [<the>] <light> [<of>][<the>]{name}"
+      - "mi <turn_on> [<the>] <light> [<of>][<the>]{name}"
     example: "accendi le luci dell'angolo gioco"
     name_domains:
       - "light"

--- a/tests/it/HassTurnOff/name_only.yaml
+++ b/tests/it/HassTurnOff/name_only.yaml
@@ -26,6 +26,8 @@ tests:
       - "spegni la luce a soffitto"
       - "la luce a soffitto spegni"
       - "disattiva la luce a soffitto"
+      - "mi spegni la luce a soffitto"
+      - "mi spegni luce a soffitto"
     slots:
       name: "Luce a Soffitto"
     response: "Ho spento Luce a Soffitto"
@@ -34,6 +36,7 @@ tests:
       - "spegni la lampada comodino"
       - "la lampada comodino spegni"
       - "disattiva lampada comodino"
+      - "mi spegni la lampada comodino"
     slots:
       name: "Lampada Comodino"
     response: "Ho spento Lampada Comodino"
@@ -42,6 +45,8 @@ tests:
   - sentences:
       - "spegni angolo gioco luci"
       - "angolo gioco luci spegni"
+      - "mi spegni angolo gioco luci"
+      - "mi spegni le luci dell'angolo gioco"
     slots:
       name: "Angolo Gioco"
     response: "Ho spento Angolo Gioco"
@@ -51,6 +56,7 @@ tests:
       - "spegni il ventilatore a soffitto"
       - "il ventilatore a soffitto spegni"
       - "disattiva il ventilatore a soffitto"
+      - "mi spegni il ventilatore a soffitto"
     slots:
       name: "Ventilatore a Soffitto"
     response: "Ho spento Ventilatore a Soffitto"

--- a/tests/it/HassTurnOn/name_only.yaml
+++ b/tests/it/HassTurnOn/name_only.yaml
@@ -20,6 +20,8 @@ tests:
   - sentences:
       - "accendi la luce centrale"
       - "luce centrale"
+      - "mi accendi la luce centrale"
+      - "mi accendi luce centrale"
     slots:
       name: Luce Centrale
     response: "Ho acceso Luce Centrale"
@@ -28,6 +30,7 @@ tests:
   - sentences:
       - "accendi il ventilatore soffitto"
       - "attiva il ventilatore soffitto"
+      - "mi accendi il ventilatore soffitto"
     slots:
       name: Ventilatore Soffitto
     response: "Ho acceso Ventilatore Soffitto"
@@ -36,6 +39,7 @@ tests:
   - sentences:
       - "accendi le luci dell'angolo gioco"
       - "accendi luci angolo gioco"
+      - "mi accendi le luci dell'angolo gioco"
     slots:
       name: Angolo Gioco
     response: "Ho acceso Angolo Gioco"


### PR DESCRIPTION
## Summary

In colloquial Italian, forms such as "mi accendi X" and "mi spegni X" are common ways to request that a device be turned on or off.

The existing Italian sentences recognize forms such as "puoi accendere X", but do not recognize the corresponding simple forms "mi accendi X" and "mi spegni X".

This change adds the missing forms only to the `name_only` slot combinations for `HassTurnOn` and `HassTurnOff`.

The word `mi` is not added to the global Italian skip words. The change remains scoped to the affected sentence templates and keeps the generic `{name}` slot.

Specific Italian ON/OFF sentence tests were added, including article and preposition variants. The full Linux suite passes without regressions or ON/OFF inversion cases.
