### PR TITLE
[ES] Separate list item completion and removal

### DIFF
--- a/responses/es/HassListCompleteItem.yaml
+++ b/responses/es/HassListCompleteItem.yaml
@@ -2,4 +2,4 @@ language: "es"
 responses:
   intents:
     HassListCompleteItem:
-      item_completed: "Se eliminó {{ slots.item }}"
+      item_completed: "Se completó {{ slots.item }}"

--- a/responses/es/HassListRemoveItem.yaml
+++ b/responses/es/HassListRemoveItem.yaml
@@ -1,0 +1,6 @@
+---
+language: "es"
+responses:
+  intents:
+    HassListRemoveItem:
+      item_deleted: "Se eliminó {{ slots.item }}"

--- a/rules/es/common.yaml
+++ b/rules/es/common.yaml
@@ -11,9 +11,12 @@ expansion_rules:
   cancela: cancel(a[r]|á|e|ación)
   cambia: (cambi(a[r]|á|e|o)|(muev[a|e]|mov[er|é]))
   cierra: (cierr(a|e)|cerr(ar|á)|<baja>)
+  completa: (complet(a|e|ar|á)|finaliz(a|ar|á)|finalice|termin(a|e|ar|á))
+  completado: (completad(o|a)[s]|hech(o|a)[s]|realizad(o|a)[s])
   continúa: (contin(úa|úe|uar|uá)|(sig(ue|a)|segu(ir|í))|(reactiv(a|e|ar|á))|reanud(a|e|ar|á))
   crea: (cre(a|e|ar|á))
   cual_es: (cu(a|á)l es [el |la ]|cu(a|á)les son [los |las ]|c(o|ó)mo (va|está|marcha|se encuentra)[n] [el |la |los |las ])
+  da_por_completado: ((d(a|á|ar)|dé) por <completado>)
   de_aqui: "[(de|en)] (aquí|acá|(el|la) <habitación>)"
   dime: (sab(es|é)|dime|dec(ir|í|id)[me]|ind(i|í)(ca|que|car|cá)[me])
   dime_si: <dime> si
@@ -28,7 +31,9 @@ expansion_rules:
   establece_sube_baja: (<establece>|<enciende>|<sube>|<baja>)
   floor: "[([en|de] [el|la]|del)] ([planta|piso] {floor}|{floor} [planta|piso])"
   inicia: (inici(a|e|ar|á)|com[i]en(za|ce|zar|zá)|emp[i]e(za|ce|zar|zá))
+  lista_nombre: "((de|en) [[mi] lista[do]|[la] lista|lista[do]] [de|del|de la[s]|de los] {name}|(del|en [el]) listado [de|del|de la[s]|de los] {name}|(de|en) {name})"
   luces: "[el|la|los|las] (luz|luces|lámpara[s]|bombill(a|o)[s]|ampolleta[s]|luminaria[s]|lamparilla[s]|foco[s]|interruptor[es]|llave[s][ de la luz])"
+  marca: (marc(a|ar|á)|marque)
   otra_vez: (otra vez|de nuevo|una vez más)
   pausa: (paus(a|ar|e|á)|<para>)
   para: (par(a|ar|e|á))|det(én|ener|enga|ené)
@@ -39,6 +44,8 @@ expansion_rules:
   salta: (salt(a|e|ar|á))
   se_encuentra: (se (encuentra|localiza|ubica)|está|mora)
   sube: (sub(a|e|ir|í)|levant(a|e|ar|á)|aument(a|e|ar|á)|increment(a|e|ar|á))
+  suprime: (suprim(a|e|ir|í)|retir(a|e|ar|á)|rem(ueve|ueva|over|ové))
+  tacha: tach(a|e|ar|á)
   vol: "[el|la] (volumen|música)"
   vuelve: ((vuelve|vuelva|volver|volvé)|(regres(a|e|ar|á))|(retorn(a|e|ar|á))|(retroced(e|a|er|é)))
   habitación: (habitaci(ón|ones)|pieza[s]|cuarto[s]|aposento[s]|sala[s]|[re]cámara[s])

--- a/sentences/es/HassListCompleteItem/name_item.yaml
+++ b/sentences/es/HassListCompleteItem/name_item.yaml
@@ -1,6 +1,6 @@
 ---
 # HassListCompleteItem - name_item
-# example: elimina manzanas de mi lista de Mercadona
+# example: marca sacar la basura como completado en mi lista de Tareas
 # slots:
 # - {item}
 # - {name}
@@ -8,9 +8,13 @@
 language: "es"
 data:
   - sentences:
