### PR TITLE
[ml] Add floor-based temperature queries

### DIFF
--- a/responses/ml/HassClimateGetTemperature.yaml
+++ b/responses/ml/HassClimateGetTemperature.yaml
@@ -2,4 +2,22 @@ language: ml
 responses:
   intents:
     HassClimateGetTemperature:
+      current_temperature: >
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
+        {% if temperature not in ['unavailable', 'unknown'] %}
+          {{ temperature | float | round(1) | replace(".0", "") }} ഡിഗ്രി
+        {% else %}
+          താപനില സെൻസർ ലഭ്യമല്ല.
+        {% endif %}
+
+      target_temperature: >
+        {% set target_temperature = state_attr(state.entity_id, 'temperature') %}
+        {% set temperature = state.state if target_temperature is none else target_temperature %}
+        {% if temperature not in ['unavailable', 'unknown'] %}
+          {{ temperature | float | round(1) | replace(".0", "") }} ഡിഗ്രി
+        {% else %}
+          തെർമോസ്റ്റാറ്റ് ലഭ്യമല്ല.
+        {% endif %}
+
       default: "{{ state.state }} ഡിഗ്രികൾ"

--- a/sentences/ml/HassClimateGetTemperature/floor_only.yaml
+++ b/sentences/ml/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassClimateGetTemperature - floor_only
+# example: ഒന്നാം നിലയിലെ താപനില എത്രയാണ്
+# slots: {floor}
+
+language: "ml"
+data:
+  - sentences:
+      - "{floor} നിലയിലെ <temp> <what_is>"
+
+    example: "ഒന്നാം നിലയിലെ താപനില എത്രയാണ്"
+    response: "current_temperature"

--- a/tests/ml/HassClimateGetTemperature/floor_only.yaml
+++ b/tests/ml/HassClimateGetTemperature/floor_only.yaml
@@ -1,0 +1,29 @@
+---
+# HassClimateGetTemperature - floor_only
+
+language: "ml"
+
+floors:
+  - name: "ഒന്നാം"
+
+areas:
+  - name: "കിടപ്പുമുറി"
+    floor: "ഒന്നാം"
+
+entities:
+  - name: "കിടപ്പുമുറി തെർമോസ്റ്റാറ്റ്"
+    domain: "climate"
+    state: "heat"
+    area: "കിടപ്പുമുറി"
+    attributes:
+      unit_of_measurement: °C
+      current_temperature: 26
+
+tests:
+  - sentences:
+      - "ഒന്നാം നിലയിലെ താപനില എന്താണ്"
+      - "ഒന്നാം നിലയിലെ താപനില എത്രയാണ്"
+
+    slots:
+      floor: "ഒന്നാം"
+    response: "26 ഡിഗ്രി"


### PR DESCRIPTION
- Add Malayalam HassClimateGetTemperature sentences for requesting the temperature on a specified floor.
- Match floor names using the “{floor} നിലയിലെ <temp> <what_is>” pattern, including “ഒന്നാം നിലയിലെ താപനില എത്രയാണ്”.
- Add current-temperature and target-temperature response templates with natural Malayalam “ഡിഗ്രി” phrasing.
- Format whole-number temperatures without a trailing decimal while preserving meaningful decimal values.
- Add Malayalam fallback messages when the temperature sensor or thermostat is unavailable.
- Add a floor-only test fixture with a climate entity and verify floor-slot recognition and the expected “26 ഡിഗ്രി” response.