### PR TITLE
[it] Stop matching climatizzatore/condizionatore as fan

### DIFF
--- a/rules/it/fans.yaml
+++ b/rules/it/fans.yaml
@@ -1,3 +1,3 @@
 language: it
 expansion_rules:
-  fan: (ventol(a|e) | ventilator(e|i) | ventilazione | climatizzator(e|i) | condizionator(e|i))
+  fan: (ventol(a|e) | ventilator(e|i) | ventilazione)

--- a/tests/it/_test_failures.yaml
+++ b/tests/it/_test_failures.yaml
@@ -1,6 +1,4 @@
 language: it
 sentences:
-  - "accendi in soggiorno il climatizzatore"
-  - "spegni in soggiorno il climatizzatore"
   - "spegni il ventilatore in soggiorno"
   - "accendi il ventilatore in cucina"


### PR DESCRIPTION
Fixes #3054.

`climatizzatore` and `condizionatore` mean air conditioner / climate
control unit, not fan. They were listed as synonyms in the shared
`<fan>` expansion rule used by `HassTurnOn`/`HassTurnOff`, so a
sentence like "accendi il condizionatore in camera" was parsed as a
request to turn on a `fan` entity. Since no fan entity exists on a
typical setup, Assist replied with a misleading "non conosco nessun
dispositivo di tipo fan" instead of doing anything useful — exactly
what the issue reports.

No language (Italian included) has a generic `inferred_domain: climate`
block for `HassTurnOn`/`HassTurnOff` — climate entities are only
reachable there by name. So the correct fix is to stop these two words
from claiming the `fan` domain, matching the workaround the reporter
already validated locally in their own `_common.yaml` override.

Also removes the two now-fixed sentences from `tests/it/_test_failures.yaml`,
per that file's own "must be removed when fixed" convention.

Checked with:
```
python3 -m script.intentfest validate --language it
pytest tests --language it                                   # 332 passed, no regressions
python3 -m script.intentfest check_overmatch --language it    # 0 cross-intent mismatches
```