-      - "(<elimina>|<quita>) {shopping_list_item:item} (de|en) [[mi|el|la] lista[do] [de|del|de la[s]|de los]] {name}"
-      - "(<elimina>|<quita>) (de|en) [[mi|el|la] lista[do] [de|del|de la[s]|de los]] {name} {shopping_list_item:item}"
-    example: "elimina manzanas de mi lista de Mercadona"
+      - "(<completa>|<tacha>) {todo_list_item:item} <lista_nombre>"
+      - "<marca> {todo_list_item:item} [como <completado>] <lista_nombre>"
+      - "<marca> [como <completado>] {todo_list_item:item} <lista_nombre>"
+      - "<da_por_completado> {todo_list_item:item} <lista_nombre>"
+      - "(<completa>|<tacha>) <lista_nombre> {todo_list_item:item}"
+      - "<marca> <lista_nombre> {todo_list_item:item} [como <completado>]"
+    example: "marca sacar la basura como completado en mi lista de Tareas"
     name_domains:
       - "todo"
     response: "item_completed"

--- a/sentences/es/HassListRemoveItem/name_item.yaml
+++ b/sentences/es/HassListRemoveItem/name_item.yaml
@@ -1,0 +1,16 @@
+---
+# HassListRemoveItem - name_item
+# example: elimina sacar la basura de mi lista de Tareas
+# slots:
+# - {item}
+# - {name}
+
+language: "es"
+data:
+  - sentences:
+      - "(<elimina>|<quita>|<suprime>) {todo_list_item:item} <lista_nombre>"
+      - "(<elimina>|<quita>|<suprime>) <lista_nombre> {todo_list_item:item}"
+    example: "elimina sacar la basura de mi lista de Tareas"
+    name_domains:
+      - "todo"
+    response: "item_deleted"

--- a/tests/es/HassListCompleteItem/name_item.yaml
+++ b/tests/es/HassListCompleteItem/name_item.yaml
@@ -1,33 +1,34 @@
 ---
 # HassListCompleteItem - name_item
-# example: elimina manzanas de mi lista de Mercadona
+# example: marca sacar la basura como completado en mi lista de Tareas
 
-language: "es"
+language: es
 entities:
-  - name: "Mercadona"
+  - name: "Tareas"
     domain: "todo"
 
 tests:
   - sentences:
-      - "elimina manzanas de mi lista de Mercadona"
-      - "eliminar manzanas en Mercadona"
-      - "eliminá manzanas de lista Mercadona"
-      - "borrar manzanas en el listado Mercadona"
-      - "borra manzanas en el lista del Mercadona"
-      - "borrá manzanas en la lista Mercadona"
-      - "elimina manzanas de la lista del Mercadona"
-      - "quita manzanas en el listado del Mercadona"
-      - "quitá manzanas en la lista Mercadona"
-      - "quitar manzanas de la lista del Mercadona"
+      - "marca sacar la basura como completado en mi lista de Tareas"
+      - "marque sacar la basura como hecho en la lista Tareas"
+      - "marcá sacar la basura como realizado en lista Tareas"
+      - "marca como completado sacar la basura en Tareas"
+      - "completa sacar la basura en Tareas"
+      - "completá sacar la basura en lista Tareas"
+      - "finaliza sacar la basura en la lista Tareas"
+      - "finalice sacar la basura en la lista de Tareas"
+      - "terminá sacar la basura de mi lista Tareas"
+      - "tacha sacar la basura de la lista de Tareas"
+      - "da por hecho sacar la basura en el listado Tareas"
     slots:
-      item: "manzanas"
-      name: "Mercadona"
-    response: "Se eliminó manzanas"
+      item: "sacar la basura"
+      name: "Tareas"
+    response: "Se completó sacar la basura"
   - sentences:
-      - "elimine en la lista Mercadona manzanas"
-      - "borra de la lista del Mercadona manzanas"
-      - "quita de la lista Mercadona manzanas"
+      - "marca en la lista Tareas sacar la basura como completado"
+      - "completa en la lista de Tareas sacar la basura"
+      - "tacha de mi lista Tareas sacar la basura"
     slots:
-      item: "manzanas"
-      name: "Mercadona"
-    response: "Se eliminó manzanas"
+      item: "sacar la basura"
+      name: "Tareas"
+    response: "Se completó sacar la basura"

