### PR TITLE
[ml] Add todo list 'item add' sentences

### DIFF
--- a/responses/ml/HassListAddItem.yaml
+++ b/responses/ml/HassListAddItem.yaml
@@ -1,0 +1,5 @@
+language: "ml"
+responses:
+  intents:
+    HassListAddItem:
+      item_added: "{{ slots.item }} ചേർത്തു"

--- a/rules/ml/inflections.yaml
+++ b/rules/ml/inflections.yaml
@@ -1,0 +1,9 @@
+# Malayalam noun inflections used in sentence templates.
+# These may include accusative, genitive, dative, instrumental, locative,
+# sociative, vocative, and plural forms. Add an expansion rule only when it
+# is referenced by a sentence template; unused rules fail repository tests.
+
+language: ml
+expansion_rules:
+  # Locative inflections
+  list_locative: (പട്ടികയിൽ|സൂചികയിൽ|സൂചിയിൽ|ലിസ്റ്റിൽ)

--- a/sentences/ml/HassListAddItem/name_item.yaml
+++ b/sentences/ml/HassListAddItem/name_item.yaml
@@ -1,0 +1,16 @@
+---
+# HassListAddItem - name_item
+# example: എന്റെ മോർ പട്ടികയിൽ നാരങ്ങ ചേർക്കുക
+# slots:
+# - {item}
+# - {name}
+
+language: "ml"
+data:
+  - sentences:
+      - "[എന്റെ] {name} <list_locative> {todo_list_item:item} ചേർക്കുക"
+      - "{name} <list_locative> {todo_list_item:item} ഇടുക"
+    example: "എന്റെ മോർ പട്ടികയിൽ നാരങ്ങ ചേർക്കുക"
+    name_domains:
+      - "todo"
+    response: "item_added"

--- a/tests/ml/HassListAddItem/name_item.yaml
+++ b/tests/ml/HassListAddItem/name_item.yaml
@@ -1,0 +1,17 @@
+---
+# HassListAddItem - name_item
+# example: എന്റെ മോർ പട്ടികയിൽ നാരങ്ങ ചേർക്കുക
+
+language: "ml"
+entities:
+  - name: "മോർ"
+    domain: "todo"
+
+tests:
+  - sentences:
+      - "എന്റെ മോർ പട്ടികയിൽ നാരങ്ങ ചേർക്കുക"
+      - "മോർ ലിസ്റ്റിൽ നാരങ്ങ ഇടുക"
+    slots:
+      item: "നാരങ്ങ"
+      name: "മോർ"
+    response: "നാരങ്ങ ചേർത്തു"


### PR DESCRIPTION
- Add Malayalam sentence templates for adding items to named todo lists, including “എന്റെ മോർ പട്ടികയിൽ നാരങ്ങ ചേർക്കുക” and “മോർ ലിസ്റ്റിൽ നാരങ്ങ ഇടുക”.
- Add a shared `list_locative` expansion for “പട്ടികയിൽ”, “സൂചികയിൽ”, “സൂചിയിൽ”, and “ലിസ്റ്റിൽ”.
- Add an `item_added` response that confirms the added item, such as “നാരങ്ങ ചേർത്തു”.
- Add `name_item` tests covering named todo lists, wildcard items, and both sentence patterns.