### PR TITLE
[ml] Complete HassCancelTimer slot coverage

### DIFF
--- a/sentences/ml/HassCancelTimer/area_only.yaml
+++ b/sentences/ml/HassCancelTimer/area_only.yaml
@@ -1,0 +1,10 @@
+---
+# HassCancelTimer - area_only
+
+language: ml
+data:
+  - sentences:
+      - "{area}<media_locative_attributive> <timer_singular> <timer_cancel>"
+      - "{area}<media_locative> ഉള്ള <timer_singular> <timer_cancel>"
+    example: "അടുക്കളയിലെ നേരക്കരുവി റദ്ദാക്കുക"
+    response: default

--- a/sentences/ml/HassCancelTimer/name_only.yaml
+++ b/sentences/ml/HassCancelTimer/name_only.yaml
@@ -1,0 +1,9 @@
+---
+# HassCancelTimer - name_only
+
+language: ml
+data:
+  - sentences:
+      - "{timer_name:name} [<named>] <timer_singular> <timer_cancel>"
+    example: "ഇഡ്ഡലി എന്ന നേരക്കരുവി റദ്ദാക്കുക"
+    response: default

--- a/tests/ml/HassCancelTimer/area_only.yaml
+++ b/tests/ml/HassCancelTimer/area_only.yaml
@@ -1,0 +1,20 @@
+---
+language: ml
+areas:
+  - name: അടുക്കള
+timers:
+  - is_active: true
+    area: അടുക്കള
+    start_minutes: 5
+    total_seconds_left: 300
+    rounded_minutes_left: 5
+tests:
+  - sentences:
+      - അടുക്കളയിലെ നേരക്കരുവി റദ്ദാക്കുക
+      - അടുക്കളയിൽ ഉള്ള സമയക്കരുവി നിർത്തൂ
+      - അടുക്കളയിലെ കാലതിട്ടക്കരുവി നിർത്തുക
+      - അടുക്കളയിൽ ഉള്ള റ്റൈമർ റദ്ദാക്കൂ
+      - അടുക്കളയിലെ ടൈമർ ക്യാൻസൽ ചെയ്യുക
+    slots:
+      area: "അടുക്കള"
+    response: "ടൈമർ റദ്ദാക്കി"

--- a/tests/ml/HassCancelTimer/name_only.yaml
+++ b/tests/ml/HassCancelTimer/name_only.yaml
@@ -1,0 +1,18 @@
+---
+language: ml
+timers:
+  - is_active: true
+    name: ഇഡ്ഡലി
+    start_minutes: 5
+    total_seconds_left: 300
+    rounded_minutes_left: 5
+tests:
+  - sentences:
+      - ഇഡ്ഡലി എന്ന നേരക്കരുവി റദ്ദാക്കുക
+      - ഇഡ്ഡലി എന്ന പേരുള്ള സമയക്കരുവി നിർത്തൂ
+      - ഇഡ്ഡലി കാലതിട്ടക്കരുവി നിർത്തുക
+      - ഇഡ്ഡലി എന്ന റ്റൈമർ റദ്ദാക്കൂ
+      - ഇഡ്ഡലി ടൈമർ ക്യാൻസൽ ചെയ്യുക
+    slots:
+      name: "ഇഡ്ഡലി"
+    response: "ടൈമർ റദ്ദാക്കി"


### PR DESCRIPTION
## Summary

- add Malayalam cancellation of timers by name
- add Malayalam cancellation of timers by area
- complete all 6 declared HassCancelTimer combinations
- reuse existing Malayalam response, rules, inflections, and lists

## Validation

- pinned Prettier formatting passed
- Malayalam validation passed
- 13 focused HassCancelTimer checks passed
- all 609 Malayalam tests passed
- 1,861 sentences checked with 0 overmatches and 0 no-matches
- 0 dead Malayalam rules or lists