--- a/tests/es/HassListRemoveItem/name_item.yaml
+++ b/tests/es/HassListRemoveItem/name_item.yaml
@@ -1,0 +1,38 @@
+---
+# HassListRemoveItem - name_item
+# example: elimina sacar la basura de mi lista de Tareas
+
+language: es
+entities:
+  - name: "Tareas"
+    domain: "todo"
+
+tests:
+  - sentences:
+      - "elimina sacar la basura de mi lista de Tareas"
+      - "elimine sacar la basura de la lista Tareas"
+      - "eliminar sacar la basura en Tareas"
+      - "eliminá sacar la basura de la lista Tareas"
+      - "borra sacar la basura en el listado Tareas"
+      - "borrar sacar la basura de la lista de Tareas"
+      - "quita sacar la basura del listado de Tareas"
+      - "quitar sacar la basura de la lista Tareas"
+      - "suprime sacar la basura de mi lista Tareas"
+      - "suprimí sacar la basura de lista Tareas"
+      - "retira sacar la basura de la lista de Tareas"
+      - "retirá sacar la basura de mi lista Tareas"
+      - "remueve sacar la basura de la lista Tareas"
+      - "remové sacar la basura de lista Tareas"
+    slots:
+      item: "sacar la basura"
+      name: "Tareas"
+    response: "Se eliminó sacar la basura"
+  - sentences:
+      - "elimina de la lista Tareas sacar la basura"
+      - "borra de la lista de Tareas sacar la basura"
+      - "quita de mi lista Tareas sacar la basura"
+      - "suprime de la lista Tareas sacar la basura"
+    slots:
+      item: "sacar la basura"
+      name: "Tareas"
+    response: "Se eliminó sacar la basura"


### PR DESCRIPTION
## Summary

- Implement the missing Spanish `HassListRemoveItem/name_item` combination, including its response and tests.
- Correct the existing `HassListCompleteItem/name_item` grammar and response so completing an item and permanently removing it are distinct operations.
- Add shared expansion rules for named-list phrases and the completion/removal vocabulary.

## Why the existing completion intent must change

Spanish `HassListCompleteItem` was originally added in [#3318](https://github.com/OHF-Voice/intents/pull/3318) in August 2025, before `HassListRemoveItem` existed. It consequently used `elimina`, `borra`, and `quita` to complete an item and responded with `Se eliminó ...`.

`HassListRemoveItem` was introduced later in [#3768](https://github.com/OHF-Voice/intents/pull/3768), in March 2026. Both intents have the same `{name}` and wildcard `{item}` slots, so adding the Spanish removal intent with those verbs while leaving the completion grammar unchanged would make the sentence sets semantically identical and ambiguous. The pre-implementation test demonstrated this directly: `elimina sacar la basura de mi lista de Tareas`, tested as `HassListRemoveItem`, was instead recognized as `HassListCompleteItem`.

The same migration was performed for English when the removal intent was introduced: PR #3768 removed `delete` and `remove` from `HassListCompleteItem` and transferred them to `HassListRemoveItem`, leaving `check` and `complete` for completion.

## Romance-language comparison

The Romance languages that implement both intents maintain the same semantic separation:

- Catalan completes with forms such as `acaba` and `completa`, while removal uses `elimina`, `esborra`, `treu`, and `suprimeix`.
- French completes with `coche`, `valide`, and `marque`, while removal uses `supprime` and `enlève`.
- Brazilian Portuguese completes with `terminar`, `completar`, and `marcar`, while removal uses `excluir`, `apagar`, `tirar`, and `remover`.

Italian currently implements only `HassListCompleteItem` and still accepts `elimina` and `rimuovi`. Since it has no `HassListRemoveItem` sentence set yet, it reflects the same kind of pre-separation state Spanish was in and cannot be used as the model once both intents coexist.

## Implementation notes

- Completion now uses `marca`, `completa`, `finaliza`, `termina`, `tacha`, and `da por hecho/completado/realizado` forms.
- Removal owns `elimina`, `borra`, `quita`, `suprime`, `retira`, and `remueve` forms.
- Informal, formal, infinitive, and voseo command forms are supported where applicable.
- Both item-first and list-first word orders remain supported.
- A shared `<lista_nombre>` rule handles forms such as `en Tareas`, `de mi lista de Tareas`, and `del listado de Tareas` consistently between both intents.
- Both intents use `{todo_list_item:item}`, matching the current generic todo-list implementations in other languages.
- The completion response changes from `Se eliminó {{ slots.item }}` to `Se completó {{ slots.item }}`. The new removal response uses `Se eliminó {{ slots.item }}`.
- The legacy `HassShoppingListCompleteItem` intent is unchanged. It has no corresponding shopping-list removal intent and is outside the generic named-list split implemented here.
- Tests use the generic list name `Tareas` and item `sacar la basura`.

## Testing

- Before implementation, the two focused tests failed for the expected reasons: completion phrases were unrecognized, and removal phrases selected `HassListCompleteItem`.
- Both focused `HassListCompleteItem` and `HassListRemoveItem` tests pass after implementation.
- Full Spanish suite: `605 passed`, including the Speech-to-Phrase tests.
- Cross-intent checker: `1153` Spanish test sentences checked, `0` over-matches and `0` no-match sentences.
- Spanish validation passes.
- Pruning check reports no dead Spanish rules or lists.
