### PR TITLE
[en] Add radio as a media_class value

### DIFF
--- a/lists/en/media.yaml
+++ b/lists/en/media.yaml
@@ -24,3 +24,5 @@ lists:
         out: "movie"
       - in: "[tv] show"
         out: "tv_show"
+      - in: "radio [station]"
+        out: "radio"

--- a/tests/en/HassMediaSearchAndPlay/media_class_only.yaml
+++ b/tests/en/HassMediaSearchAndPlay/media_class_only.yaml
@@ -61,3 +61,11 @@ tests:
       search_query: "Breaking Bad"
       media_class: "tv_show"
     response: "Playing media"
+
+  - sentences:
+      - "play the radio station KEXP"
+      - "play radio KEXP"
+    slots:
+      search_query: "KEXP"
+      media_class: "radio"
+    response: "Playing media"


### PR DESCRIPTION
Closes #3718.

`media_player.search_media` and `music_assistant.search` already accept
`radio` as a `media_class` value, but the `en` `media_class` list has no
entry for it. So a request like "play radio KEXP" has no way to tell
HassMediaSearchAndPlay that "KEXP" is a radio station rather than an
artist or track, and it falls back to a fuzzy search that often matches
the wrong thing (per the linked issue).

Adds `"radio [station]"` -> `"radio"` to `lists/en/media.yaml`, same
shape as the existing `movie`/`tv_show`/etc. entries. No template
changes needed, `{media_class}` is already generic.

A companion change adding the same value to the Italian list is in #4189
(currently open, since the Italian media_class list is introduced by
that PR).

Checked with:
```
python3 -m script.intentfest validate --language en
pytest tests --language en                                    # 609 passed, no regressions
python3 -m script.intentfest check_overmatch --language en    # 0 cross-intent mismatches across 1170 sentences
```