### PR TITLE
Add Danish HassMediaSearchAndPlay sentences

### DIFF
--- a/sentences/da/HassMediaSearchAndPlay/area_media_class.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/area_media_class.yaml
@@ -1,0 +1,16 @@
+---
+# HassMediaSearchAndPlay - area_media_class
+# example: spil sangen Bohemian Rhapsody i køkkenet
+# slots:
+# - {area}
+# - {search_query}
+# - {media_class}
+
+language: "da"
+
+data:
+  - sentences:
+      - "spil {media_class} {search_query} i {area}"
+      - "afspil {media_class} {search_query} i {area}"
+    example: "spil sangen Bohemian Rhapsody i køkkenet"
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/area_media_class.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/area_media_class.yaml
@@ -7,7 +7,6 @@
 # - {media_class}
 
 language: "da"
-
 data:
   - sentences:
       - "spil {media_class} {search_query} i {area}"

--- a/sentences/da/HassMediaSearchAndPlay/area_only.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/area_only.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaSearchAndPlay - area_only
+# example: spil The Office i køkkenet
+# slots:
+# - {area}
+# - {search_query}
+
+language: "da"
+
+data:
+  - sentences:
+      - "spil {search_query} i {area}"
+      - "afspil {search_query} i {area}"
+    example: "spil The Office i køkkenet"
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/area_only.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/area_only.yaml
@@ -6,7 +6,6 @@
 # - {search_query}
 
 language: "da"
-
 data:
   - sentences:
       - "spil {search_query} i {area}"

--- a/sentences/da/HassMediaSearchAndPlay/default.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/default.yaml
@@ -1,0 +1,13 @@
+---
+# HassMediaSearchAndPlay - default
+# example: play The Office
+# slots: {search_query}
+# context_area: true
+language: "da"
+
+data:
+  - sentences:
+      - "spil {search_query}"
+      - "afspil {search_query}"
+    example: "spil The Office"
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/default.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/default.yaml
@@ -3,8 +3,8 @@
 # example: play The Office
 # slots: {search_query}
 # context_area: true
-language: "da"
 
+language: "da"
 data:
   - sentences:
       - "spil {search_query}"

--- a/sentences/da/HassMediaSearchAndPlay/media_class_only.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/media_class_only.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaSearchAndPlay - media_class_only
+# example: spil nummeret Bohemian Rhapsody
+# slots:
+# - {search_query}
+# - {media_class}
+# context_area: true
+
+language: "da"
+
+data:
+  - sentences:
+      - "spil {media_class} {search_query}"
+      - "spil {search_query} {media_class}"
+      - "afspil {media_class} {search_query}"
+      - "afspil {search_query} {media_class}"
+    example: "spil nummeret Bohemian Rhapsody"
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/media_class_only.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/media_class_only.yaml
@@ -7,7 +7,6 @@
 # context_area: true
 
 language: "da"
-
 data:
   - sentences:
       - "spil {media_class} {search_query}"

--- a/sentences/da/HassMediaSearchAndPlay/name_area.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/name_area.yaml
@@ -7,14 +7,11 @@
 # - {search_query}
 
 language: "da"
-
 data:
   - sentences:
       - "spil {search_query} på {name} i {area}"
       - "afspil {search_query} på {name} i {area}"
     example: "spil The Office på TV'et i køkkenet"
-
     name_domains:
       - "media_player"
-
     response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/name_area.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/name_area.yaml
@@ -1,0 +1,20 @@
+---
+# HassMediaSearchAndPlay - name_area
+# example: spil The Office på TV'et i køkkenet
+# slots:
+# - {name}
+# - {area}
+# - {search_query}
+
+language: "da"
+
+data:
+  - sentences:
+      - "spil {search_query} på {name} i {area}"
+      - "afspil {search_query} på {name} i {area}"
+    example: "spil The Office på TV'et i køkkenet"
+
+    name_domains:
+      - "media_player"
+
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/name_area_media_class.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/name_area_media_class.yaml
@@ -1,0 +1,18 @@
+---
+# HassMediaSearchAndPlay - name_area_media_class
+# example: spil kunstneren Queen på TV'et i køkkenet
+# slots:
+# - {name}
+# - {area}
+# - {search_query}
+# - {media_class}
+
+language: "da"
+data:
+  - sentences:
+      - "spil {media_class} {search_query} på {name} i {area}"
+      - "afspil {media_class} {search_query} på {name} i {area}"
+    example: "spil kunstneren Queen på TV'et i køkkenet"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/name_media_class.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/name_media_class.yaml
@@ -1,0 +1,17 @@
+---
+# HassMediaSearchAndPlay - name_media_class
+# example: spil nummeret Bohemian Rhapsody på TV'et
+# slots:
+# - {name}
+# - {search_query}
+# - {media_class}
+
+language: "da"
+data:
+  - sentences:
+      - "spil {media_class} {search_query} på {name}"
+      - "afspil {media_class} {search_query} på {name}"
+    example: "spil nummeret Bohemian Rhapsody på TV'et"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/name_only.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/name_only.yaml
@@ -1,0 +1,19 @@
+---
+# HassMediaSearchAndPlay - name_only
+# example: spil Bohemian Rhapsody på tv'et
+# slots:
+# - {name}
+# - {search_query}
+
+language: "da"
+
+data:
+  - sentences:
+      - "spil {search_query} på {name}"
+      - "afspil {search_query} på {name}"
+    example: "spil Bohemian Rhapsody på tv'et"
+
+    name_domains:
+      - "media_player"
+
+    response: "default"

--- a/sentences/da/HassMediaSearchAndPlay/name_only.yaml
+++ b/sentences/da/HassMediaSearchAndPlay/name_only.yaml
@@ -6,14 +6,11 @@
 # - {search_query}
 
 language: "da"
-
 data:
   - sentences:
       - "spil {search_query} på {name}"
       - "afspil {search_query} på {name}"
     example: "spil Bohemian Rhapsody på tv'et"
-
     name_domains:
       - "media_player"
-
     response: "default"


### PR DESCRIPTION
Adds Danish sentence templates for HassMediaSearchAndPlay.

Included:
- default
- area_only
- area_media_class
- media_class_only
- name_only
- name_area
- name_media_class
- name_area_media_class

Added both "spil" and "afspil" variants of the English "play" to support natural Danish voice commands.